### PR TITLE
Set 'Source volume type' as an OSP source title for storage mapping

### DIFF
--- a/documentation/modules/creating-migration-plan.adoc
+++ b/documentation/modules/creating-migration-plan.adoc
@@ -53,7 +53,7 @@ To create a new storage mapping:
 
 .. If your source provider is VMware, select a *Source datastore* and a *Target storage class*.
 .. If your source provider is {rhv-full}, select a *Source storage domain* and a *Target storage class*.
-.. If your source provider is {osp}, select a *Source* and a *Target storage class*.
+.. If your source provider is {osp}, select a *Source volume type* and a *Target storage class*.
 
 . Optional: Select *Save current mapping as a template* and enter a name for the storage mapping.
 . Click *Next*.

--- a/documentation/modules/creating-storage-mapping.adoc
+++ b/documentation/modules/creating-storage-mapping.adoc
@@ -27,7 +27,7 @@ You can create a storage mapping by using the {ocp} web console to map source di
 
 .. If your source provider is VMware, select a *Source datastore* and a *Target storage class*.
 .. If your source provider is {rhv-full}, select a *Source storage domain* and a *Target storage class*.
-.. If your source provider is {osp}, select a *Source* and a *Target storage class*.
+.. If your source provider is {osp}, select a *Source volume type* and a *Target storage class*.
 
 . Optional: Click *Add* to create additional storage mappings or to map multiple source disk storages to a single target storage class.
 . Click *Create*.


### PR DESCRIPTION
MTV 2.4

Set 'Source volume type' as a source title for storage mapping, in case the source provider is OSP.

Based on fix: https://github.com/kubev2v/forklift-console-plugin/pull/429