### PR TITLE
OCP-OCP migration

### DIFF
--- a/documentation/modules/creating-network-mapping.adoc
+++ b/documentation/modules/creating-network-mapping.adoc
@@ -17,15 +17,13 @@ You can create one or more network mappings by using the {ocp} web console to ma
 
 . In the {ocp} web console, click *Migration* -> *NetworkMaps for virtualization*.
 . Click *Create NetworkMap*.
-. Complete the following fields:
+. Specify the following fields:
 
 * *Name*: Enter a name to display in the network mappings list.
 * *Source provider*: Select a source provider.
 * *Target provider*: Select a target provider.
-+
-The *Source networks* and *Target namespaces/networks* text boxes become active.
 
-. Select a source network and a target namespace/network from the list.
+. Select a *Source network* and a *Target namespace/network*.
 . Optional: Click *Add* to create additional network mappings or to map multiple source networks to a single target network.
 . If you create an additional network mapping, select the network attachment definition as the target network.
 . Click *Create*.

--- a/documentation/modules/creating-storage-mapping.adoc
+++ b/documentation/modules/creating-storage-mapping.adoc
@@ -23,14 +23,14 @@ You can create a storage mapping by using the {ocp} web console to map source di
 * *Source provider*: Select a source provider.
 * *Target provider*: Select a target provider.
 
-. Map source disk storages to target storage classes as follows:
+. To create a storage mapping, click *Add* and map storage sources to target storage classes as follows:
 
 .. If your source provider is VMware vSphere, select a *Source datastore* and a *Target storage class*.
 .. If your source provider is {rhv-full}, select a *Source storage domain* and a *Target storage class*.
 .. If your source provider is {osp}, select a *Source volume type* and a *Target storage class*.
 .. If your source provider is a set of one or more OVA files, select a *Source* and a *Target storage class* for the dummy storage that applies to all virtual disks within the OVA files.
-
-. Optional: Click *Add* to create additional storage mappings or to map multiple source disk storages to a single target storage class.
+.. If your storage provider is {virt}. select a *Source storage class* and a *Target storage class*.
+.. Optional: Click *Add* to create additional storage mappings, including mapping multiple storage sources to a single target storage class.
 . Click *Create*.
 +
 The mapping is displayed on the *StorageMaps* page.

--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -253,34 +253,39 @@ spec:
     destination:
       name: <destination_cluster>
       namespace: {namespace}
-  map:
-    network: <3>
-      name: <network_map> <4>
+  map: <3>
+    network: <4>
+      name: <network_map> <5>
       namespace: {namespace}
-    storage:
-      name: <storage_map> <5>
+    storage: <6>
+      name: <storage_map> <7>
       namespace: {namespace}
   targetNamespace: {namespace}
-  vms: <6>
-    - id: <source_vm> <7>
+  vms: <8>
+    - id: <source_vm> <9>
     - name: <source_vm>
-      hooks: <8>
+      namespace: {namespace} <10>
+      hooks: <11>
         - hook:
             namespace: {namespace}
-            name: <hook> <9>
-          step: <step> <10>
+            name: <hook> <12>
+          step: <step> <13>
 EOF
 ----
 <1> Specify the name of the `Plan` CR.
 <2> Specify whether the migration is warm or cold. If you specify a warm migration without specifying a value for the `cutover` parameter in the `Migration` manifest, only the precopy stage will run.
-<3> You can add multiple network mappings.
-<4> Specify the name of the `NetworkMap` CR.
-<5> Specify the name of the `StorageMap` CR.
-<6> You can use either the `id` _or_ the `name` parameter to specify the source VMs.
-<7> Specify the VMware VM MOR, {rhv-short} VM UUID or the {osp} VM UUID.
-<8> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
-<9> Specify the name of the `Hook` CR.
-<10> Allowed values are `PreHook`, before the migration plan starts, or `PostHook`, after the migration is complete.
+<3> Specify only one network map and one storage map per plan.
+<4> Specify a network mapping even if the VMs to be migrated are not assigned to a network. The mapping can be empty in this case.
+<5> Specify the name of the `NetworkMap` CR.
+<6> Specify a storage mapping even if the VMs to be migrated are not assigned with disk images. The mapping can be empty in this case.
+<7> Specify the name of the `StorageMap` CR.
+<8> For all source providers except for {virt}, you can use either the `id` _or_ the `name` parameter to specify the source VMs. +
+{virt} source provider only: You can use only the `name` parameter, not the `id.` parameter to specify the source VMs.
+<9> Specify the VMware VM MOR, {rhv-short} VM UUID or the {osp} VM UUID.
+<10> {virt} source provider only.
+<11> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
+<12> Specify the name of the `Hook` CR.
+<13> Allowed values are `PreHook`, before the migration plan starts, or `PostHook`, after the migration is complete.
 
 . Create a `Migration` manifest to run the `Plan` CR:
 +


### PR DESCRIPTION
MTV 2.5

Resolves https://issues.redhat.com/browse/MTV-575 by:
1. Adding an additional option to step 4 of "Creating a storage mapping."
2. Modifying the specification of the `vms` section of the `Plan` manifest for OCP source providers. 

Also adds a note about creating providers for future use to the CLI instructions. 

Previews:

1. https://file.emea.redhat.com/rhoch/ocp_ocp_mig/html-single/#creating-storage-mapping_mtv.
2. https://file.emea.redhat.com/rhoch/ocp_ocp_mig/html-single/#migrating-virtual-machines-from-cli [last note before prerequisites] 
3. https://file.emea.redhat.com/rhoch/ocp_ocp_mig/html-single/#migrating-virtual-machines-from-cli [step 7]