### PR TITLE
MTV 2.2 only Migrating virtual machines

### DIFF
--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -58,7 +58,7 @@ EOF
 ----
 <1> Specify the vCenter admin user or the {rhv-short} {manager} user.
 <2> Specify the user password.
-<3> {rhv-short} only: Specify the CA certificate of the {manager}. You can retrieve it at `https://<fqdn>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`.
+<3> {rhv-short} only: Specify the CA certificate of the {manager}. You can retrieve it at `https://<www.example.com>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`.
 <4> VMware only: Specify the vCenter SHA-1 fingerprint.
 
 . Create a `Provider` manifest for the source provider:
@@ -80,7 +80,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `ovirt` and `vsphere`.
-<2> Specify the API end point URL, for example, `https://<fqdn>/sdk` for vSphere or `https://<fqdn>/ovirt-engine/api/` for {rhv-short}.
+<2> Specify the API end point URL, for example, `https://<www.example.com>/sdk` for vSphere or `https://<www.example.com>/ovirt-engine/api/` for {rhv-short}.
 <3> Specify the name of provider `Secret` CR.
 
 . VMware only: Create a `Host` manifest:

--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -51,13 +51,14 @@ type: Opaque
 stringData:
   user: <user> <1>
   password: <password> <2>
-  cacert: <{rhv-short}_ca_certificate> <3>
+  cacert: | <3>
+    <{rhv-short}_ca_certificate>
   thumbprint: <vcenter_fingerprint> <4>
 EOF
 ----
-<1> Specify the base64-encoded vCenter user or the {rhv-short} {manager} user.
-<2> Specify the base64-encoded password.
-<3> {rhv-short} only: Specify the base64-encoded CA certificate of the {manager}. You can retrieve it at `https://<www.example.com>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`.
+<1> Specify the vCenter admin user or the {rhv-short} {manager} user.
+<2> Specify the user password.
+<3> {rhv-short} only: Specify the CA certificate of the {manager}. You can retrieve it at `https://<fqdn>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`.
 <4> VMware only: Specify the vCenter SHA-1 fingerprint.
 
 . Create a `Provider` manifest for the source provider:
@@ -79,7 +80,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `ovirt` and `vsphere`.
-<2> Specify the API end point URL, for example, `https://<www.example.com>/sdk` for vSphere or `https://<www.example.com>/ovirt-engine/api/` for {rhv-short}.
+<2> Specify the API end point URL, for example, `https://<fqdn>/sdk` for vSphere or `https://<fqdn>/ovirt-engine/api/` for {rhv-short}.
 <3> Specify the name of provider `Secret` CR.
 
 . VMware only: Create a `Host` manifest:


### PR DESCRIPTION
MTV 2.2 only. 

Same as the PR Remove "base64-encoded" from source provider instructions #299 https://github.com/konveyor/forklift-documentation/pull/299  **except for comment 1 in step 2**