### PR TITLE
MTV-543: changing z-stream attribute for 2.4.1

### DIFF
--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -15,7 +15,7 @@
 :project-short: MTV
 :project-first: {project-full} ({project-short})
 :project-version: 2.4
-:project-z-version: 2.4.0
+:project-z-version: 2.4.1
 :the: The
 :the-lc: the
 :virt: OpenShift Virtualization


### PR DESCRIPTION
Changing the *documentation/modules/common-attributes.adoc*

Line 18: *:project-z-version: 2.4.1*