### PR TITLE
OVA migration

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -29,6 +29,8 @@ You can use {the-lc} {project-first} to migrate virtual machines from the follow
 * Open Virtual Appliances (OVAs) that were created by VMware vSphere
 * Remote {virt} clusters
 
+include::modules/snippet_ova_tech_preview.adoc[]
+
 [NOTE]
 ====
 Migration using {osp} source providers only supports VMs that use only Cinder volumes.
@@ -77,6 +79,7 @@ include::modules/obtaining-vmware-fingerprint.adoc[leveloffset=+3]
 :context: mtv
 :mtv:
 include::modules/increasing-nfc-memory-vmware-host.adoc[leveloffset=+3]
+include::modules/ova-prerequisites.adoc[leveloffset=+2]
 include::modules/compatibility-guidelines.adoc[leveloffset=+2]
 
 [id="installing-the-operator"]
@@ -127,7 +130,7 @@ You can use {project-short} to migrate VMs from the following source providers:
 * {osp}
 * {rhv-full}
 * VMware vSphere
-* Open Virtual Appliances (OVAs) that originate from or are compatible with VMware vSphere.
+* Open Virtual Appliances (OVAs) that were created by VMware vSphere.
 
 You can add a source provider by using the {ocp} web console.
 
@@ -153,6 +156,7 @@ include::modules/adding-source-provider.adoc[leveloffset=+4]
 include::modules/selecting-migration-network-for-vmware-source-provider.adoc[leveloffset=+5]
 :mtv!:
 :context: ova
+
 :ova:
 include::modules/adding-source-provider.adoc[leveloffset=+4]
 :ova!:

--- a/documentation/modules/creating-storage-mapping.adoc
+++ b/documentation/modules/creating-storage-mapping.adoc
@@ -25,9 +25,10 @@ You can create a storage mapping by using the {ocp} web console to map source di
 
 . Map source disk storages to target storage classes as follows:
 
-.. If your source provider is VMware, select a *Source datastore* and a *Target storage class*.
+.. If your source provider is VMware vSphere, select a *Source datastore* and a *Target storage class*.
 .. If your source provider is {rhv-full}, select a *Source storage domain* and a *Target storage class*.
 .. If your source provider is {osp}, select a *Source volume type* and a *Target storage class*.
+.. If your source provider is a set of one or more OVA files, select a *Source* and a *Target storage class* for the dummy storage that applies to all virtual disks within the OVA files.
 
 . Optional: Click *Add* to create additional storage mappings or to map multiple source disk storages to a single target storage class.
 . Click *Create*.

--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -14,6 +14,8 @@ You must specify a name for cluster-scoped CRs.
 You must specify both a name and a namespace for namespace-scoped CRs.
 ====
 
+include::snippet_ova_tech_preview.adoc[]
+
 [NOTE]
 ====
 Migration using {osp} source providers only supports VMs that use only Cinder volumes.
@@ -46,31 +48,46 @@ metadata:
       uid: <provider_uid>
   labels:
     createdForProviderType: <provider_type> <2>
+    createdForResourceType: providers
 type: Opaque
-stringData:
-  user: <user> <3>
-  password: <password> <4>
-  insecureSkipVerify: <true/false> <5>
-  domainName: <domain_name> <6>
-  projectName: <project_name> <7>
-  regionName: <region name> <8>
-  cacert: | <9>
+stringData: <3>
+  user: <user> <4>
+  password: <password> <5>
+  insecureSkipVerify: <true/false> <6>
+  domainName: <domain_name> <7>
+  projectName: <project_name> <8>
+  regionName: <region name> <9>
+  cacert: | <10>
     <ca_certificate>
-  url: <api_end_point> <10>
-  thumbprint: <vcenter_fingerprint> <11>
+  url: <api_end_point> <11>
+  thumbprint: <vcenter_fingerprint> <12>
 EOF
 ----
 <1> The `ownerReferences` section is optional.
-<2>  Specify the type of source provider. Allowed values are `ovirt`, `vsphere`, and `openstack`. This label is needed to verify the credentials are correct when the remote system is accessible and, for {rhv-short}, to retrieve the {manager} CA certificate when a third-party certificate is specified.
-<3> Specify the vCenter user, the {rhv-short} {manager} user, or the {osp} user.
-<4> Specify the user password.
-<5> Specify `<true>` to skip certificate verification, which proceeds with an insecure migration and then the certificate is not required. Insecure migration means that the transferred data is sent over an insecure connection and potentially sensitive data could be exposed. Specifying `<false>` verifies the certificate.
-<6> {osp} only: Specify the domain name.
-<7> {osp} only: Specify the project name.
-<8> {osp} only: Specify the name of the {osp} region.
-<9> {rhv-short} and {osp} only: For {rhv-short}, enter the {manager} CA certificate unless it was replaced by a third-party certificate, in which case enter the {manager} Apache CA certificate. You can retrieve the {manager} CA certificate at https://<engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA. For {osp}, enter the CA certificate for connecting to the source environment. The certificate is not used when `insecureSkipVerify` is set to `<true>`.
-<10> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere, `https://<engine_host>/ovirt-engine/api/` for {rhv-short}, or `https://<identity_service>/v3` for {osp}.
-<11> VMware only: Specify the vCenter SHA-1 fingerprint.
+<2> Specify the type of source provider. Allowed values are `ovirt`, `vsphere`, `openstack`, and `ova`. This label is needed to verify the credentials are correct when the remote system is accessible and, for {rhv-short}, to retrieve the {manager} CA certificate when a third-party certificate is specified.
+<3> The `stringData` section for OVA is different and is described in a note that follows the description of the `Secret` manifest.
+<4> Specify the vCenter user, the {rhv-short} {manager} user, or the {osp} user.
+<5> Specify the user password.
+<6> Specify `<true>` to skip certificate verification, which proceeds with an insecure migration and then the certificate is not required. Insecure migration means that the transferred data is sent over an insecure connection and potentially sensitive data could be exposed. Specifying `<false>` verifies the certificate.
+<7> {osp} only: Specify the domain name.
+<8> {osp} only: Specify the project name.
+<9> {osp} only: Specify the name of the {osp} region.
+<10> {rhv-short} and {osp} only: For {rhv-short}, enter the {manager} CA certificate unless it was replaced by a third-party certificate, in which case enter the {manager} Apache CA certificate. You can retrieve the {manager} CA certificate at https://<engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA. For {osp}, enter the CA certificate for connecting to the source environment. The certificate is not used when `insecureSkipVerify` is set to `<true>`.
+<11> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere, `https://<engine_host>/ovirt-engine/api/` for {rhv-short}, or `https://<identity_service>/v3` for {osp}.
+<12> VMware only: Specify the vCenter SHA-1 fingerprint.
++
+[NOTE]
+====
+The `stringData` section for an OVA `Secret` manifest is as follows:
+[source,yaml,subs="attributes+"]
+----
+stringData:
+  url: <nfs_server:/nfs_path>
+----
+where: +
+`nfs_server`: An IP or hostname of the server where the share was created. +
+`nfs_path` : The path on the server where the OVA files are stored.
+====
 
 . Create a `Provider` manifest for the source provider:
 +

--- a/documentation/modules/ova-prerequisites.adoc
+++ b/documentation/modules/ova-prerequisites.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+
+:_content-type: REFERENCE
+[id="ova-prerequisites_{context}"]
+= Open Virtual Appliance (OVA) prerequisites
+
+The following prerequisites apply to Open Virtual Appliance (OVA) file migrations:
+
+* All OVA files are created by VMware vSphere.
+
+[NOTE]
+====
+Migration of OVA files that were not created by VMware vSphere but are compatible with vSphere might succeed. However, migration of such files is not supported by {project-short}. {project-short} supports only OVA files created by VMware vSphere.
+====
+
+* The OVA files are in one or more folders under an NFS shared directory in one of the following structures:
+
+** In one or more compressed Open Virtualization Format (OVF) packages that hold all the VM information.
++
+The filenames of the compressed packages *must* have `.ova` extensions. Several packages can be stored either in the same folder or in individual folders:
++
+`<nfs_shared_directory>/folder1/vm1.ova` +
+`<nfs_shared_directory>/folder1/vm2.ova` (`vm1.ova` and `vm2.ova` in `folder1`)
++
+_or_
++
+`<nfs_shared_directory>/folder1/vm1.ova` +
+`<nfs_shared_directory>/folder2/vm2.ova` (`vm1.ova` in `folder1`, `vm2.ova` in `folder2`)
+
+** In extracted OVF packages, each package being an individual folder:
++
+`<nfs_shared_directory>/vm1/` +
+`<nfs_shared_directory>/vm2/`

--- a/documentation/modules/snippet_ova_tech_preview.adoc
+++ b/documentation/modules/snippet_ova_tech_preview.adoc
@@ -1,0 +1,12 @@
+:_content-type: SNIPPET
+
+Migration using one or more Open Virtual Appliance (OVA) files as a source provider is a Technology Preview.
+
+[IMPORTANT]
+====
+Migration using one or more Open Virtual Appliance (OVA) files as a source provider is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product
+features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red Hat Technology Preview
+features, see https://access.redhat.com/support/offerings/techpreview/.
+====


### PR DESCRIPTION
MTV 2.5

Resolves https://issues.redhat.com/browse/MTV-568 by updating the MTV user guide to include information on importing OVA files.

Note. This PR does not discuss creating OVA source providers in the UI. That is part of  https://github.com/kubev2v/forklift-documentation/pull/402. 

Previews:
1. https://file.emea.redhat.com/rhoch/ova/html-single/#ova-prerequisites_mtv [OVA prerequisites]. The Technology Preview notifications in the guide in the same places as the OpenStack ones did in version 2.4 -- as shown here and in the Create Providers PR. 
2. https://file.emea.redhat.com/rhoch/ova/html-single/#creating-storage-mapping_mtv [Storage mapping step 4d].
3. https://file.emea.redhat.com/rhoch/ova/html-single/#migrating-virtual-machines-cli_mtv [Procedure step 1 -- callout 4 in YAML and note after YAML]
