### PR TITLE
Importing direct LUNs from RHV

### DIFF
--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -23,6 +23,10 @@ Migration using {osp} source providers only supports VMs that use only Cinder vo
 
 * VMware only: You must have a VMware Virtual Disk Development Kit (VDDK) image in a secure registry that is accessible to all clusters.
 
+* {rhv-full} ({rhv-short}) only: If you are migrating a virtual machine with a direct LUN disk, ensure that the nodes in the {virt} destination cluster that the VM is expected to run on can access the backend storage.
+
+include::snip-migrating-luns.adoc[]
+
 .Procedure
 
 . Create a `Secret` manifest for the source provider credentials:

--- a/documentation/modules/rhv-prerequisites.adoc
+++ b/documentation/modules/rhv-prerequisites.adoc
@@ -12,3 +12,7 @@ The following prerequisites apply to {rhv-full} migrations:
 * You must have the {manager} CA certificate, unless it was replaced by a third-party certificate, in which case, specify the {manager} Apache CA certificate.
 +
 You can obtain the {manager}  CA certificate by navigating to https://<engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA in a browser.
+
+* If you are migrating a virtual machine with a direct LUN disk, ensure that the nodes in the {virt} destination cluster that the VM is expected to run on can access the backend storage.
+
+include::snip-migrating-luns.adoc[]

--- a/documentation/modules/snip-migrating-luns.adoc
+++ b/documentation/modules/snip-migrating-luns.adoc
@@ -1,0 +1,10 @@
+:_content-type: SNIPPET
+
+[NOTE]
+====
+* Unlike disk images that _are copied_ from a source provider to a target provider, LUNs are _detached_, _but not removed_, from virtual machines in the source provider and then attached to the virtual machines (VMs) that are created in the target provider.
+
+* LUNs are not removed from the source provider during the migration in case fallback to the source provider is required. However, before re-attaching the LUNs to VMs in the source provider, ensure that the LUNs are not used by VMs on the target environment at the same time, which might lead to data corruption.
+
+* Migration of Fibre Channel LUNs is not supported.
+====

--- a/documentation/modules/virt-migration-workflow.adoc
+++ b/documentation/modules/virt-migration-workflow.adoc
@@ -81,4 +81,3 @@ The `virt-launcher` pod runs `QEMU-KVM` with the PVCs attached as VM disks.
 . If the VM ran on the source environment, the `Migration Controller` powers on the VM, the `KubeVirt Controller` service creates a `virt-launcher` pod and a `VirtualMachineInstance` CR.
 +
 The `virt-launcher` pod runs `QEMU-KVM` with the PVCs attached as VM disks.
-


### PR DESCRIPTION
MTV 2.5

Resolves https://issues.redhat.com/browse/MTV-555 by adding a note in several places about importing direct LUNs from a RHV source provider.

Previews:

1. https://file.emea.redhat.com/rhoch/lun/html-single/#rhv-prerequisites_mtv [Last RHV prerequisite and note]
2. https://file.emea.redhat.com/rhoch/lun/html-single/#migrating-virtual-machines-cli_mtv [RHV prerequisite in "Migrating Virtual machines"  
