### PR TITLE
MTV-442: Update Create Provider step

### DIFF
--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -59,7 +59,7 @@ spec:
   type: <provider_type> <1>
   url: <api_end_point> <2>
   settings:
-    vddkInitImage: <registry_route_or_server_path>/vddk: (3)
+    vddkInitImage: <registry_route_or_server_path>/vddk:<tag> <3>
   secret:
     name: <secret> <4>
     namespace: {namespace}


### PR DESCRIPTION
MTV 2.3.4+

Resolves https://issues.redhat.com/browse/MTV-442 by fixing the errors listed in the Jira. 

Preview: Step 2 of http://file.emea.redhat.com/rhoch/create_provider/html-single/#migrating-virtual-machines-from-cli