### PR TITLE
MTV-488: Add disable hibernation to VM prerequisites

### DIFF
--- a/documentation/modules/vmware-prerequisites.adoc
+++ b/documentation/modules/vmware-prerequisites.adoc
@@ -14,10 +14,16 @@ The following prerequisites apply to VMware migrations:
 * You must create a VMware Virtual Disk Development Kit (VDDK) image.
 * You must obtain the SHA-1 fingerprint of the vCenter host.
 * If you are migrating more than 10 VMs from an ESXi host in the same migration plan, you must increase the NFC service memory of the host.
+* It is strongly recommended to disable hibernation because {project-first} does not support migrating hibernated VMs.
+
+[IMPORTANT]
+====
+In the event of a power outage, data might be lost for a VM with disabled hibernation. However, if hibernation is not disabled, migration will fail
+====
 
 [NOTE]
 ====
-Neither {project-first} nor OpenShift Virtualization support conversion of Btrfs for migrating VMs from VMWare.
+Neither {project-short} nor OpenShift Virtualization support conversion of Btrfs for migrating VMs from VMWare.
 ====
 
 [discrete]


### PR DESCRIPTION
MTV 2.4

Resolves https://issues.redhat.com/browse/MTV-488 by including "disable hibernation" in the list of VMware migration prerequisites.

Preview: http://file.emea.redhat.com/rhoch/hibernate/html-single/#vmware-prerequisites_mtv (last item in list before the note)