### PR TITLE
MTV-465 document supported versions hvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/*
+.idea/*
 */build/*
 documentation/*/build/*
 .jekyll-cache

--- a/documentation/doc-Release_notes/master.adoc
+++ b/documentation/doc-Release_notes/master.adoc
@@ -12,6 +12,7 @@ ifeval::["{build}" == "downstream"]
 include::modules/making-open-source-more-inclusive.adoc[]
 endif::[]
 
+include::modules/rn-2.4.adoc[leveloffset=+1]
 include::modules/rn-2.3.adoc[leveloffset=+1]
 include::modules/rn-2.2.adoc[leveloffset=+1]
 include::modules/rn-2.1.adoc[leveloffset=+1]

--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -6,7 +6,7 @@
 :namespace: openshift-mtv
 :oc: oc
 :ocp: OpenShift Container Platform
-:ocp-version: 4.10
+:ocp-version: 4.11
 :ocp-short: OCP
 :operator: mtv-operator
 :operator-name-ui: Migration Tookit for Virtualization Operator

--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -14,8 +14,8 @@
 :project-full: Migration Toolkit for Virtualization
 :project-short: MTV
 :project-first: {project-full} ({project-short})
-:project-version: 2.3
-:project-z-version: 2.3.0
+:project-version: 2.4
+:project-z-version: 2.4.0
 :the: The
 :the-lc: the
 :virt: OpenShift Virtualization

--- a/documentation/modules/compatibility-guidelines.adoc
+++ b/documentation/modules/compatibility-guidelines.adoc
@@ -12,5 +12,5 @@ You must install compatible software versions.
 .Compatible software versions
 |===
 |{project-full} |{ocp} |{virt} |VMware vSphere |{rhv-full}
-|2.3.3 |4.10 or later |4.10 or later |6.5 or later |4.4.9 or later
+|2.4.0 |4.11, 4.12 |4.11, 4.12 |6.5 or later |4.4.9 or later
 |===

--- a/documentation/modules/compatibility-guidelines.adoc
+++ b/documentation/modules/compatibility-guidelines.adoc
@@ -11,6 +11,6 @@ You must install compatible software versions.
 [cols="1,1,1,1,1", options="header"]
 .Compatible software versions
 |===
-|{project-full} |{ocp} |{virt} |VMware vSphere |{rhv-full}
+|{project-full} |{ocp} |{virt} |VMware vSphere |{rhv-full}|OpenStack|
 |2.4.0 |4.11, 4.12 |4.11, 4.12 |6.5 or later |4.4.9 or later
-|===
+|?|===

--- a/documentation/modules/compatibility-guidelines.adoc
+++ b/documentation/modules/compatibility-guidelines.adoc
@@ -8,9 +8,10 @@
 
 You must install compatible software versions.
 
-[cols="1,1,1,1,1", options="header"]
+[cols="1,1,1,1,1,1", options="header"]
 .Compatible software versions
 |===
 |{project-full} |{ocp} |{virt} |VMware vSphere |{rhv-full}|OpenStack|
 |2.4.0 |4.11, 4.12 |4.11, 4.12 |6.5 or later |4.4.9 or later
-|?|===
+|?|
+===

--- a/documentation/modules/rn-2.4.adoc
+++ b/documentation/modules/rn-2.4.adoc
@@ -5,7 +5,7 @@
 [id="rn-24_{context}"]
 = {project-full} 2.4
 
-You can migrate virtual machines (VMs) from VMware vSphere or {rhv-full} to {virt} with {the-lc} {project-first}.
+You can migrate virtual machines (VMs) from VMware vSphere or {rhv-full} to {virt} with {the-lc} {project-first} and OpenStack.
 
 The release notes describe technical changes, new features and enhancements, and known issues.
 
@@ -14,26 +14,24 @@ The release notes describe technical changes, new features and enhancements, and
 
 This release has the following technical changes:
 
-.Technical change 1
+* Technical change 1
 
-Description 1
+  ** Description 1
 
-.Technical change 2
+* Technical change 2
 
-Description 2
+  ** Description 2
 
 [id="new-features-and-enhancements-24_{context}"]
 == New features and enhancements
 
 This release has the following features and improvements:
 
-.link:https://issues.redhat.com/browse/MTV-427[MTV-427] - OCP console plugin
+* link:https://issues.redhat.com/browse/MTV-427[MTV-427] - OCP console plugin. +
+  ** Updated UI (is this relevant?) +
+  ** UI of MTV integrated in *Migration* item in web console. +
 
-MTV Operator installed from CLI. +
-MTV web console URL.
-
-.link:https://issues.redhat.com/browse/MTV-426[MTV-426] - OpenStack migration
-
+* link:https://issues.redhat.com/browse/MTV-426[MTV-426] - OpenStack migration. +
 See new link:https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization/2.3/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#rhv-prerequisites_mtv[prerequisites] for RHV and VMware migration, and link:https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization/2.3/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#migrating-virtual-machines-cli_mtv[procedure] to migrate virtual machines.
 
 [id="known-issues-24_{context}"]
@@ -41,22 +39,19 @@ See new link:https://access.redhat.com/documentation/en-us/migration_toolkit_for
 
 This release has the following known issues:
 
-.link:https://issues.redhat.com/browse/MTV-505[MTV-505] - Power off OpenStack VM in cold migration
-
+* link:https://issues.redhat.com/browse/MTV-505[MTV-505] - Power off OpenStack VM in cold migration +
 This issue implements the following: +
+====
+`pkg/controller/plan/adapter/openstack/client.go` +
+`Power off the source VM.` +
+`func (c *Client) PowerOff(vmRef ref.Ref) error` +
+`{ return nil }`
+====
 
-` pkg/controller/plan/adapter/openstack/client.go` +
-` // Power off the source VM.` +
-` func (c *Client) PowerOff(vmRef ref.Ref) error` +
-` { return nil }`
+* link:https://issues.redhat.com/browse/MTV-349[MTV-349] - RHV snapshots are not deleted after a successful migration
 
-.link:https://issues.redhat.com/browse/MTV-349[MTV-349] - RHV snapshots are not deleted after a successful migration
-
-Issue description
-
-.link:https://issues.redhat.com/browse/MTV-456[MTV-456] - Migration fails during precopy/cutover while a snapshot operation is executed on the source VM
-
-Warm migration fails, returning an error, when performing another snapshot operation (create/delete) on the RHV source VM.
+* link:https://issues.redhat.com/browse/MTV-456[MTV-456] - Migration fails during precopy/cutover while a snapshot operation is executed on the source VM. +
+Warm migration fails, returning an error, when performing another snapshot operation (create/delete) on the RHV source VM. +
 Workaround: Wait for the snapshot operation to complete before running the next precopy/cutover procedure.
 
 [id="resolved-issues-24_{context}"]
@@ -64,13 +59,13 @@ Workaround: Wait for the snapshot operation to complete before running the next 
 
 This release has the following resolved issue:
 
-.link:https://issues.redhat.com/browse/MTV-332[MTV-332] - Update virt-v2v container to el9
+* link:https://issues.redhat.com/browse/MTV-332[MTV-332] - Update virt-v2v container to el9
 
-* This fix enables conversion to RHEL9 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2067171#c1[BZ-2067171])
-* A fix in virt-v2v causes it to install quem-ga within the converted guest (link:https://bugzilla.redhat.com/show_bug.cgi?id=2028764[BZ-2028764])
+** link:https://bugzilla.redhat.com/show_bug.cgi?id=2067171#c1[BZ-2067171]
+** A fix in virt-v2v causes it to install quem-ga within the converted guest (link:https://bugzilla.redhat.com/show_bug.cgi?id=2028764[BZ-2028764])
 
-link:https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization/2.3/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#migrating-virtual-machines-cli_mtv[MTV-333] - Convert u440fx to q35 +
-i440fx chpset with PIOS is reverted to q35 bios.
+* link:https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization/2.3/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#migrating-virtual-machines-cli_mtv[MTV-333] - Convert i440fx to q35 +
+i440fx chipset with BIOS is reverted to q35 BIOS.
 
-link:https://issues.redhat.com/browse/MTV-345[MTV-345] - Map IDE to SATA +
+* link:https://issues.redhat.com/browse/MTV-345[MTV-345] - Map IDE to SATA +
 CNV does not support IDE disk interface, so the disks are mapped to SATA.

--- a/documentation/modules/rn-2.4.adoc
+++ b/documentation/modules/rn-2.4.adoc
@@ -1,0 +1,76 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Release_notes/master.adoc
+
+[id="rn-24_{context}"]
+= {project-full} 2.4
+
+You can migrate virtual machines (VMs) from VMware vSphere or {rhv-full} to {virt} with {the-lc} {project-first}.
+
+The release notes describe technical changes, new features and enhancements, and known issues.
+
+[id="technical-changes-24_{context}"]
+== Technical changes
+
+This release has the following technical changes:
+
+.Technical change 1
+
+Description 1
+
+.Technical change 2
+
+Description 2
+
+[id="new-features-and-enhancements-24_{context}"]
+== New features and enhancements
+
+This release has the following features and improvements:
+
+.link:https://issues.redhat.com/browse/MTV-427[MTV-427] - OCP console plugin
+
+MTV Operator installed from CLI. +
+MTV web console URL.
+
+.link:https://issues.redhat.com/browse/MTV-426[MTV-426] - OpenStack migration
+
+See new link:https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization/2.3/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#rhv-prerequisites_mtv[prerequisites] for RHV and VMware migration, and link:https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization/2.3/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#migrating-virtual-machines-cli_mtv[procedure] to migrate virtual machines.
+
+[id="known-issues-24_{context}"]
+== Known issues
+
+This release has the following known issues:
+
+.link:https://issues.redhat.com/browse/MTV-505[MTV-505] - Power off OpenStack VM in cold migration
+
+This issue implements the following: +
+
+` pkg/controller/plan/adapter/openstack/client.go` +
+` // Power off the source VM.` +
+` func (c *Client) PowerOff(vmRef ref.Ref) error` +
+` { return nil }`
+
+.link:https://issues.redhat.com/browse/MTV-349[MTV-349] - RHV snapshots are not deleted after a successful migration
+
+Issue description
+
+.link:https://issues.redhat.com/browse/MTV-456[MTV-456] - Migration fails during precopy/cutover while a snapshot operation is executed on the source VM
+
+Warm migration fails, returning an error, when performing another snapshot operation (create/delete) on the RHV source VM.
+Workaround: Wait for the snapshot operation to complete before running the next precopy/cutover procedure.
+
+[id="resolved-issues-24_{context}"]
+== Resolved issues
+
+This release has the following resolved issue:
+
+.link:https://issues.redhat.com/browse/MTV-332[MTV-332] - Update virt-v2v container to el9
+
+* This fix enables conversion to RHEL9 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2067171#c1[BZ-2067171])
+* A fix in virt-v2v causes it to install quem-ga within the converted guest (link:https://bugzilla.redhat.com/show_bug.cgi?id=2028764[BZ-2028764])
+
+link:https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization/2.3/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#migrating-virtual-machines-cli_mtv[MTV-333] - Convert u440fx to q35 +
+i440fx chpset with PIOS is reverted to q35 bios.
+
+link:https://issues.redhat.com/browse/MTV-345[MTV-345] - Map IDE to SATA +
+CNV does not support IDE disk interface, so the disks are mapped to SATA.

--- a/forklift-documentation-1/.idea/vcs.xml
+++ b/forklift-documentation-1/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/forklift-documentation-1/.idea/workspace.xml
+++ b/forklift-documentation-1/.idea/workspace.xml
@@ -5,7 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="01f3fca3-8eda-4cef-8574-44f82884c0e6" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/../documentation/modules/compatibility-guidelines.adoc" beforeDir="false" afterPath="$PROJECT_DIR$/../documentation/modules/compatibility-guidelines.adoc" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/forklift-documentation-1/.idea/workspace.xml
+++ b/forklift-documentation-1/.idea/workspace.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="01f3fca3-8eda-4cef-8574-44f82884c0e6" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/../documentation/modules/compatibility-guidelines.adoc" beforeDir="false" afterPath="$PROJECT_DIR$/../documentation/modules/compatibility-guidelines.adoc" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ExportToHTMLSettings">
+    <option name="OUTPUT_DIRECTORY" value="$PROJECT_DIR$/exportToHTML" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$/.." />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectId" id="2Nh66kd2ivgTvvT5V06WRee90nj" />
+  <component name="ProjectLevelVcsManager" settingsEditedManually="true" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;
+  }
+}</component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="01f3fca3-8eda-4cef-8574-44f82884c0e6" name="Changes" comment="" />
+      <created>1680103793935</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1680103793935</updated>
+    </task>
+    <servers />
+  </component>
+</project>


### PR DESCRIPTION
@mavital @ahadas 
MTV-465:
Changed "Compatible software versions" table for MTV version 2.4.0.
Change supported OCP to 4.11 and 4.12. Please review and comment/correct if necessary.
Please review other supported software.

Thanks