### PR TITLE
Operating MTV with non-cluster admin users

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -113,7 +113,7 @@ You must ensure that all xref:prerequisites[prerequisites] are met.
 
 VMware only: You must have the minimal set of xref:vmware-privileges_{context}[VMware privileges].
 
-VMware only: You must create a xref:creating-vddk-image_{context}[VMware Virtual Disk Development Kit (VDDK)] image.
+VMware only: Creating a xref:creating-vddk-image_{context}[VMware Virtual Disk Development Kit (VDDK)] image will increase migration speed.
 ====
 
 include::modules/mtv-ui.adoc[leveloffset=+2]
@@ -192,10 +192,16 @@ You can migrate virtual machines to {virt} from the command line.
 
 *  VMware only: You must have the xref:obtaining-vmware-fingerprint_{context}[vCenter SHA-1 fingerprint].
 
-*  VMware only: You must create a xref:creating-vddk-image_{context}[VMware Virtual Disk Development Kit (VDDK)] image.
+*  VMware only:  Creating a xref:creating-vddk-image_{context}[VMware Virtual Disk Development Kit (VDDK)] image will increase migration speed.
 
 *  You must ensure that all xref:prerequisites[prerequisites] are met.
 ====
+
+:mtv!:
+:context: cli
+include::modules/non-admin-permissions-for-ui.adoc[leveloffset=+2]
+:cli!:
+:context: mtv
 
 include::modules/migrating-virtual-machines-cli.adoc[leveloffset=+2]
 include::modules/obtaining-vmware-fingerprint.adoc[leveloffset=+2]

--- a/documentation/modules/non-admin-permissions-for-ui.adoc
+++ b/documentation/modules/non-admin-permissions-for-ui.adoc
@@ -1,0 +1,72 @@
+:_content-type: CONCEPT
+
+[id="non-admin-permissions_{context}"]
+= Permissions needed by non-administrators to work with migration plan components
+
+If you are an administrator, you can work with all components of migration plans (for example, providers, network mappings, and migration plans).
+
+By default, non-administrators have limited ability to work with migration plans and their components. As an administrator, you can modify their roles to allow them full access to all components, or you can give them limited permissions.
+
+For example, administrators can assign non-administrators one or more of the following cluster roles for migration plans:
+
+[cols="2", options="header"]
+.Example migration plan roles and their privileges
+|===
+|Role | Description
+
+| `plans.forklift.konveyor.io-v1beta1-view`
+| Can view migration plans but not to create, delete or modify them
+
+| `plans.forklift.konveyor.io-v1beta1-edit`
+| Can create, delete or modify (all parts of `edit` permissions) individual migration plans
+
+| `plans.forklift.konveyor.io-v1beta1-admin`
+| All `edit` privileges and the ability to delete the entire collection of migration plans
+|===
+
+Note that pre-defined cluster roles include a resource (`plans`), an API group (`forklift.konveyor.io-v1beta1`) and an action (for example, `view`, `edit`).
+
+As a more comprehensive example, you can grant non-administrators the following set of permissions per namespace:
+
+* Create and modify storage maps, network maps, and migration plans for the namespaces they have access to
+* Attach providers created by administrators to storage maps, network maps, and migration plans
+* Not be able to create providers or to change system settings
+
+[cols="3", options="header"]
+.Example permissions required for non-adminstrators to work with migration plan components but not create providers
+|===
+|Actions |API group |Resource
+
+|`get`, `list`, `watch`, `create`, `update`, `patch`, `delete`
+|`forklift.konveyer.io`
+|`plans`
+
+| `get`, `list`, `watch`, `create`, `update`, `patch`, `delete`
+|`forklift.konveyer.io`
+|`migrations`
+
+|`get`, `list`, `watch`, `create`, `update`, `patch`, `delete`
+|`forklift.konveyer.io`
+|`hooks`
+
+|`get`, `list`, `watch`
+|`forklift.konveyer.io`
+|`providers`
+
+|`get`, `list`, `watch`, `create`, `update`, `patch`, `delete`
+|`forklift.konveyer.io`
+|`networkmaps`
+
+| `get`, `list`, `watch`, `create`, `update`, `patch`, `delete`
+|`forklift.konveyer.io`
+|`storagemaps`
+
+|`get`, `list`, `watch`
+|`forklift.konveyer.io`
+|`forkliftcontrollers`
+|===
+
+[NOTE]
+====
+Non-administrators need to have the `create` permissions that are part of `edit` roles for network maps and for storage maps to create migration plans, even when using a template for a network map or a storage map.
+====

--- a/documentation/modules/snip_permissions-info.adoc
+++ b/documentation/modules/snip_permissions-info.adoc
@@ -1,0 +1,10 @@
+:_content-type: SNIPPET
+
+If you are an administrator, you can see and work with components (providers, plans, etc.) for all projects.
+
+If you are a non-administrator, you can only see and work only with the components of projects you have permissions for.
+
+[TIP]
+====
+You can see which projects you have permissions for by clicking the *Project* list, which is in the upper-left of every page in the *Migrations* section except for the *Overview*.
+====


### PR DESCRIPTION
MTV 2.5

Resolves https://issues.redhat.com/browse/MTV-431 by:
* Adding information describing the differences between what admins and non-admins can see and do in MTV
* Discussing permission set options for non-admins 

Previews: 
1. https://file.emea.redhat.com/rhoch/non_admin/html-single/#admins-and-non-admins [Section 4.1 and 4.1.1]
2. https://file.emea.redhat.com/rhoch/non_admin/html-single/#non-admin-permissions_cli  [Section 5.1] 