### PR TITLE
Bug 2142529: VM names are automatically changed to comply with RFC 1123 DNS Subdomain

### DIFF
--- a/documentation/modules/source-vm-prerequisites.adoc
+++ b/documentation/modules/source-vm-prerequisites.adoc
@@ -10,6 +10,19 @@ The following prerequisites apply to all migrations:
 
 * ISO/CDROM disks must be unmounted.
 * Each NIC must contain one IPv4 and/or one IPv6 address.
-* The VM name must contain only lowercase letters (`a-z`), numbers (`0-9`), or hyphens (`-`), up to a maximum of 253 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (`.`), or special characters.
-* The VM name must not duplicate the name of a VM in the {virt} environment.
 * The VM operating system must be certified and supported for use as a link:https://access.redhat.com/articles/973163#ocpvirt[guest operating system with {virt}] _and_ for link:https://access.redhat.com/articles/1351473[conversion to KVM with `virt-v2v`].
+* VM names must contain only lowercase letters (`a-z`), numbers (`0-9`), or hyphens (`-`), up to a maximum of 253 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (`.`), or special characters.
+* VM names must not duplicate the name of a VM in the {virt} environment.
++
+[NOTE]
+====
+{project-full} automatically assigns a new name to a VM that does not comply with the rules.
+
+{project-full} makes the following changes when it automatically generates a new VM name:
+
+* Excluded characters are removed.
+* Uppercase letters are switched to lowercase letters.
+* Any underscore (`_`) is changed to a dash (`-`).
+
+This feature allows a migration to proceed smoothly even if someone entered a VM name that does not follow the rules.
+====


### PR DESCRIPTION
MTV 1.7.6

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2142529 by adding note to prerequisites for all migrations.

Preview: 