### PR TITLE
MTV-504: Add user to VDDK Dockerfile

### DIFF
--- a/documentation/modules/creating-vddk-image.adoc
+++ b/documentation/modules/creating-vddk-image.adoc
@@ -46,6 +46,7 @@ $ tar -xzf VMware-vix-disklib-<version>.x86_64.tar.gz
 ----
 $ cat > Dockerfile <<EOF
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+USER 1001
 COPY vmware-vix-disklib-distrib /vmware-vix-disklib-distrib
 RUN mkdir -p /opt
 ENTRYPOINT ["cp", "-r", "/vmware-vix-disklib-distrib", "/opt"]


### PR DESCRIPTION
MTV 2.4

Resolves https://issues.redhat.com/browse/MTV-504 by adding a line to the Dockerfile in step 6 of https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization/2.3/html/installing_and_using_the_migration_toolkit_for_virtualization/prerequisites#creating-vddk-image_mtv

Preview: http://file.emea.redhat.com/rhoch/vddk_docker/html-single/#creating-vddk-image_mtv, step 6, line 3 of the Dockerfile.  