### PR TITLE
Minor changes to CLI documentation

### DIFF
--- a/documentation/modules/canceling-migration-cli.adoc
+++ b/documentation/modules/canceling-migration-cli.adoc
@@ -14,7 +14,7 @@ You can cancel an entire migration or individual virtual machines (VMs) while a 
 +
 [source,terminal,subs="attributes+"]
 ----
-$ {oc} delete migration <migration> -n {namespace} <1>
+$ {oc} delete migration <migration> -n <namespace> <1>
 ----
 <1> Specify the name of the `Migration` CR.
 
@@ -29,7 +29,7 @@ apiVersion: forklift.konveyor.io/v1beta1
 kind: Migration
 metadata:
   name: <migration>
-  namespace: {namespace}
+  namespace: <namespace>
 ...
 spec:
   cancel:
@@ -46,5 +46,5 @@ The value of the `id` key is the _managed object reference_, for a VMware VM, or
 +
 [source,terminal,subs="attributes+"]
 ----
-$ {oc} get migration/<migration> -n {namespace} -o yaml
+$ {oc} get migration/<migration> -n <namespace> -o yaml
 ----

--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -40,7 +40,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: <secret>
-  namespace: {namespace}
+  namespace: <namespace>
   ownerReferences: <1>
     - apiVersion: forklift.konveyor.io/v1beta1
       kind: Provider
@@ -97,8 +97,8 @@ $ cat << EOF | {oc} apply -f -
 apiVersion: forklift.konveyor.io/v1beta1
 kind: Provider
 metadata:
-  name: <provider>
-  namespace: {namespace}
+  name: <source_provider>
+  namespace: <namespace>
 spec:
   type: <provider_type> <1>
   url: <api_end_point> <2>
@@ -106,7 +106,7 @@ spec:
     vddkInitImage: <registry_route_or_server_path>/vddk:<tag> <3>
   secret:
     name: <secret> <4>
-    namespace: {namespace}
+    namespace: <namespace>
 EOF
 ----
 <1> Allowed values are `ovirt`, `vsphere`, and `openstack`.
@@ -123,10 +123,10 @@ apiVersion: forklift.konveyor.io/v1beta1
 kind: Host
 metadata:
   name: <vmware_host>
-  namespace: {namespace}
+  namespace: <namespace>
 spec:
   provider:
-    namespace: {namespace}
+    namespace: <namespace>
     name: <source_provider> <1>
   id: <source_host_mor> <2>
   ipAddress: <source_network_ip> <3>
@@ -145,12 +145,11 @@ apiVersion: forklift.konveyor.io/v1beta1
 kind: NetworkMap
 metadata:
   name: <network_map>
-  namespace: {namespace}
+  namespace: <namespace>
 spec:
   map:
     - destination:
-        name: <pod>
-        namespace: {namespace}
+        name: <network_name>
         type: pod <1>
       source: <2>
         id: <source_network_id> <3>
@@ -165,17 +164,17 @@ spec:
   provider:
     source:
       name: <source_provider>
-      namespace: {namespace}
+      namespace: <namespace>
     destination:
-      name: <destination_cluster>
-      namespace: {namespace}
+      name: <destination_provider>
+      namespace: <namespace>
 EOF
 ----
 <1> Allowed values are `pod` and `multus`.
 <2> You can use either the `id` _or_ the `name` parameter to specify the source network.
 <3> Specify the VMware network MOR, the {rhv-short} network UUID, or the {osp} network UUID.
 <4> Specify a network attachment definition for each additional {virt} network.
-<5> Specify the namespace of the {virt} network attachment definition.
+<5> Required only when `type` is `multus`. Specify the namespace of the {virt} network attachment definition.
 
 . Create a `StorageMap` manifest to map source and destination storage:
 +
@@ -186,7 +185,7 @@ apiVersion: forklift.konveyor.io/v1beta1
 kind: StorageMap
 metadata:
   name: <storage_map>
-  namespace: {namespace}
+  namespace: <namespace>
 spec:
   map:
     - destination:
@@ -202,10 +201,10 @@ spec:
   provider:
     source:
       name: <source_provider>
-      namespace: {namespace}
+      namespace: <namespace>
     destination:
-      name: <destination_cluster>
-      namespace: {namespace}
+      name: <destination_provider>
+      namespace: <namespace>
 EOF
 ----
 <1> Allowed values are `ReadWriteOnce` and `ReadWriteMany`.
@@ -220,7 +219,7 @@ apiVersion: forklift.konveyor.io/v1beta1
 kind: Hook
 metadata:
   name: <hook>
-  namespace: {namespace}
+  namespace: <namespace>
 spec:
   image: quay.io/konveyor/hook-runner <1>
   playbook: | <2>
@@ -243,31 +242,31 @@ apiVersion: forklift.konveyor.io/v1beta1
 kind: Plan
 metadata:
   name: <plan> <1>
-  namespace: {namespace}
+  namespace: <namespace>
 spec:
   warm: true <2>
   provider:
     source:
       name: <source_provider>
-      namespace: {namespace}
+      namespace: <namespace>
     destination:
-      name: <destination_cluster>
-      namespace: {namespace}
+      name: <destination_provider>
+      namespace: <namespace>
   map: <3>
     network: <4>
       name: <network_map> <5>
-      namespace: {namespace}
+      namespace: <namespace>
     storage: <6>
       name: <storage_map> <7>
-      namespace: {namespace}
-  targetNamespace: {namespace}
+      namespace: <namespace>
+  targetNamespace: <target_namespace>
   vms: <8>
     - id: <source_vm> <9>
     - name: <source_vm>
-      namespace: {namespace} <10>
+      namespace: <namespace> <10>
       hooks: <11>
         - hook:
-            namespace: {namespace}
+            namespace: <namespace>
             name: <hook> <12>
           step: <step> <13>
 EOF
@@ -296,11 +295,11 @@ apiVersion: forklift.konveyor.io/v1beta1
 kind: Migration
 metadata:
   name: <migration> <1>
-  namespace: {namespace}
+  namespace: <namespace>
 spec:
   plan:
     name: <plan> <2>
-    namespace: {namespace}
+    namespace: <namespace>
   cutover: <cutover_time> <3>
 EOF
 ----
@@ -314,5 +313,5 @@ You can associate multiple `Migration` CRs with a single `Plan` CR. If a migrati
 +
 [source,terminal,subs="attributes+"]
 ----
-$ {oc} get migration/<migration> -n {namespace} -o yaml
+$ {oc} get migration/<migration> -n <namespace> -o yaml
 ----


### PR DESCRIPTION
MTV 2.5

[No Jira] Changes:
1. Changes <provider> to <source_provider> in the `Provider` manifest description to be consistent with the rest of the manifests in the procedure.
2. Changes {namespace} to <namespace> in the procedure for migrating VMs via CLI so that user will insert the correct namespace instead of copy-pasting openshift-mtv automatically. 
3. The same for the procedure for canceling a migration via CLI.

Previews:
1 and 2: https://file.emea.redhat.com/rhoch/minor_cli/html-single/#migrating-virtual-machines-cli_mtv [Migration using CLI]
3: https://file.emea.redhat.com/rhoch/minor_cli/html-single/#canceling-migration-cli_mtv [canceling a migration]