### PR TITLE
MTV-422: Change VDDK container image in documentation

### DIFF
--- a/documentation/modules/creating-vddk-image.adoc
+++ b/documentation/modules/creating-vddk-image.adoc
@@ -30,8 +30,8 @@ Storing the VDDK image in a public registry might violate the VMware license ter
 $ mkdir /tmp/<dir_name> && cd /tmp/<dir_name>
 ----
 
-. In a browser, navigate to the link:https://code.vmware.com/sdk/vddk[VMware VDDK download page].
-. Select the latest VDDK version and click *Download*.
+. In a browser, navigate to the link:https://developer.vmware.com/web/sdk/7.0/vddk[VMware VDDK version 7 download page].
+. Select version 7.0.3.2 and click *Download*.
 . Save the VDDK archive file in the temporary directory.
 . Extract the VDDK archive:
 +


### PR DESCRIPTION
MTV 4.3.2

Resolves https://issues.redhat.com/browse/MTV-422 by specifying that users should download VDDK version 7.0.3.2.

Preview: http://file.emea.redhat.com/rhoch/vddk7/html-single/#creating-vddk-image_mtv