### PR TITLE
MTV-609: uninterpolated asciidoc variable, changing to OpenShift to fix

### DIFF
--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -6,6 +6,7 @@
 :namespace: openshift-mtv
 :oc: oc
 :ocp: Red Hat OpenShift
+:ocp-name: OpenShift
 :ocp-short: OpenShift
 :ocp-version: 4.11
 :operator: mtv-operator

--- a/documentation/modules/virt-migration-workflow.adoc
+++ b/documentation/modules/virt-migration-workflow.adoc
@@ -19,7 +19,7 @@ You can use the detailed migration workflow to troubleshoot a failed migration.
 
 The workflow describes the following steps:
 
-*Warm Migration or migration to a remote OpenShift cluster:*
+*Warm Migration or migration to a remote {ocp-name} cluster:*
 
 . When you create the `Migration` custom resource (CR) to run a migration plan, the `Migration Controller` service creates a `DataVolume` CR for each source VM disk.
 +
@@ -42,7 +42,7 @@ The `conversion` pod runs `virt-v2v`, which installs and configures device drive
 +
 The `virt-launcher` pod runs `QEMU-KVM` with the PVCs attached as VM disks.
 
-*Cold migration from {rhv-short} or {osp} to the local {ocp-short} cluster:*
+*Cold migration from {rhv-short} or {osp} to the local {ocp-name} cluster:*
 
 . When you create a `Migration` custom resource (CR) to run a migration plan, the `Migration Controller` service creates for each source VM disk a `PersistentVolumeClaim` CR, and an `OvirtVolumePopulator` when the source is {rhv-short}, or an `OpenstackVolumePopulator` CR  when the source is {osp}.
 +
@@ -61,7 +61,7 @@ The `virt-launcher` pod runs `QEMU-KVM` with the PVCs attached as VM disks.
 +
 The `virt-launcher` pod runs `QEMU-KVM` with the PVCs attached as VM disks.
 
-*Cold migration from VMWare to the local {ocp-short} cluster:*
+*Cold migration from VMWare to the local {ocp-name} cluster:*
 
 . When you create a `Migration` custom resource (CR) to run a migration plan, the `Migration Controller` service creates a `DataVolume` CR for each source VM disk.
 +


### PR DESCRIPTION
Fixing small error in documentation - 

Line 22  change from:
*Warm Migration or migration to a remote {ocp-short} cluster:*
*Warm Migration or migration to a remote OpenShift cluster:*
![image](https://github.com/kubev2v/forklift-documentation/assets/106804821/e0e4fc35-a2ea-4b34-91e6-ff4af1d9f80f)
I will fix completely in 2.5