### PR TITLE
Edit VDDK note

### DIFF
--- a/documentation/modules/creating-vddk-image.adoc
+++ b/documentation/modules/creating-vddk-image.adoc
@@ -35,7 +35,7 @@ $ mkdir /tmp/<dir_name> && cd /tmp/<dir_name>
 +
 [NOTE]
 ====
-In order to migrate to {virt} 4.12 or earlier, download VDDK version 7.0.3.2 from link:https://developer.vmware.com/web/sdk/7.0/vddk[VMware VDDK version 7 download page].
+In order to migrate to {virt} 4.12, download VDDK version 7.0.3.2 from the link:https://developer.vmware.com/web/sdk/7.0/vddk[VMware VDDK version 7 download page].
 ====
 . Save the VDDK archive file in the temporary directory.
 . Extract the VDDK archive:


### PR DESCRIPTION
MTV 2.5

Resolves https://issues.redhat.com/browse/MTV-632 by removing the phrase "or earlier" in the note that appears in "Creating a VDDK image"

Preview: https://file.emea.redhat.com/rhoch/vddk_note/html-single/#creating-vddk-image_mtv

