### PR TITLE
vSphere migrations and 2023 FIPS

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -217,7 +217,7 @@ include::modules/mtv-resources-and-services.adoc[leveloffset=+3]
 include::modules/mtv-workflow.adoc[leveloffset=+3]
 include::modules/virt-migration-workflow.adoc[leveloffset=+3]
 
-[id="logs-and-crs_{context}"]
+[id="logs-and-crs"]
 === Logs and custom resources
 
 You can download logs and custom resource (CR) information for troubleshooting. For more information, see the xref:virt-migration-workflow_{context}[detailed migration workflow].

--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -4,9 +4,14 @@
 
 [id="adding-source-provider_{context}"]
 ifdef::vmware[]
-= Adding a VMware source provider
+= Adding a VMware vSphere source provider
 
-You can add a VMware source provider by using the {ocp} web console.
+You can add a VMware vSphere source provider by using the {ocp} web console.
+
+[IMPORTANT]
+====
+EMS enforcement is disabled for migrations with VMware vSphere source providers in order to enable migrations from versions of vSphere that are supported by {project-full} but do not comply with the 2023 FIPS requirements. Therefore, users should consider whether migrations from vSphere source providers risk their compliance with FIPS. Supported versions of vSphere are specified in xref:../master.adoc#compatibility-guidelines_mtv[Software compatibility guidelines].
+====
 
 .Prerequisites
 


### PR DESCRIPTION
MTV 2.5

Resolves https://issues.redhat.com/browse/MTV-633 by adding a note indicating that EMS enforcement is disabled for vSphere migrations because vSphere does not comply with 2023 FIPS requirements. 

Preview: https://file.emea.redhat.com/rhoch/FIPS/html-single/#adding-source-providers [Note labeled "IMPORTANT" in section 4.1.1.1]