### PR TITLE
Change OpenStack to OpenShift

### DIFF
--- a/documentation/modules/adding-virt-provider.adoc
+++ b/documentation/modules/adding-virt-provider.adoc
@@ -23,7 +23,7 @@ You can add {a-virt} destination provider to the {ocp} web console in addition t
 * *Kubernetes API server URL*: Specify the {ocp} cluster API endpoint.
 * *Service account token*: Specify the `cluster-admin` service account token.
 +
-If both *URL* and *Service account token* are left blank, the local {osp} cluster is used.
+If both *URL* and *Service account token* are left blank, the local {ocp-short} cluster is used.
 
 . Click *Create*.
 +

--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -6,6 +6,7 @@
 :namespace: openshift-mtv
 :oc: oc
 :ocp: Red Hat OpenShift
+:ocp-short: OpenShift
 :ocp-version: 4.11
 :operator: mtv-operator
 :operator-name-ui: Migration Toolkit for Virtualization Operator


### PR DESCRIPTION
There's a typo in the "Adding destination providers" section: we refer to OpenStack instead of OpenShift when explaining that providing blank URL and Service account token in the add-provider dialog means the local cluster will be used. This PR replaces "local OpenStack cluster" with "local OpenShift cluster" to fix this.