### PR TITLE
Cleanup: Adding providers

### DIFF
--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -28,7 +28,7 @@ endif::[]
 . Click *Create Provider*.
 ifdef::vmware[]
 . Select *VMware* from the *Provider type* list.
-. Fill in the following fields:
+. Specify the following fields:
 
 * *Provider name*: Name to display in the list of providers
 * *vCenter host name or IP address*: vCenter host name or IP address - if a certificate for FQDN is specified, the value of this field needs to match the FQDN in the certificate
@@ -41,7 +41,7 @@ ifdef::vmware[]
 endif::[]
 ifdef::rhv[]
 . Select *Red Hat Virtualization* from the *Provider type* list.
-. Fill in the following fields:
+. Specify the following fields:
 
 * *Provider name*: Name to display in the list of providers
 * *RHV Manager host name or IP address*: {manager} host name or IP address -  if a certificate for FQDN is specified, the value of this field needs to match the FQDN in the certificate

--- a/documentation/modules/adding-virt-provider.adoc
+++ b/documentation/modules/adding-virt-provider.adoc
@@ -17,7 +17,7 @@ You can add {a-virt} destination provider to the {ocp} web console in addition t
 . In the {ocp} web console, click *Migration* -> *Providers for virtualization*.
 . Click *Create Provider*.
 . Select *{virt}* from the *Provider type* list.
-. Fill in the following fields:
+. Specify the following fields:
 
 * *Provider name*: Specify the provider name to display in the list of target providers.
 * *Kubernetes API server URL*: Specify the {ocp} cluster API endpoint.

--- a/documentation/modules/osh-adding-source-provider.adoc
+++ b/documentation/modules/osh-adding-source-provider.adoc
@@ -30,7 +30,7 @@ Migration using {osp} source providers only supports VMs that use only Cinder vo
 . Click *Create Provider*.
 
 . Select *Red Hat OpenStack Platform* from the *Provider type* list.
-. Fill in the following fields:
+. Specify the following fields:
 
 * *Provider name*: Name to display in the list of providers
 * *{osp} Identity server URL*: {osp} Identity (Keystone) endpoint, for example, `http://controller:5000/v3`

--- a/documentation/modules/selecting-migration-network-for-virt-provider.adoc
+++ b/documentation/modules/selecting-migration-network-for-virt-provider.adoc
@@ -17,8 +17,7 @@ You can override the default migration network of the provider by selecting a di
 
 .Procedure
 
-. In the {ocp} web console, click *Migration* -> *Providers for virtualization*..
-. Click the *{virt}* tab.
+. In the {ocp} web console, click *Migration* -> *Providers for virtualization*.
 . Select a provider and click *Select migration network*.
 . Select a network from the list of available networks and click *Select*.
 . Click the network number in the *Networks* column beside the provider to verify that the selected network is the default migration network.

--- a/documentation/modules/selecting-migration-network-for-vmware-source-provider.adoc
+++ b/documentation/modules/selecting-migration-network-for-vmware-source-provider.adoc
@@ -25,20 +25,14 @@ The source virtual disks are copied by a pod that is connected to the pod networ
 .Procedure
 
 . In the {ocp} web console, click *Migration* -> *Providers for virtualization*.
-. Click the *VMware* tab.
 . Click the host number in the *Hosts* column beside a provider to view a list of hosts.
 . Select one or more hosts and click *Select migration network*.
-. Select a *Network*.
-+
-You can clear the selection by selecting the default network.
+. Specify the following fields:
 
-. If your source provider is VMware, complete the following fields:
-* *ESXi host admin username*: Specify the ESXi host admin user, for example, `root`.
-* *ESXi host admin password*: Specify the ESXi host admin password.
+* *Network*: Network name
+* *ESXi host admin username*: For example, `root`
+* *ESXi host admin password*: Password
 
-. If your source provider is {rhv-full}, complete the following fields:
-* *Username*: Specify the {manager} user.
-* *Password*: Specify the {manager} password.
 . Click *Save*.
 . Verify that the status of each host is *Ready*.
 +


### PR DESCRIPTION
MTV 2.4

[no jira]: Updates Section 4.1, "Adding providers" to reflect changes to the UI or to cleanup aspects of the OCP plugin not covered in previous PRs.

Preview: section 4.1.1.1.1 in http://file.emea.redhat.com/rhoch/cleanup_chapter4/html-single/#adding-source-providers