### PR TITLE
MTV-443: Extend file system overhead for EXT4

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="bae41807-75dc-4724-961a-f1118541f5c7" name="Changes" comment="MTV-422: Change VDDK container image in documentation">
+      <change beforePath="$PROJECT_DIR$/documentation/modules/error-messages.adoc" beforeDir="false" afterPath="$PROJECT_DIR$/documentation/modules/error-messages.adoc" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectId" id="2K5YVDHhqR9AB0oCPRiAECWhfse" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ASKED_ADD_EXTERNAL_FILES&quot;: &quot;true&quot;,
+    &quot;ASKED_SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/home/rhoch/Documents/forklift-documentation&quot;
+  }
+}</component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="bae41807-75dc-4724-961a-f1118541f5c7" name="Changes" comment="" />
+      <created>1673265932612</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1673265932612</updated>
+    </task>
+    <task id="LOCAL-00001" summary="After SME review.">
+      <created>1673266625985</created>
+      <option name="number" value="00001" />
+      <option name="presentableId" value="LOCAL-00001" />
+      <option name="project" value="LOCAL" />
+      <updated>1673266625985</updated>
+    </task>
+    <task id="LOCAL-00002" summary="Additional">
+      <created>1673272883698</created>
+      <option name="number" value="00002" />
+      <option name="presentableId" value="LOCAL-00002" />
+      <option name="project" value="LOCAL" />
+      <updated>1673272883698</updated>
+    </task>
+    <task id="LOCAL-00003" summary="Additional">
+      <created>1673273713515</created>
+      <option name="number" value="00003" />
+      <option name="presentableId" value="LOCAL-00003" />
+      <option name="project" value="LOCAL" />
+      <updated>1673273713515</updated>
+    </task>
+    <task id="LOCAL-00004" summary="Peer review">
+      <created>1673347569838</created>
+      <option name="number" value="00004" />
+      <option name="presentableId" value="LOCAL-00004" />
+      <option name="project" value="LOCAL" />
+      <updated>1673347569838</updated>
+    </task>
+    <task id="LOCAL-00005" summary="MTV-442: Update Create Provider step">
+      <created>1673453945181</created>
+      <option name="number" value="00005" />
+      <option name="presentableId" value="LOCAL-00005" />
+      <option name="project" value="LOCAL" />
+      <updated>1673453945181</updated>
+    </task>
+    <task id="LOCAL-00006" summary="MTV-422: Change VDDK container image in documentation">
+      <created>1674143324246</created>
+      <option name="number" value="00006" />
+      <option name="presentableId" value="LOCAL-00006" />
+      <option name="project" value="LOCAL" />
+      <updated>1674143324246</updated>
+    </task>
+    <option name="localTasksCounter" value="7" />
+    <servers />
+  </component>
+  <component name="VcsManagerConfiguration">
+    <MESSAGE value="After SME review." />
+    <MESSAGE value="Additional" />
+    <MESSAGE value="Peer review" />
+    <MESSAGE value="MTV-442: Update Create Provider step in migrating-virtual-machines-from-cli" />
+    <MESSAGE value="MTV-442: Update Create Provider step" />
+    <MESSAGE value="MTV-422: Change VDDK container image in documentation" />
+    <option name="LAST_COMMIT_MESSAGE" value="MTV-422: Change VDDK container image in documentation" />
+  </component>
+</project>

--- a/documentation/modules/error-messages.adoc
+++ b/documentation/modules/error-messages.adoc
@@ -10,4 +10,12 @@ This section describes error messages and how to resolve them.
 
 .warm import retry limit reached
 
-The `warm import retry limit reached` error message is displayed during a warm migration if a VMware virtual machine (VM) has reached the maximum number (28) of changed block tracking (CBT) snapshots during the precopy stage. You must delete some of the CBT snapshots from the VM and restart the migration plan.
+The `warm import retry limit reached` error message is displayed during a warm migration if a VMware virtual machine (VM) has reached the maximum number (28) of changed block tracking (CBT) snapshots during the precopy stage.
+
+To resolve this problem, delete some of the CBT snapshots from the VM and restart the migration plan.
+
+.Unable to resize disk image to required size
+
+The `Unable to resize disk image to required size` error message is displayed if a migration that uses block storage and persistent volumes created with an EXT4 file system fails. The problem occurs because the default overhead that is assumed by CDI does not completely include the reserved place for the root partition.
+
+To resolve this problem, increase the file system overhead in CDI to be more than 10%.

--- a/documentation/modules/storage-support.adoc
+++ b/documentation/modules/storage-support.adoc
@@ -22,6 +22,11 @@ If the {virt} storage does not support link:https://access.redhat.com/documentat
 See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/virtualization/virtual-machines#virt-customizing-storage-profile_virt-creating-data-volumes[Enabling a statically-provisioned storage class] for details on editing the storage profile.
 ====
 
+[NOTE]
+====
+If your migration uses block storage and persistent volumes created with an EXT4 file system, increase the file system overhead in CDI to be more than 10%. The default overhead that is assumed by CDI does not completely include the reserved place for the root partition. If you do not increase the file system overhead in CDI by this amount, your migration might fail.
+====
+
 .Default volume and access modes
 [cols="1,1,1", options="header"]
 |===


### PR DESCRIPTION
MTV 2.4

Resolves https://issues.redhat.com/browse/MTV-443 by adding a prerequisite and a troubleshooting item dealing with a migration that uses block storage and persistent volumes created with an EXT4 file system

Preview: