### PR TITLE
MTV 2.5 supports only cold migration for OpenStack

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -21,22 +21,13 @@ endif::[]
 [id="about-mtv"]
 == About {the-lc} {project-full}
 
-You can migrate virtual machines from VMware vSphere, {rhv-full}, or {osp} source providers to {virt} with {the-lc} {project-first}.
+You can use {the-lc} {project-first} to migrate virtual machines from the following source providers to {virt} destination providers:
 
-Migration using OpenStack source providers is a Technology Preview.
-
-[IMPORTANT]
-====
-Migration using OpenStack source providers is a Technology Preview feature only. Technology Preview features
-are not supported with Red Hat production service level agreements (SLAs) and
-might not be functionally complete. Red Hat does not recommend using them
-in production. These features provide early access to upcoming product
-features, enabling customers to test functionality and provide feedback during
-the development process.
-
-For more information about the support scope of Red Hat Technology Preview
-features, see https://access.redhat.com/support/offerings/techpreview/.
-====
+* VMware vSphere
+* {rhv-full} ({rhv-short})
+* {osp}
+* Open Virtual Appliances (OVAs) that were created by VMware vSphere
+* Remote {virt} clusters
 
 [NOTE]
 ====

--- a/documentation/modules/about-cold-warm-migration.adoc
+++ b/documentation/modules/about-cold-warm-migration.adoc
@@ -6,22 +6,14 @@
 [id="about-cold-warm-migration_{context}"]
 = About cold and warm migration
 
-{project-short} supports cold migration from {rhv-full} ({rhv-short}) and warm migration from VMware vSphere and from {rhv-short}.
+{project-short} supports cold migration from:
 
-As a Technology Preview, {project-short} supports cold migration using {osp} source providers.
+* VMware vSphere
+* {rhv-full} ({rhv-short})
+* {osp}
+* Remote {virt} clusters
 
-[IMPORTANT]
-====
-Migration using OpenStack source providers is a Technology Preview feature only. Technology Preview features
-are not supported with Red Hat production service level agreements (SLAs) and
-might not be functionally complete. Red Hat does not recommend using them
-in production. These features provide early access to upcoming product
-features, enabling customers to test functionality and provide feedback during
-the development process.
-
-For more information about the support scope of Red Hat Technology Preview
-features, see https://access.redhat.com/support/offerings/techpreview/.
-====
+{project-short} supports warm migration from VMware vSphere and from {rhv-short}.
 
 [NOTE]
 ====

--- a/documentation/modules/creating-migration-plan.adoc
+++ b/documentation/modules/creating-migration-plan.adoc
@@ -60,6 +60,11 @@ To create a new storage mapping:
 . Select a migration type and click *Next*.
 * Cold migration: The source VMs are stopped while the data is copied.
 * Warm migration: The source VMs run while the data is copied incrementally. Later, you will run the cutover, which stops the VMs and copies the remaining VM data and metadata.
++
+[NOTE]
+====
+Warm migration is supported only from vSphere and {rhv-full}.
+====
 .  Click *Next*.
 . Optional: You can create a migration hook to run an Ansible playbook before or after migration:
 .. Click *Add hook*.

--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -14,21 +14,6 @@ You must specify a name for cluster-scoped CRs.
 You must specify both a name and a namespace for namespace-scoped CRs.
 ====
 
-As a Technology Preview, {project-short} supports migrations using OpenStack source providers.
-
-[IMPORTANT]
-====
-Migration using OpenStack source providers is a Technology Preview feature only. Technology Preview features
-are not supported with Red Hat production service level agreements (SLAs) and
-might not be functionally complete. Red Hat does not recommend using them
-in production. These features provide early access to upcoming product
-features, enabling customers to test functionality and provide feedback during
-the development process.
-
-For more information about the support scope of Red Hat Technology Preview
-features, see https://access.redhat.com/support/offerings/techpreview/.
-====
-
 [NOTE]
 ====
 Migration using {osp} source providers only supports VMs that use only Cinder volumes.

--- a/documentation/modules/openstack-prerequisites.adoc
+++ b/documentation/modules/openstack-prerequisites.adoc
@@ -10,18 +10,6 @@ The following prerequisites apply to {osp} migrations:
 
 * You must use a xref:compatibility-guidelines_{context}[compatible version] of {osp}.
 
-[IMPORTANT]
-====
-Migration using {osp} source providers is a Technology Preview feature only. Technology Preview features
-are not supported with Red Hat production service level agreements (SLAs) and
-might not be functionally complete. Red Hat does not recommend using them
-in production. These features provide early access to upcoming product
-features, enabling customers to test functionality and provide feedback during
-the development process.
-For more information about the support scope of Red Hat Technology Preview
-features, see https://access.redhat.com/support/offerings/techpreview/.
-====
-
 [NOTE]
 ====
 Migration using {osp} source providers only supports VMs that use only Cinder volumes.

--- a/documentation/modules/osh-adding-source-provider.adoc
+++ b/documentation/modules/osh-adding-source-provider.adoc
@@ -7,18 +7,6 @@
 
 You can add an {osp} source provider by using the {ocp} web console.
 
-[IMPORTANT]
-====
-Migration using {osp} source providers is a Technology Preview feature only. Technology Preview features
-are not supported with Red Hat production service level agreements (SLAs) and
-might not be functionally complete. Red Hat does not recommend using them
-in production. These features provide early access to upcoming product
-features, enabling customers to test functionality and provide feedback during
-the development process.
-For more information about the support scope of Red Hat Technology Preview
-features, see https://access.redhat.com/support/offerings/techpreview/.
-====
-
 [NOTE]
 ====
 Migration using {osp} source providers only supports VMs that use only Cinder volumes.


### PR DESCRIPTION
MTV 2.5 

Resolves https://issues.redhat.com/browse/MTV-550 and https://github.com/kubev2v/forklift-documentation/pull/408 by:
1. Specifying that MTV 2.5 supports only cold migration for OpenStack
2. Removing Technology Preview notifications for OpenStack migrations

Previews:
1. https://file.emea.redhat.com/rhoch/no_warm_mig_ostack/html-single/#about-mtv [OpenStack Technology Preview notice removed; OpenStack listed among providers that support cold migration]
2. https://file.emea.redhat.com/rhoch/no_warm_mig_ostack/html-single/#openstack-prerequisites_mtv [OpenStack Technology Preview notice removed from OpenStack prerequisites] 
3. https://file.emea.redhat.com/rhoch/no_warm_mig_ostack/html-single/#adding-source-providers [OpenStack Technology Preview notice removed from "Adding an OpenStack source provider"]
4. https://file.emea.redhat.com/rhoch/no_warm_mig_ostack/html-single/#creating-migration-plan_mtv [note after step 13 in "Creating a migration plan] 

