### PR TITLE
Cleanup: Migration plan options

### DIFF
--- a/documentation/modules/migration-plan-options-ui.adoc
+++ b/documentation/modules/migration-plan-options-ui.adoc
@@ -8,6 +8,7 @@
 
 On the *Plans for virtualization* page of the {ocp} web console, you can click the {kebab} beside a migration plan to access the following options:
 
+* *Get logs*: Retrieves the logs of a migration. When you click *Get logs*, a confirmation window opens. After you click *Get logs* in the window, wait until *Get logs* changes to *Download logs* and then click the button to download the logs.
 * *Edit*: Edit the details of a migration plan. You cannot edit a migration plan while it is running or after it has completed successfully.
 * *Duplicate*: Create a new migration plan with the same virtual machines (VMs), parameters, mappings, and hooks as an existing plan. You can use this feature for the following tasks:
 


### PR DESCRIPTION
MTV 2.4

Partially resolves https://issues.redhat.com/browse/MTV-510 by updating section of 4.6, "Migration plan options" of the MTV user guide.

Preview: http://file.emea.redhat.com/rhoch/cleanup_plan_options/html-single/#running-migration-plan_mtv