### PR TITLE
MTV-427: OCP plug-in

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -80,6 +80,8 @@ include::modules/compatibility-guidelines.adoc[leveloffset=+2]
 
 You can install the {operator-name} by using the {ocp} web console or the command line interface (CLI).
 
+In {project-first} version 2.4 and later, the {operator-name} includes the {project-short} plugin for the {ocp} web console.
+
 :!mtv:
 :context: web
 :web:
@@ -89,11 +91,9 @@ include::modules/installing-mtv-operator.adoc[leveloffset=+2]
 :context: cli
 :cli:
 include::modules/installing-mtv-operator.adoc[leveloffset=+2]
-
 :!cli:
 :context: mtv
 :mtv:
-include::modules/obtaining-console-url.adoc[leveloffset=+2]
 
 [id="migrating-vms-web-console"]
 == Migrating virtual machines by using the {ocp} web console
@@ -159,8 +159,6 @@ You can migrate virtual machines to {virt} from the command line.
 
 [IMPORTANT]
 ====
-*  You must be logged in as a user with `cluster-admin` privileges.
-
 *  VMware only: You must have the minimal set of xref:vmware-privileges_{context}[VMware privileges].
 
 *  VMware only: You must have the xref:obtaining-vmware-fingerprint_{context}[vCenter SHA-1 fingerprint].

--- a/documentation/modules/accessing-logs-ui.adoc
+++ b/documentation/modules/accessing-logs-ui.adoc
@@ -6,7 +6,7 @@
 [id="accessing-logs-ui_{context}"]
 = Downloading logs and custom resource information from the web console
 
-You can download logs and information about custom resources (CRs) for a completed, failed, or canceled migration plan or for migrated virtual machines (VMs) by using the {project-short} web console.
+You can download logs and information about custom resources (CRs) for a completed, failed, or canceled migration plan or for migrated virtual machines (VMs) by using the {ocp} web console.
 
 .Procedure
 

--- a/documentation/modules/canceling-migration-ui.adoc
+++ b/documentation/modules/canceling-migration-ui.adoc
@@ -6,11 +6,11 @@
 [id="canceling-migration-ui_{context}"]
 = Canceling a migration
 
-You can cancel the migration of some or all virtual machines (VMs) while a migration plan is in progress by using the {project-short} web console.
+You can cancel the migration of some or all virtual machines (VMs) while a migration plan is in progress by using the {ocp} web console.
 
 .Procedure
 
-. Click *Migration Plans*.
+. Click *Plans for virtualization*.
 . Click the name of a running migration plan to view the migration details.
 . Select one or more VMs and click *Cancel*.
 . Click *Yes, cancel* to confirm the cancellation.

--- a/documentation/modules/collected-logs-cr-info.adoc
+++ b/documentation/modules/collected-logs-cr-info.adoc
@@ -6,7 +6,7 @@
 [id="collected-logs-cr-info_{context}"]
 = Collected logs and custom resource information
 
-You can download logs and custom resource (CR) `yaml` files for the following targets by using the {project-short} web console or the command line interface (CLI):
+You can download logs and custom resource (CR) `yaml` files for the following targets by using the {ocp} web console or the command line interface (CLI):
 
 * Migration plan: Web console or CLI.
 * Virtual machine: Web console or CLI.

--- a/documentation/modules/creating-migration-plan.adoc
+++ b/documentation/modules/creating-migration-plan.adoc
@@ -6,7 +6,7 @@
 [id="creating-migration-plan_{context}"]
 = Creating a migration plan
 
-You can create a migration plan by using the {project-short} web console.
+You can create a migration plan by using the {ocp} web console.
 
 A migration plan allows you to group virtual machines to be migrated together or with the same migration parameters, for example, a percentage of the members of a cluster or a complete application.
 

--- a/documentation/modules/creating-network-mapping.adoc
+++ b/documentation/modules/creating-network-mapping.adoc
@@ -6,7 +6,7 @@
 [id="creating-network-mapping_{context}"]
 = Creating a network mapping
 
-You can create one or more network mappings by using the {project-short} web console to map source networks to {virt} networks.
+You can create one or more network mappings by using the {ocp} web console to map source networks to {virt} networks.
 
 .Prerequisites
 
@@ -15,18 +15,19 @@ You can create one or more network mappings by using the {project-short} web con
 
 .Procedure
 
-. Click *Mappings*.
-. Click the *Network* tab and then click *Create mapping*.
+. In the {ocp} web console, click *Migration* -> *NetworkMaps for virtualization*.
+. Click *Create NetworkMap*.
 . Complete the following fields:
 
 * *Name*: Enter a name to display in the network mappings list.
 * *Source provider*: Select a source provider.
 * *Target provider*: Select a target provider.
-* *Source networks*: Select a source network.
-* *Target namespaces/networks*: Select a target network.
++
+The *Source networks* and *Target namespaces/networks* text boxes become active.
 
+. Select a source network and a target namespace/network from the list.
 . Optional: Click *Add* to create additional network mappings or to map multiple source networks to a single target network.
 . If you create an additional network mapping, select the network attachment definition as the target network.
 . Click *Create*.
 +
-The network mapping is displayed on the *Network mappings* screen.
+The network mapping is displayed on the *NetworkMaps* screen.

--- a/documentation/modules/creating-storage-mapping.adoc
+++ b/documentation/modules/creating-storage-mapping.adoc
@@ -6,7 +6,7 @@
 [id="creating-storage-mapping_{context}"]
 = Creating a storage mapping
 
-You can create a storage mapping by using the {project-short} web console to map source data stores to {virt} storage classes.
+You can create a storage mapping by using the {ocp} web console to map source data stores to {virt} storage classes.
 
 .Prerequisites
 

--- a/documentation/modules/installing-mtv-operator.adoc
+++ b/documentation/modules/installing-mtv-operator.adoc
@@ -34,13 +34,14 @@ The {operator-name} is a Community Operator. Red Hat does not support Community 
 ====
 endif::[]
 . Click *{operator-name-ui}* and then click *Install*.
-. On the *Install Operator* page, click *Install*.
-. Click *Operators* -> *Installed Operators* to verify that *{operator-name-ui}* appears in the *{namespace}* project with the status *Succeeded*.
-. Click *{operator-name-ui}*.
-. Under *Provided APIs*, locate the *ForkliftController*, and click *Create Instance*.
+. Click *Create ForkliftController* when the button becomes active.
 . Click *Create*.
++
+Your ForkliftController appears in the list that is displayed.
 . Click *Workloads* -> *Pods* to verify that the {project-short} pods are running.
-include::snippet_getting_web_console_url_web.adoc[]
+. Click *Operators* -> *Installed Operators* to verify that *{operator-name-ui}* appears in the *{namespace}* project with the status *Succeeded*.
++
+When the plugin is ready you will be prompted to reload the page.  The  *Migration* menu item is automatically added to the navigation bar, displayed on the left of the {ocp} web console.
 endif::[]
 ifdef::cli[]
 
@@ -104,12 +105,12 @@ metadata:
   name: {operator}
   namespace: {namespace}
 spec:
-  channel: release-v{project-z-version}
+  channel: release-v{project-version}
   installPlanApproval: Automatic
   name: {operator}
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: "mtv-operator.{project-z-version}"
+  startingCSV: "mtv-operator.v{project-z-version}"
 EOF
 ----
 endif::[]
@@ -138,10 +139,13 @@ $ {oc} get pods -n {namespace}
 +
 .Example output
 ----
-NAME                                  READY  STATUS   RESTARTS  AGE
-forklift-controller-788bdb4c69-mw268  2/2    Running  0         2m
-forklift-operator-6bf45b8d8-qps9v     1/1    Running  0         5m
-forklift-ui-7cdf96d8f6-xnw5n          1/1    Running  0         2m
+NAME                                                    READY   STATUS    RESTARTS   AGE
+forklift-api-bb45b8db4-cpzlg                            1/1     Running   0          6m34s
+forklift-controller-7649db6845-zd25p                    2/2     Running   0          6m38s
+forklift-must-gather-api-78fb4bcdf6-h2r4m               1/1     Running   0          6m28s
+forklift-operator-59c87cfbdc-pmkfc                      1/1     Running   0          28m
+forklift-ui-plugin-5c5564f6d6-zpd85                     1/1     Running   0          6m24s
+forklift-validation-7d84c74c6f-fj9xg                    1/1     Running   0          6m30s
+forklift-volume-populator-controller-85d5cb64b6-mrlmc   1/1     Running   0          6m36s
 ----
-include::snippet_getting_web_console_url_cli.adoc[]
 endif::[]

--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -36,7 +36,6 @@ Migration using {osp} source providers only supports VMs that use only Cinder vo
 
 .Prerequisites
 
-* You must be logged in as a user with `cluster-admin` privileges.
 * VMware only: You must have a VMware Virtual Disk Development Kit (VDDK) image in a secure registry that is accessible to all clusters.
 
 .Procedure

--- a/documentation/modules/migration-plan-options-ui.adoc
+++ b/documentation/modules/migration-plan-options-ui.adoc
@@ -6,7 +6,7 @@
 [id="migration-plan-options-ui_{context}"]
 = Migration plan options
 
-On the *Migration plans* page of the {project-short} web console, you can click the {kebab} beside a migration plan to access the following options:
+On the *Plans for virtualization* page of the {ocp} web console, you can click the {kebab} beside a migration plan to access the following options:
 
 * *Edit*: Edit the details of a migration plan. You cannot edit a migration plan while it is running or after it has completed successfully.
 * *Duplicate*: Create a new migration plan with the same virtual machines (VMs), parameters, mappings, and hooks as an existing plan. You can use this feature for the following tasks:

--- a/documentation/modules/running-migration-plan.adoc
+++ b/documentation/modules/running-migration-plan.adoc
@@ -6,7 +6,7 @@
 [id="running-migration-plan_{context}"]
 = Running a migration plan
 
-You can run a migration plan and view its progress in the {project-short} web console.
+You can run a migration plan and view its progress in the {ocp} web console.
 
 .Prerequisites
 

--- a/documentation/modules/selecting-migration-network-for-virt-provider.adoc
+++ b/documentation/modules/selecting-migration-network-for-virt-provider.adoc
@@ -6,7 +6,7 @@
 [id="selecting-migration-network-for-virt-provider_{context}"]
 = Selecting a migration network for {a-virt} provider
 
-You can select a default migration network for {a-virt} provider in the {project-short} web console to improve performance. The default migration network is used to transfer disks to the namespaces in which it is configured.
+You can select a default migration network for {a-virt} provider in the {ocp} web console to improve performance. The default migration network is used to transfer disks to the namespaces in which it is configured.
 
 If you do not select a migration network, the default migration network is the `pod` network, which might not be optimal for disk transfer.
 
@@ -17,7 +17,7 @@ You can override the default migration network of the provider by selecting a di
 
 .Procedure
 
-. In the {project-short} web console, click *Providers*.
+. In the {ocp} web console, click *Migration* -> *Providers for virtualization*..
 . Click the *{virt}* tab.
 . Select a provider and click *Select migration network*.
 . Select a network from the list of available networks and click *Select*.

--- a/documentation/modules/selecting-migration-network-for-vmware-source-provider.adoc
+++ b/documentation/modules/selecting-migration-network-for-vmware-source-provider.adoc
@@ -6,7 +6,7 @@
 [id="selecting-migration-network-for-vmware-source-provider_{context}"]
 = Selecting a migration network for a VMware source provider
 
-You can select a migration network in the {project-short} web console for a source provider to reduce risk to the source environment and to improve performance.
+You can select a migration network in the {ocp} web console for a source provider to reduce risk to the source environment and to improve performance.
 
 Using the default network for migration can result in poor performance because the network might not have sufficient bandwidth. This situation can have a negative effect on the source platform because the disk transfer operation might saturate the network.
 
@@ -24,7 +24,7 @@ The source virtual disks are copied by a pod that is connected to the pod networ
 
 .Procedure
 
-. In the {project-short} web console, click *Providers*
+. In the {ocp} web console, click *Migration* -> *Providers for virtualization*.
 . Click the *VMware* tab.
 . Click the host number in the *Hosts* column beside a provider to view a list of hosts.
 . Select one or more hosts and click *Select migration network*.


### PR DESCRIPTION
MTV 2.4

Resolves: https://issues.redhat.com/browse/MTV-427 by changing installation instructions to reflect that the MTV web console is now being integrated to the OCP web console. 

Also partially resolves https://issues.redhat.com/browse/MTV-467 by removing the statement "You must be logged in as a user with cluster-admin privileges" in the Prerequisites of the "Migrating virtual machines" section.  That requirement still appears elsewhere in the guide.  

Previews: 

1.http://file.emea.redhat.com/rhoch/web_in_operator/html-single/#installing-mtv-operator_web
2. http://file.emea.redhat.com/rhoch/web_in_operator/html-single/#installing-mtv-operator_cli  CLI installation
3. http://file.emea.redhat.com/rhoch/web_in_operator/html-single/#migrating-virtual-machines-from-cli  cluster-admin requirement removed

No previews: "MTV web console" changed to "OpenShift Container Platform web console" through the document. You can see the changes in the files.

NOTE: As I worked through the UI, i noticed that a number of UI names were changed. I started correcting them, then stopped because the PR was getting too large for anyone's good. These changes and other Ui changes will be taken care of in later PRs.  