### PR TITLE
Additional authentication methods for OpenStack source providers

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -56,6 +56,19 @@ include::modules/network-prerequisites.adoc[leveloffset=+2]
 include::modules/source-vm-prerequisites.adoc[leveloffset=+2]
 include::modules/rhv-prerequisites.adoc[leveloffset=+2]
 include::modules/openstack-prerequisites.adoc[leveloffset=+2]
+
+==== Additional authentication methods for migrations with {osp} source providers
+
+{project-short} versions 2.5 and later support the following authentication methods for migrations with {osp} source providers in addition to the standard username and password credential set:
+
+* Token authentication
+* Application credential authentication
+
+You can use these methods to migrate virtual machines with {osp} source providers using the CLI the same way you migrate other virtual machines, except for how you prepare the `Secret` manifest.
+
+include::modules/ostack-token-auth.adoc[leveloffset=+4]
+include::modules/ostack-app-cred-auth.adoc[leveloffset=+4]
+
 include::modules/vmware-prerequisites.adoc[leveloffset=+2]
 include::modules/creating-vddk-image.adoc[leveloffset=+3]
 :context: prereqs
@@ -108,9 +121,29 @@ You can add source providers and destination providers for a virtual machine mig
 [id="adding-source-providers"]
 ==== Adding source providers
 
-You can add a VMware source provider, {a-rhv} source provider, or an {osp} source provider by using the {ocp} web console.
+You can use {project-short} to migrate VMs from the following source providers:
+
+* {virt}
+* {osp}
+* {rhv-full}
+* VMware vSphere
+* Open Virtual Appliances (OVAs) that originate from or are compatible with VMware vSphere.
+
+You can add a source provider by using the {ocp} web console.
 
 :mtv!:
+:context: cnv
+:cnv:
+include::modules/adding-source-provider.adoc[leveloffset=+4]
+:cnv!:
+:context: ostack
+:ostack:
+include::modules/adding-source-provider.adoc[leveloffset=+4]
+:ostack!:
+:context: rhv
+:rhv:
+include::modules/adding-source-provider.adoc[leveloffset=+4]
+:rhv!:
 :context: vmware
 :vmware:
 include::modules/adding-source-provider.adoc[leveloffset=+4]
@@ -119,14 +152,11 @@ include::modules/adding-source-provider.adoc[leveloffset=+4]
 :mtv:
 include::modules/selecting-migration-network-for-vmware-source-provider.adoc[leveloffset=+5]
 :mtv!:
-:context: rhv
-:rhv:
+:context: ova
+:ova:
 include::modules/adding-source-provider.adoc[leveloffset=+4]
-:rhv!:
+:ova!:
 :context: mtv
-:mtv:
-
-include::modules/osh-adding-source-provider.adoc[leveloffset=+4]
 
 [id="adding-destination-providers"]
 ==== Adding destination providers
@@ -161,6 +191,8 @@ You can migrate virtual machines to {virt} from the command line.
 
 include::modules/migrating-virtual-machines-cli.adoc[leveloffset=+2]
 include::modules/obtaining-vmware-fingerprint.adoc[leveloffset=+2]
+
+
 include::modules/canceling-migration-cli.adoc[leveloffset=+2]
 
 [id="advanced-migration-options"]

--- a/documentation/modules/ostack-app-cred-auth.adoc
+++ b/documentation/modules/ostack-app-cred-auth.adoc
@@ -1,0 +1,95 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+
+:_content-type: PROCEDURE
+[id="openstack-application-credential-authentication_{context}"]
+= Using application credential authentication with an {osp} source provider
+
+You can use application credential authentication, instead of username and password authentication, when you use create an {osp} source provider.
+
+{project-short} supports both of the following types of application credential authentication:
+
+* Application credential ID
+* Application credential name
+
+For each type of application credential authentication, you need to use data from OpenStack to create a `Secret` manifest.
+
+.Prerequisites
+
+You have an {osp} account.
+
+.Procedure
+
+. In the dashboard of the {osp} web console, click *Project* > *API Access*.
+. Expand *Download OpenStack RC file* and click *OpenStack RC file*.
++
+The file that is downloaded, referred to here as `<openstack_rc_file>`, includes the following fields used for application credential authentication:
++
+[source, terminal]
+----
+OS_AUTH_URL
+OS_PROJECT_ID
+OS_PROJECT_NAME
+OS_DOMAIN_NAME
+OS_USERNAME
+----
+
+. To get the data needed for application credential authentication, run the following command:
++
+[source,terminal]
+----
+$ openstack application credential create --role member --role reader --secret redhat forklift
+----
++
+The output, referred to here as `<openstack_credential_output>`, includes:
++
+* The `id`  and `secret` that you need for authentication using an application credential ID
+* The `name` and `secret` that you need for authentication using an application credential name
+
+. Create a `Secret` manifest similar to the following:
+
+** For authentication using the application credential ID:
++
+[source,yaml]
+----
+cat << EOF | oc apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openstack-secret-appid
+  namespace: openshift-mtv
+  labels:
+    createdForProviderType: openstack
+type: Opaque
+stringData:
+  authType: applicationcredential
+  applicationCredentialID: <id_from_openstack_credential_output>
+  applicationCredentialSecret: <secret_from_openstack_credential_output>
+  url: <OS_AUTH_URL_from_openstack_rc_file>
+EOF
+----
+
+** For authentication using the application credential name:
++
+----
+cat << EOF | oc apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openstack-secret-appname
+  namespace: openshift-mtv
+  labels:
+    createdForProviderType: openstack
+type: Opaque
+stringData:
+  authType: applicationcredential
+  applicationCredentialName: <name_from_openstack_credential_output>
+  applicationCredentialSecret: <secret_from_openstack_credential_output>
+  domainName: <OS_DOMAIN_NAME_from_openstack_rc_file>
+  username: <OS_USERNAME_from_openstack_rc_file>
+  url: <OS_AUTH_URL_from_openstack_rc_file>
+EOF
+----
+
+. Continue migrating your virtual machine according to the procedure in xref:migrating-virtual-machines-from-cli[Migrating virtual machines], starting with step 2, "Create a `Provider` manifest for the source provider."

--- a/documentation/modules/ostack-token-auth.adoc
+++ b/documentation/modules/ostack-token-auth.adoc
@@ -1,0 +1,95 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+
+:_content-type: PROCEDURE
+[id="openstack-token-authentication_{context}"]
+= Using token authentication with an {osp} source provider
+
+You can use token authentication, instead of username and password authentication, when you create an {osp} source provider.
+
+{project-short} supports both of the following types of token authentication:
+
+* Token with user ID
+* Token with user name
+
+For each type of token authentication, you need to use data from OpenStack to create a `Secret` manifest.
+
+.Prerequisites
+
+Have an {osp} account.
+
+.Procedure
+
+. In the dashboard of the {osp} web console, click *Project > API Access*.
+. Expand *Download OpenStack RC file* and click *OpenStack RC file*.
++
+The file that is downloaded, referred to here as `<openstack_rc_file>`, includes the following fields used for token authentication:
++
+[source, terminal]
+----
+OS_AUTH_URL
+OS_PROJECT_ID
+OS_PROJECT_NAME
+OS_DOMAIN_NAME
+OS_USERNAME
+----
+
+. To get the data needed for token authentication, run the following command:
++
+[source,terminal]
+----
+$ openstack token issue
+----
++
+The output, referred to here as `<openstack_token_output>`, includes the `token`, `userID`, and `projectID` that you need for authentication using a token with user ID.
+
+
+. Create a `Secret` manifest similar to the following:
+
+** For authentication using a token with user ID:
++
+[source,yaml]
+----
+cat << EOF | oc apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openstack-secret-tokenid
+  namespace: openshift-mtv
+  labels:
+    createdForProviderType: openstack
+type: Opaque
+stringData:
+  authType: token
+  token: <token_from_openstack_token_output>
+  projectID: <projectID_from_openstack_token_output>
+  userID: <userID_from_openstack_token_output>
+  url: <OS_AUTH_URL_from_openstack_rc_file>
+EOF
+----
+
+** For authentication using a token with user name:
++
+[source,yaml]
+----
+cat << EOF | oc apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openstack-secret-tokenname
+  namespace: openshift-mtv
+  labels:
+    createdForProviderType: openstack
+type: Opaque
+stringData:
+  authType: token
+  token: <token_from_openstack_token_output>
+  domainName: <OS_DOMAIN_NAME_from_openstack_rc_file>
+  projectName: <OS_PROJECT_NAME_from_openstack_rc_file>
+  username: <OS_USERNAME_from_openstack_rc_file>
+  url: <OS_AUTH_URL_from_openstack_rc_file>
+EOF
+----
+
+. Continue migrating your virtual machine according to the procedure in xref:migrating-virtual-machines-from-cli[Migrating virtual machines], starting with step 2, "Create a `Provider` manifest for the source provider."


### PR DESCRIPTION
MTV 2.5

Resolves https://issues.redhat.com/browse/MTV-551 by adding descriptions of how to use token authentication and application credential authentication with OpenStack source providers.

Preview: https://file.emea.redhat.com/rhoch/ostack_auth/html-single/#additional_authentication_methods_for_migrations_with_openstack_source_providers [end of OpenStack prerequisites]