### PR TITLE
Document RHV credentials validation

### DIFF
--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -19,8 +19,7 @@ You can add {a-rhv} source provider by using the {project-short} web console.
 
 .Prerequisites
 
-* CA certificate of the {manager}.
-* Apache CA certificate of the {manager}, in case the {manager} Apache CA certificate was replaced with a third-party CA certificate.
+* {manager} CA certificate, unless it was replaced by a third-party certificate, in which case, specify the {manager} Apache CA certificate
 endif::[]
 
 .Procedure
@@ -47,7 +46,7 @@ ifdef::rhv[]
 * *Hostname or IP address*: {manager} host name or IP address
 * *Username*: {manager} user
 * *Password*: {manager} password
-* *CA certificate*: CA certificate of the {manager}. If the {manager} Apache CA certificate was replaced with a third-party CA certificate, both CA certificates need to be specified.
+* *CA certificate*: {manager} CA certificate, unless it was replaced by a third-party certificate, in which case, specify the {manager} Apache CA certificate
 endif::[]
 
 . Click *Add* to add and save the provider.

--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -5,11 +5,10 @@
 // If namespace must be formatted with backticks, use + instead.
 :namespace: openshift-mtv
 :oc: oc
-:ocp: OpenShift Container Platform
+:ocp: Red Hat OpenShift
 :ocp-version: 4.11
-:ocp-short: OCP
 :operator: mtv-operator
-:operator-name-ui: Migration Tookit for Virtualization Operator
+:operator-name-ui: Migration Toolkit for Virtualization Operator
 :operator-name: MTV Operator
 :project-full: Migration Toolkit for Virtualization
 :project-short: MTV

--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -31,19 +31,23 @@ kind: Secret
 metadata:
   name: <secret>
   namespace: {namespace}
+  labels:
+    createdForProviderType: <provider_type> <1>
 type: Opaque
 stringData:
-  user: <user> <1>
-  password: <password> <2>
-  cacert: | <3>
-    <engine_ca_certificate>
-  thumbprint: <vcenter_fingerprint> <4>
+  user: <user> <2>
+  password: <password> <3>
+  cacert: | <4>
+    <ca_certificate>
+  url: <api_end_point>
+  thumbprint: <vcenter_fingerprint> <5>
 EOF
 ----
-<1> Specify the vCenter user or the {rhv-short} {manager} user.
-<2> Specify the user password.
-<3> {rhv-short} only: Specify the CA certificate of the {manager}. You can retrieve it at `https://<engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`.
-<4> VMware only: Specify the vCenter SHA-1 fingerprint.
+<1>  Specify the type of source provider. Allowed values are `ovirt` and `vsphere`. This label is needed to verify that the credentials are correct when the remote system is accessible and, for {rhv-short}, to retrieve the {manager} CA certificate when a third-party certificate is specified for `cacert`.
+<2> Specify the vCenter user or the {rhv-short} {manager} user.
+<3> Specify the user password.
+<4> {rhv-short} only: Specify the {manager} CA certificate, unless it was replaced by a third-party certificate, in which case, specify the {manager} Apache CA certificater. You can retrieve the {manager} CA certificate at https://<engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA.
+<5> VMware only: Specify the vCenter SHA-1 fingerprint.
 
 . Create a `Provider` manifest for the source provider:
 +

--- a/documentation/modules/rhv-prerequisites.adoc
+++ b/documentation/modules/rhv-prerequisites.adoc
@@ -9,7 +9,6 @@
 The following prerequisites apply to {rhv-full} migrations:
 
 * You must use a xref:compatibility-guidelines_{context}[compatible version] of {rhv-full}.
-* You must have the CA certificate of the {manager}.
+* You must have the {manager} CA certificate, unless it was replaced by a third-party certificate, in which case, specify the {manager} Apache CA certificate.
 +
-You can obtain the CA certificate by navigating to `https://<engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA` in a browser.
-If the {manager} Apache CA certificate was replaced with a third-party CA certificate, you must have both the {manager} Apache CA certificate and {manager} CA certificate.
+You can obtain the {manager}  CA certificate by navigating to https://<engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA in a browser.

--- a/documentation/modules/upgrading-mtv-ui.adoc
+++ b/documentation/modules/upgrading-mtv-ui.adoc
@@ -14,7 +14,7 @@ You must upgrade to the next release without skipping a release, for example, fr
 
 .Procedure
 
-. In the {ocp-short} web console, click *Operators* -> *Installed Operators* -> *{operator-name-ui}* -> *Subscription*.
+. In the {ocp} web console, click *Operators* -> *Installed Operators* -> *{operator-name-ui}* -> *Subscription*.
 
 . Change the update channel to the correct release.
 +


### PR DESCRIPTION
MTV 4.2

Resolves https://issues.redhat.com/browse/MTV-429 by describing how to correctly work with third-party certificates. This change affects the prerequisites for RHV migrations, the procedure for adding a RHV source provider in the UI, and the procedure for migrating virtual machines via the CLI.

Previews:
1.  Prerequisites for RHV migrations (last item) http://file.emea.redhat.com/rhoch/rhv_cred/html-single/#rhv-prerequisites_mtv

2. Procedure for adding a RHV source provider in the UI  (step 4 in section 4.1.1.2, description of "CA certificate") http://file.emea.redhat.com/rhoch/rhv_cred/html-single/#adding-source-providers

3. Procedure for migrating virtual machines via the CLI  http://file.emea.redhat.com/rhoch/rhv_cred/html-single/#migrating-virtual-machines-cli_mtv (callout 3 for the YAML file in step 1)
