### PR TITLE
OpenStack migration using the UI

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -76,7 +76,7 @@ include::modules/installing-mtv-operator.adoc[leveloffset=+2]
 include::modules/obtaining-console-url.adoc[leveloffset=+2]
 
 [id="migrating-vms-web-console"]
-== Migrating virtual machines by using the {project-short} web console
+== Migrating virtual machines by using the {ocp} web console
 
 You can migrate virtual machines (VMs) to {virt} by using the {ocp} web console.
 
@@ -120,7 +120,7 @@ include::modules/osh-adding-source-provider.adoc[leveloffset=+4]
 [id="adding-destination-providers"]
 ==== Adding destination providers
 
-You can add  a {virt} destination provider by using the {project-short} web console.
+You can add  a {virt} destination provider by using the {ocp} web console.
 
 include::modules/adding-virt-provider.adoc[leveloffset=+4]
 include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+4]

--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -78,7 +78,7 @@ include::modules/obtaining-console-url.adoc[leveloffset=+2]
 [id="migrating-vms-web-console"]
 == Migrating virtual machines by using the {project-short} web console
 
-You can migrate virtual machines (VMs) to {virt} by using the {project-short} web console.
+You can migrate virtual machines (VMs) to {virt} by using the {ocp} web console.
 
 [IMPORTANT]
 ====
@@ -92,12 +92,12 @@ VMware only: You must create a xref:creating-vddk-image_{context}[VMware Virtual
 [id="adding-providers"]
 === Adding providers
 
-You can add source providers and destination providers for a virtual machine migration by using the {project-short} web console.
+You can add source providers and destination providers for a virtual machine migration by using the {ocp} web console.
 
 [id="adding-source-providers"]
 ==== Adding source providers
 
-You can add a VMware source provider, {a-rhv} source provider, or an {osh} source provider by using the {project-short} web console.
+You can add a VMware source provider, {a-rhv} source provider, or an {osp} source provider by using the {ocp} web console.
 
 :mtv!:
 :context: vmware

--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -97,7 +97,7 @@ You can add source providers and destination providers for a virtual machine mig
 [id="adding-source-providers"]
 ==== Adding source providers
 
-You can add {a-rhv} source provider or a VMware source provider by using the {project-short} web console.
+You can add a VMware source provider, {a-rhv} source provider, or an {osh} source provider by using the {project-short} web console.
 
 :mtv!:
 :context: vmware
@@ -114,6 +114,8 @@ include::modules/adding-source-provider.adoc[leveloffset=+4]
 :rhv!:
 :context: mtv
 :mtv:
+
+include::modules/osh-adding-source-provider.adoc[leveloffset=+4]
 
 [id="adding-destination-providers"]
 ==== Adding destination providers

--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -15,7 +15,7 @@ endif::[]
 ifdef::rhv[]
 = Adding {a-rhv} source provider
 
-You can add {a-rhv} source provider by using the {project-short} web console.
+You can add {a-rhv} source provider by using the {ocp} web console.
 
 .Prerequisites
 
@@ -24,7 +24,7 @@ endif::[]
 
 .Procedure
 
-. In the {project-short} web console, click *Providers*.
+. In the {ocp} web console, click *Migration* -> *Providers for virtualization*.
 . Click *Create provider*.
 ifdef::vmware[]
 . Select *VMware* from the *Provider type* list.

--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -6,7 +6,7 @@
 ifdef::vmware[]
 = Adding a VMware source provider
 
-You can add a VMware source provider by using the {project-short} web console.
+You can add a VMware source provider by using the {ocp} web console.
 
 .Prerequisites
 

--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -25,12 +25,12 @@ endif::[]
 .Procedure
 
 . In the {project-short} web console, click *Providers*.
-. Click *Add provider*.
+. Click *Create provider*.
 ifdef::vmware[]
-. Select *VMware* from the *Type* list.
+. Select *VMware* from the *Provider type* list.
 . Fill in the following fields:
 
-* *Name*: Name to display in the list of providers
+* *Provider name*: Name to display in the list of providers
 * *vCenter host name or IP address*: vCenter host name or IP address - if a certificate for FQDN is specified, the value of this field needs to match the FQDN in the certificate
 * *vCenter user name*: vCenter user, for example, `user@vsphere.local`
 * *vCenter password*: vCenter user password
@@ -40,10 +40,10 @@ ifdef::vmware[]
 . Enter the *SHA-1 fingerprint*.
 endif::[]
 ifdef::rhv[]
-. Select *Red Hat Virtualization* from the *Type* list.
+. Select *Red Hat Virtualization* from the *Provider Type* list.
 . Fill in the following fields:
 
-* *Name*: Name to display in the list of providers
+* *Provider name*: Name to display in the list of providers
 * *RHV Manager host name or IP address*: {manager} host name or IP address -  if a certificate for FQDN is specified, the value of this field needs to match the FQDN in the certificate
 * *RHV Manager user name*: {manager} user
 * *RHV Manager password*: {manager} password

--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -31,24 +31,27 @@ ifdef::vmware[]
 . Fill in the following fields:
 
 * *Name*: Name to display in the list of providers
-* *Hostname or IP address*: vCenter host name or IP address
-* *Username*: vCenter user, for example, `user@vsphere.local`
-* *Password*: vCenter user password
+* *vCenter host name or IP address*: vCenter host name or IP address - if a certificate for FQDN is specified, the value of this field needs to match the FQDN in the certificate
+* *vCenter user name*: vCenter user, for example, `user@vsphere.local`
+* *vCenter password*: vCenter user password
 * *VDDK init image*: VDDKInitImage path
-* Click *Verify certificate*.
-* Select the *I trust the authenticity of this certificate* checkbox.
+
+. To allow a migration without validating the provider's CA certificate, select the *Skip certificate validation* check box. By default, the checkbox is cleared, meaning that the certificate will be validated.
+. Enter the *SHA-1 fingerprint*.
 endif::[]
 ifdef::rhv[]
 . Select *Red Hat Virtualization* from the *Type* list.
 . Fill in the following fields:
 
 * *Name*: Name to display in the list of providers
-* *Hostname or IP address*: {manager} host name or IP address
-* *Username*: {manager} user
-* *Password*: {manager} password
-* *CA certificate*: {manager} CA certificate, unless it was replaced by a third-party certificate, in which case, specify the {manager} Apache CA certificate
+* *RHV Manager host name or IP address*: {manager} host name or IP address -  if a certificate for FQDN is specified, the value of this field needs to match the FQDN in the certificate
+* *RHV Manager user name*: {manager} user
+* *RHV Manager password*: {manager} password
+
+. To allow a migration without validating the provider's CA certificate, select the *Skip certificate validation* check box. By default, the checkbox is cleared, meaning that the certificate will be validated.
+. If you did not select *skip certificate validation*, the *CA certificate* field is visible. Drag the CA certificate to the text box or browse for it and click *Select*. Use the {manager} CA certificate or {manager} Apache CA certificate if the {manager} CA certificate was replaced by a third-party certificate on the Apache server. If you did select the check box, the *CA certificate* text box is not visible.
 endif::[]
 
-. Click *Add* to add and save the provider.
+. Click *Create* to add and save the provider.
 +
 The source provider appears in the list of providers.

--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -25,7 +25,7 @@ endif::[]
 .Procedure
 
 . In the {ocp} web console, click *Migration* -> *Providers for virtualization*.
-. Click *Create provider*.
+. Click *Create Provider*.
 ifdef::vmware[]
 . Select *VMware* from the *Provider type* list.
 . Fill in the following fields:
@@ -40,7 +40,7 @@ ifdef::vmware[]
 . Enter the *SHA-1 fingerprint*.
 endif::[]
 ifdef::rhv[]
-. Select *Red Hat Virtualization* from the *Provider Type* list.
+. Select *Red Hat Virtualization* from the *Provider type* list.
 . Fill in the following fields:
 
 * *Provider name*: Name to display in the list of providers

--- a/documentation/modules/adding-virt-provider.adoc
+++ b/documentation/modules/adding-virt-provider.adoc
@@ -6,7 +6,7 @@
 [id="adding-virt-provider_{context}"]
 = Adding {a-virt} destination provider
 
-You can add {a-virt} destination provider to the {project-short} web console in addition to the default {virt} destination provider, which is the provider where you installed {project-short}.
+You can add {a-virt} destination provider to the {ocp} web console in addition to the default {virt} destination provider, which is the provider where you installed {project-short}.
 
 .Prerequisites
 

--- a/documentation/modules/adding-virt-provider.adoc
+++ b/documentation/modules/adding-virt-provider.adoc
@@ -14,16 +14,16 @@ You can add {a-virt} destination provider to the {project-short} web console in 
 
 .Procedure
 
-. In the  {project-short}  web console, click *Providers*.
-. Click *Add provider*.
-. Select *{virt}* from the *Type* list.
+. In the {ocp} web console, click *Migration* -> *Providers for virtualization*.
+. Click *Create provider*.
+. Select *{virt}* from the *Provider type* list.
 . Fill in the following fields:
 
-* *Name*: Specify the provider name to display in the list of target providers.
-* *URL*: Specify the API endpoint of the cluster.
+* *Provider name*: Specify the provider name to display in the list of target providers.
+* *Kubernetes API server URL*: Specify the {ocp} cluster API endpoint.
 * *Service account token*: Specify the `cluster-admin` service account token.
 +
-If both *URL* and *Service account token* are left blank, the local OpenShift cluster is used.
+If both *URL* and *Service account token* are left blank, the local {osp} cluster is used.
 
 . Click *Create*.
 +

--- a/documentation/modules/adding-virt-provider.adoc
+++ b/documentation/modules/adding-virt-provider.adoc
@@ -17,13 +17,14 @@ You can add {a-virt} destination provider to the {project-short} web console in 
 . In the  {project-short}  web console, click *Providers*.
 . Click *Add provider*.
 . Select *{virt}* from the *Type* list.
-. Complete the following fields:
+. Fill in the following fields:
 
-* *Cluster name*: Specify the cluster name to display in the list of target providers.
+* *Name*: Specify the provider name to display in the list of target providers.
 * *URL*: Specify the API endpoint of the cluster.
 * *Service account token*: Specify the `cluster-admin` service account token.
++
+If both *URL* and *Service account token* are left blank, the local OpenShift cluster is used.
 
-. Click *Check connection* to verify the credentials.
-. Click *Add*.
+. Click *Create*.
 +
 The provider appears in the list of providers.

--- a/documentation/modules/adding-virt-provider.adoc
+++ b/documentation/modules/adding-virt-provider.adoc
@@ -15,7 +15,7 @@ You can add {a-virt} destination provider to the {ocp} web console in addition t
 .Procedure
 
 . In the {ocp} web console, click *Migration* -> *Providers for virtualization*.
-. Click *Create provider*.
+. Click *Create Provider*.
 . Select *{virt}* from the *Provider type* list.
 . Fill in the following fields:
 

--- a/documentation/modules/osh-adding-source-provider.adoc
+++ b/documentation/modules/osh-adding-source-provider.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+
+[id="osh-adding-source-provider_{context}"]
+= Adding an {osp} source provider
+
+You can add an {osp} source provider by using the {project-short} web console.
+
+[IMPORTANT]
+====
+Migration using {osp} source providers is a Technology Preview feature only. Technology Preview features
+are not supported with Red Hat production service level agreements (SLAs) and
+might not be functionally complete. Red Hat does not recommend using them
+in production. These features provide early access to upcoming product
+features, enabling customers to test functionality and provide feedback during
+the development process.
+For more information about the support scope of Red Hat Technology Preview
+features, see https://access.redhat.com/support/offerings/techpreview/.
+====
+
+[NOTE]
+====
+Migration using {osp} source providers only supports VMs that use only Cinder volumes.
+====
+
+.Procedure
+
+. In the {project-short} web console, click *Providers*.
+. Click *Add provider*.
+
+. Select *Red Hat OpenStack Platform* from the *Type* list.
+. Fill in the following fields:
+
+* *Name*: Name to display in the list of providers
+* *{osh} Identity (Keystone) URL*: {osh} Identity (Keystone) endpoint, for example, `http://controller:5000/v3`
+* *{osh} Identity (Keystone) username*: For example, `admin`
+* *{osh} Identity (Keystone) password*:
+* *Domanin*:
+* *Project*:
+* *Region*:
+
+.  To allow a migration without validating the provider's CA certificate, select the *Skip certificate validation* check box. By default, the checkbox is cleared, meaning that the certificate will be validated.
+. If you did not select *skip certificate validation*, the *CA certificate* field is visible. Drag the CA certificate used to connect to the source environment to the text box or browse for it and click *Select*.  If you did select the check box, the *CA certificate* text box is not visible.
+. Click *Create* to add and save the provider.
++
+The source provider appears in the list of providers.

--- a/documentation/modules/osh-adding-source-provider.adoc
+++ b/documentation/modules/osh-adding-source-provider.adoc
@@ -5,7 +5,7 @@
 [id="osh-adding-source-provider_{context}"]
 = Adding an {osp} source provider
 
-You can add an {osp} source provider by using the {project-short} web console.
+You can add an {osp} source provider by using the {ocp} web console.
 
 [IMPORTANT]
 ====

--- a/documentation/modules/osh-adding-source-provider.adoc
+++ b/documentation/modules/osh-adding-source-provider.adoc
@@ -27,7 +27,7 @@ Migration using {osp} source providers only supports VMs that use only Cinder vo
 .Procedure
 
 . In the {ocp} web console, click *Migration* -> *Providers for virtualization*.
-. Click *Create provider*.
+. Click *Create Provider*.
 
 . Select *Red Hat OpenStack Platform* from the *Provider type* list.
 . Fill in the following fields:

--- a/documentation/modules/osh-adding-source-provider.adoc
+++ b/documentation/modules/osh-adding-source-provider.adoc
@@ -33,7 +33,7 @@ Migration using {osp} source providers only supports VMs that use only Cinder vo
 . Fill in the following fields:
 
 * *Provider name*: Name to display in the list of providers
-* *{osp} Identity server URL*: {osh} Identity (Keystone) endpoint, for example, `http://controller:5000/v3`
+* *{osp} Identity server URL*: {osp} Identity (Keystone) endpoint, for example, `http://controller:5000/v3`
 * *{osp} username*: For example, `admin`
 * *{osp} password*:
 * *Domain*:

--- a/documentation/modules/osh-adding-source-provider.adoc
+++ b/documentation/modules/osh-adding-source-provider.adoc
@@ -33,9 +33,9 @@ Migration using {osp} source providers only supports VMs that use only Cinder vo
 . Fill in the following fields:
 
 * *Provider name*: Name to display in the list of providers
-* *{osh} Identity server URL*: {osh} Identity (Keystone) endpoint, for example, `http://controller:5000/v3`
-* *{osh} username*: For example, `admin`
-* *{osh} password*:
+* *{osp} Identity server URL*: {osh} Identity (Keystone) endpoint, for example, `http://controller:5000/v3`
+* *{osp} username*: For example, `admin`
+* *{osp} password*:
 * *Domain*:
 * *Project*:
 * *Region*:

--- a/documentation/modules/osh-adding-source-provider.adoc
+++ b/documentation/modules/osh-adding-source-provider.adoc
@@ -26,22 +26,22 @@ Migration using {osp} source providers only supports VMs that use only Cinder vo
 
 .Procedure
 
-. In the {project-short} web console, click *Providers*.
-. Click *Add provider*.
+. In the {ocp} web console, click *Migration* -> *Providers for virtualization*.
+. Click *Create provider*.
 
-. Select *Red Hat OpenStack Platform* from the *Type* list.
+. Select *Red Hat OpenStack Platform* from the *Provider type* list.
 . Fill in the following fields:
 
-* *Name*: Name to display in the list of providers
-* *{osh} Identity (Keystone) URL*: {osh} Identity (Keystone) endpoint, for example, `http://controller:5000/v3`
-* *{osh} Identity (Keystone) username*: For example, `admin`
-* *{osh} Identity (Keystone) password*:
-* *Domanin*:
+* *Provider name*: Name to display in the list of providers
+* *{osh} Identity server URL*: {osh} Identity (Keystone) endpoint, for example, `http://controller:5000/v3`
+* *{osh} username*: For example, `admin`
+* *{osh} password*:
+* *Domain*:
 * *Project*:
 * *Region*:
 
 .  To allow a migration without validating the provider's CA certificate, select the *Skip certificate validation* check box. By default, the checkbox is cleared, meaning that the certificate will be validated.
-. If you did not select *skip certificate validation*, the *CA certificate* field is visible. Drag the CA certificate used to connect to the source environment to the text box or browse for it and click *Select*.  If you did select the check box, the *CA certificate* text box is not visible.
+. If you did not select *Skip certificate validation*, the *CA certificate* field is visible. Drag the CA certificate used to connect to the source environment to the text box or browse for it and click *Select*.  If you did select the check box, the *CA certificate* text box is not visible.
 . Click *Create* to add and save the provider.
 +
 The source provider appears in the list of providers.


### PR DESCRIPTION
MTV 2.4

Partially resolves https://issues.redhat.com/browse/MTV-426 by describing how to define OpenStack source providers using the UI.

Also includes changes made to the procedures for defining other providers in the UI.

Previews:

1. Adding source providers (vmWare, RHV, and OpenStack): http://file.emea.redhat.com/rhoch/openstack_ui/html-single/#adding-source-providers  [Sorry I cannot break the file down to each of the source procviders]

2: Adding destination providers (OpenShift Virtualization): http://file.emea.redhat.com/rhoch/openstack_cli/html-single/#adding-destination-providers 