### PR TITLE
MTV-443: Extend file system overhead for EXT4

### DIFF
--- a/documentation/modules/error-messages.adoc
+++ b/documentation/modules/error-messages.adoc
@@ -10,4 +10,12 @@ This section describes error messages and how to resolve them.
 
 .warm import retry limit reached
 
-The `warm import retry limit reached` error message is displayed during a warm migration if a VMware virtual machine (VM) has reached the maximum number (28) of changed block tracking (CBT) snapshots during the precopy stage. You must delete some of the CBT snapshots from the VM and restart the migration plan.
+The `warm import retry limit reached` error message is displayed during a warm migration if a VMware virtual machine (VM) has reached the maximum number (28) of changed block tracking (CBT) snapshots during the precopy stage.
+
+To resolve this problem, delete some of the CBT snapshots from the VM and restart the migration plan.
+
+.Unable to resize disk image to required size
+
+The `Unable to resize disk image to required size` error message is displayed when migration fails because a virtual machine on the target provider uses persistent volumes with an EXT4 file system on block storage. The problem occurs because the default overhead that is assumed by CDI does not completely include the reserved place for the root partition.
+
+To resolve this problem, increase the file system overhead in CDI to be more than 10%.

--- a/documentation/modules/storage-support.adoc
+++ b/documentation/modules/storage-support.adoc
@@ -22,6 +22,12 @@ If the {virt} storage does not support link:https://access.redhat.com/documentat
 See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/virtualization/virtual-machines#virt-customizing-storage-profile_virt-creating-data-volumes[Enabling a statically-provisioned storage class] for details on editing the storage profile.
 ====
 
+[NOTE]
+====
+If your migration uses block storage and persistent volumes created with an EXT4 file system, increase the file system overhead in CDI to be more than 10%. The default overhead that is assumed by CDI does not completely include the reserved place for the root partition. If you do not increase the file system overhead in CDI by this amount, your migration might fail.
+====
+
+
 .Default volume and access modes
 [cols="1,1,1", options="header"]
 |===


### PR DESCRIPTION
MTV 2.4

Resolves https://issues.redhat.com/browse/MTV-443 by adding a prerequisite and a troubleshooting item dealing with a migration that uses block storage and persistent volumes created with an EXT4 file system

Preview:
1. http://file.emea.redhat.com/rhoch/exta4_3/html-single/#about-storage_mtv  Second note in "Storage support and default modes."

2. http://file.emea.redhat.com/rhoch/exta4_3/html-single/#error-messages_mtv Second item in "Error messages.' 