### PR TITLE
aa/MTV-465: Document Support Version

### DIFF
--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -6,7 +6,7 @@
 :namespace: openshift-mtv
 :oc: oc
 :ocp: OpenShift Container Platform
-:ocp-version: 4.10
+:ocp-version: 4.11
 :ocp-short: OCP
 :operator: mtv-operator
 :operator-name-ui: Migration Tookit for Virtualization Operator
@@ -14,8 +14,8 @@
 :project-full: Migration Toolkit for Virtualization
 :project-short: MTV
 :project-first: {project-full} ({project-short})
-:project-version: 2.3
-:project-z-version: 2.3.0
+:project-version: 2.4
+:project-z-version: 2.4.0
 :the: The
 :the-lc: the
 :virt: OpenShift Virtualization

--- a/documentation/modules/compatibility-guidelines.adoc
+++ b/documentation/modules/compatibility-guidelines.adoc
@@ -8,9 +8,9 @@
 
 You must install compatible software versions.
 
-[cols="1,1,1,1,1", options="header"]
+[cols="1,1,1,1,1,1", options="header"]
 .Compatible software versions
 |===
-|{project-full} |{ocp} |{virt} |VMware vSphere |{rhv-full}
-|2.3.3 |4.10 or later |4.10 or later |6.5 or later |4.4.9 or later
+|{project-full} |{ocp} |{virt} |VMware vSphere |{rhv-full}|OpenStack
+|2.3.3 |4.10 or later |4.10 or later |6.5 or later |4.4.9 or later|16.1 or later
 |===

--- a/documentation/modules/compatibility-guidelines.adoc
+++ b/documentation/modules/compatibility-guidelines.adoc
@@ -12,5 +12,5 @@ You must install compatible software versions.
 .Compatible software versions
 |===
 |{project-full} |{ocp} |{virt} |VMware vSphere |{rhv-full}|OpenStack
-|2.3.3 |4.10 or later |4.10 or later |6.5 or later |4.4.9 or later|16.1 or later
+|2.4.0 |4.11 or later |4.11 or later |6.5 or later |4.4.9 or later|16.1 or later
 |===


### PR DESCRIPTION
@ahadas @qiyuann @mavital
[MTV-465](https://issues.redhat.com/browse/MTV-465)

Adding a new clean version of the MTV 2.4.0 references notes without junk files and typos corrected.
The other ones are such a mess, I thought it's best to start from scratch.
Please, could you do the necessary review?
Thanks


**common-attributes.adoc**
Line 9:
**:ocp-version: 4.10** changed to **:ocp-version: 4.11**

Lines 17 & 18
**:project-version: 2.3
:project-z-version: 2.3.0**
changed to
**:project-version: 2.4
:project-z-version: 2.4.0**

**compatibility-guidelines.adoc**
Adding OpenStack compatibility to the table (Lines 11 to 15):

**[cols="1,1,1,1,1,1", options="header"]
.Compatible software versions
|===
|{project-full} |{ocp} |{virt} |VMware vSphere |{rhv-full}|OpenStack
|2.3.3 |4.10 or later |4.10 or later |6.5 or later |4.4.9 or later|16.1 or later**