### PR TITLE
Documentation updates for 2.4.1

### DIFF
--- a/documentation/modules/rn-2.4.adoc
+++ b/documentation/modules/rn-2.4.adoc
@@ -123,6 +123,10 @@ See link:https://access.redhat.com/articles/1351473[Converting virtual machines 
 
 When migrating VMs that are installed with RHEL 9 as guest operating system from vSphere, their network interfaces could be disabled when they start in OpenShift Virtualization. link:https://issues.redhat.com/browse/MTV-491[(MTV-491)]
 
+.Upgrade from 2.4.0 fails
+
+When upgrading from MTV 2.4.0 to a later version, the operation fails with an error that says the field 'spec.selector' of deployment 'forklift-controller' is immutable. Workaround: remove the custom resource `forklift-controller` of type 'ForkliftController' from the installed namespace, and recreate it. link:https://issues.redhat.com/browse/MTV-518[(MTV-518)]
+
 [id="resolved-issues-24_{context}"]
 == Resolved issues
 

--- a/documentation/modules/rn-2.4.adoc
+++ b/documentation/modules/rn-2.4.adoc
@@ -123,10 +123,6 @@ See link:https://access.redhat.com/articles/1351473[Converting virtual machines 
 
 When migrating VMs that are installed with RHEL 9 as guest operating system from vSphere, their network interfaces could be disabled when they start in OpenShift Virtualization. link:https://issues.redhat.com/browse/MTV-491[(MTV-491)]
 
-.Selection of a migration transfer network does not apply to cold migrations to the local {ocp} instance
-
-Cold migrations from vSphere, {rhv-full} or {osp}, to the {ocp} instance that {project-full} runs on, does not necessarily transfer the disks on the selected migration transfer network.
-
 [id="resolved-issues-24_{context}"]
 == Resolved issues
 

--- a/documentation/modules/rn-2.4.adoc
+++ b/documentation/modules/rn-2.4.adoc
@@ -125,7 +125,7 @@ When migrating VMs that are installed with RHEL 9 as guest operating system from
 
 .Upgrade from 2.4.0 fails
 
-When upgrading from MTV 2.4.0 to a later version, the operation fails with an error that says the field 'spec.selector' of deployment 'forklift-controller' is immutable. Workaround: remove the custom resource `forklift-controller` of type 'ForkliftController' from the installed namespace, and recreate it. The user needs to refresh the OCP Console once the 'forklift-console-plugin' pod runs in order to load the upgraded {product-short} web console. link:https://issues.redhat.com/browse/MTV-518[(MTV-518)]
+When upgrading from MTV 2.4.0 to a later version, the operation fails with an error that says the field 'spec.selector' of deployment `forklift-controller` is immutable. Workaround: remove the custom resource `forklift-controller` of type `ForkliftController` from the installed namespace, and recreate it. The user needs to refresh the OCP Console once the `forklift-console-plugin` pod runs in order to load the upgraded {product-short} web console. link:https://issues.redhat.com/browse/MTV-518[(MTV-518)]
 
 [id="resolved-issues-24_{context}"]
 == Resolved issues

--- a/documentation/modules/rn-2.4.adoc
+++ b/documentation/modules/rn-2.4.adoc
@@ -125,7 +125,7 @@ When migrating VMs that are installed with RHEL 9 as guest operating system from
 
 .Upgrade from 2.4.0 fails
 
-When upgrading from MTV 2.4.0 to a later version, the operation fails with an error that says the field 'spec.selector' of deployment 'forklift-controller' is immutable. Workaround: remove the custom resource `forklift-controller` of type 'ForkliftController' from the installed namespace, and recreate it. link:https://issues.redhat.com/browse/MTV-518[(MTV-518)]
+When upgrading from MTV 2.4.0 to a later version, the operation fails with an error that says the field 'spec.selector' of deployment 'forklift-controller' is immutable. Workaround: remove the custom resource `forklift-controller` of type 'ForkliftController' from the installed namespace, and recreate it. The user needs to refresh the OCP Console once the 'forklift-console-plugin' pod runs in order to load the upgraded {product-short} web console. link:https://issues.redhat.com/browse/MTV-518[(MTV-518)]
 
 [id="resolved-issues-24_{context}"]
 == Resolved issues

--- a/documentation/modules/selecting-migration-network-for-virt-provider.adoc
+++ b/documentation/modules/selecting-migration-network-for-virt-provider.adoc
@@ -20,4 +20,4 @@ You can override the default migration network of the provider by selecting a di
 . In the {ocp} web console, click *Migration* -> *Providers for virtualization*.
 . On the right side of the provider, select *Select migration network* from the {kebab}.
 . Select a network from the list of available networks and click *Select*.
-. Click the network number in the *Networks* column beside the provider to verify that the selected network is the default migration network.
+//. Click the network number in the *Networks* column beside the provider to verify that the selected network is the default migration network.

--- a/documentation/modules/selecting-migration-network-for-virt-provider.adoc
+++ b/documentation/modules/selecting-migration-network-for-virt-provider.adoc
@@ -18,6 +18,6 @@ You can override the default migration network of the provider by selecting a di
 .Procedure
 
 . In the {ocp} web console, click *Migration* -> *Providers for virtualization*.
-. Select a provider and click *Select migration network*.
+. On the right side of the provider, select *Select migration network* from the {kebab}.
 . Select a network from the list of available networks and click *Select*.
 . Click the network number in the *Networks* column beside the provider to verify that the selected network is the default migration network.


### PR DESCRIPTION
Update release-notes of 2.4 for 2.4.1:
- Drop an obsolete known issue ('transfer-network' is not used by volume populators, fixed by https://github.com/kubev2v/forklift/pull/321)
- Add a known-issue for the failure to upgrade from 2.4.0 (a result of the fix for https://github.com/kubev2v/forklift/issues/314)

Minor modifications in the `Selecting a migration network for an OpenShift Virtualization provider` section:
- Change how 'migration network' is selected for OpenShift Virtualization providers (changed while fixing https://github.com/kubev2v/forklift-console-plugin/issues/405)
- Commented out the section of verifying the 'migration network' of an OpenShift Virtualization provider (filed https://github.com/kubev2v/forklift-console-plugin/issues/441)