### PR TITLE
25 fixes

### DIFF
--- a/documentation/modules/accessing-logs-ui.adoc
+++ b/documentation/modules/accessing-logs-ui.adoc
@@ -10,7 +10,7 @@ You can download logs and information about custom resources (CRs) for a complet
 
 .Procedure
 
-. In the web console, click *Migration plans*.
+. In the {ocp} web console, click *Migration* -> *Plans for virtualization*.
 . Click *Get logs* beside a migration plan name.
 . In the *Get logs* window, click *Get logs*.
 +

--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -125,7 +125,7 @@ ifdef::ostack[]
 . Click *OpenStack*.
 . Specify the following fields:
 
-* *Provider resource name*: Name of the source provider
+* *Provider resource name*: Name of the source provider.
 +
 include::snip-provider-names.adoc[]
 * *URL*: {osp} Identity (Keystone) endpoint, for example, `http://controller:5000/v3`.

--- a/documentation/modules/collected-logs-cr-info.adoc
+++ b/documentation/modules/collected-logs-cr-info.adoc
@@ -26,7 +26,7 @@ The `must-gather` tool collects the following logs and CR files in an archive fi
 ** `virt-launcher` pod: VM launcher log. When a migrated VM is powered on, the `virt-launcher` pod runs `QEMU-KVM` with the PVCs attached as VM disks.
 ** `forklift-controller` pod: The log is filtered for the migration plan, virtual machine, or namespace specified by the `must-gather` command.
 ** `forklift-must-gather-api` pod: The log is filtered for the migration plan, virtual machine, or namespace specified by the `must-gather` command.
-** `hook-job` pod: The log is filtered for hook jobs. The `hook-job` naming convention is`<migration_plan>-<vm_id><5_char_id>`, for example, `plan2j-vm-3696-posthook-4mx85` or `plan2j-vm-3696-prehook-mwqnl`.
+** `hook-job` pod: The log is filtered for hook jobs. The `hook-job` naming convention is `<migration_plan>-<vm_id><5_char_id>`, for example, `plan2j-vm-3696-posthook-4mx85` or `plan2j-vm-3696-prehook-mwqnl`.
 +
 [NOTE]
 ====

--- a/documentation/modules/mtv-overview-page.adoc
+++ b/documentation/modules/mtv-overview-page.adoc
@@ -12,7 +12,7 @@ If you have Administrator privileges, you can access the *Overview* page by clic
 
 The *Overview* page displays the following information:
 
-* Migrations: The total number of migrations performed using {project-short}:
+* Migrations: The number of migrations performed using {project-short}:
 
 ** Total
 ** Running
@@ -20,7 +20,7 @@ The *Overview* page displays the following information:
 ** Succeeded
 ** Canceled
 
-* Virtual Machine Migrations:  The total number of VMs migrated using {project-short}:
+* Virtual Machine Migrations:  The number of VMs migrated using {project-short}:
 
 ** Total
 ** Running

--- a/documentation/modules/mtv-settings.adoc
+++ b/documentation/modules/mtv-settings.adoc
@@ -19,7 +19,7 @@ If you have Administrator privileges, you can access the *Overview* page and cha
 
 |Must gather cleanup after (hours)
 |The duration for retaining `must gather` reports before they are automatically deleted
-|Disabled.
+|Disabled
 
 |Controller main container CPU limit
 |The CPU limit allocated to the main controller container

--- a/documentation/modules/non-admin-permissions-for-ui.adoc
+++ b/documentation/modules/non-admin-permissions-for-ui.adoc
@@ -24,7 +24,7 @@ For example, administrators can assign non-administrators one or more of the fol
 | All `edit` privileges and the ability to delete the entire collection of migration plans
 |===
 
-Note that pre-defined cluster roles include a resource (`plans`), an API group (`forklift.konveyor.io-v1beta1`) and an action (for example, `view`, `edit`).
+Note that pre-defined cluster roles include a resource (for example, `plans`), an API group (for example, `forklift.konveyor.io-v1beta1`) and an action (for example, `view`, `edit`).
 
 As a more comprehensive example, you can grant non-administrators the following set of permissions per namespace:
 

--- a/documentation/modules/rn-2.5.adoc
+++ b/documentation/modules/rn-2.5.adoc
@@ -26,11 +26,11 @@ In this version, migration using OpenStack source providers graduated from a Tec
 
 .Disabling FIPS
 
-EMS enforcement is disabled for migrations with VMware vSphere source providers in order to enable migrations from versions of vSphere that are supported by {project-full} but do not comply with the 2023 FIPS requirements.
+EMS enforcement is disabled for migrations with VMware vSphere source providers to enable migrations from versions of vSphere that are supported by {project-full} but do not comply with the 2023 FIPS requirements.
 
-.Integration of the create/update provider dialog
+.Integration of the create and update provider user interface
 
-Reworked the forms of create and update providers so that they will align with the typical look and feel within the OCP console and ensure the up-to-date data is displayed.
+The user interface of create and update providers now aligns with the look and feel of the {ocp} web console and displays up-to-date data.
 
 .Standalone UI
 
@@ -41,29 +41,36 @@ The old UI of MTV 2.3 cannot be enabled by setting `feature_ui: true` in Forklif
 
 This release has the following features and improvements:
 
-.Migration using OVA files that are compatible with VMware vSphere
+.Migration using OVA files created by VMware vSphere
 
 // i need to wait for this ticket to be merged to add a link
-In {project-short} {project-version}, you can migrate using Open Virtual Application (OVA) files that were created by VMware vSphere as source providers. It may also work with OVAs that are created by other systems and compatible with vSphere. link:https://issues.redhat.com/browse/MTV-336[MTV-336]
+In {project-short} {project-version}, you can migrate using Open Virtual Appliance (OVA) files that were created by VMware vSphere as source providers. link:https://issues.redhat.com/browse/MTV-336[(MTV-336)]
 
-.Migrating VMs between OCP clusters
+[NOTE]
+====
+Migration of OVA files that were not created by VMware vSphere but are compatible with vSphere might succeed. However, migration of such files is not supported by {project-short}. {project-short} supports only OVA files created by VMware vSphere.
+====
+
+include::snippet_ova_tech_preview.adoc[]
+
+.Migrating VMs between {ocp} clusters
 
 // i need to wait for this ticket to be merged to add a link
 // apologies, I meant link to output of the doc ticket rather than https://issues.redhat.com/browse/MTV-336[Import VMware-compatible OVAs]
 // But let me add this as a placeholder
-In {project-short} {project-version}, you can also use Red Hat {virt} provider as a source provider. You can migrate VMs from the cluster that MTV is deployed on to another cluster, or from a remote cluster to the cluster that {project-short} is deployed on. link:https://issues.redhat.com/browse/MTV-571[MTV-571]
+In {project-short} {project-version}, you can now use Red Hat {virt} provider as a source provider as well as a destination provider. You can migrate VMs from the cluster that MTV is deployed on to another cluster, or from a remote cluster to the cluster that {project-short} is deployed on. link:https://issues.redhat.com/browse/MTV-571[(MTV-571)]
 
 .Migration of VMs with direct LUNs from RHV
 
-During the migration from RHV, direct LUNs are detached from the source virtual machines and attached to the target virtual machines. Note that this mechanism does not work yet for Fibre Channel. link:https://issues.redhat.com/browse/MTV-329[MTV-329]
+During the migration from RHV, direct LUNs are detached from the source virtual machines and attached to the target virtual machines. Note that this mechanism does not work yet for Fibre Channel. link:https://issues.redhat.com/browse/MTV-329[(MTV-329)]
 
 .Additional authentication methods for OpenStack
 
-In addition to the standard password authentication, the following authentication methods are supported: Token authentication and Application credential authentication. Workaround: The `regionName` property needs to be added manually to the provider secret when these new authentication methods are configured from the UI. link:https://issues.redhat.com/browse/MTV-539[MTV-539]
+In addition to standard password authentication, the following authentication methods are supported: Token authentication and Application credential authentication. Usage note: The `regionName` property needs to be added manually to the provider secret when these new authentication methods are configured from the UI. link:https://issues.redhat.com/browse/MTV-539[(MTV-539)]
 
 .Validation rules for OpenStack
 
-The validation service includes default validation rules for virtual machines from OpenStack. link:https://issues.redhat.com/browse/MTV-508[MTV-508]
+The validation service includes default validation rules for virtual machines from OpenStack. link:https://issues.redhat.com/browse/MTV-508[(MTV-508)]
 
 
 .VDDK is now optional for VMware vSphere providers
@@ -90,7 +97,7 @@ If deleting a migration plan and running a new migration plan with the same name
 
 .Migration of virtual machines with encrypted partitions fails during conversion
 
-vSphere only: Migrations from {rhv-short} and OpenStack don't fail, but the encryption key may be missing on the target OCP cluster.
+vSphere only: Migrations from {rhv-short} and OpenStack do not fail, but the encryption key may be missing on the target {ocp} cluster.
 
 //inclusive language - cannot use execute
 .Migration fails during precopy/cutover while a snapshot operation is performed on the source VM
@@ -98,72 +105,72 @@ vSphere only: Migrations from {rhv-short} and OpenStack don't fail, but the encr
 ////
 Some warm migrations from {rhv-short} might fail. When running a migration plan for warm migration of multiple VMs from {rhv-short}, the migrations of some VMs might fail during the cutover stage. In that case, restart the migration plan and set the cutover time for the VM migrations that failed in the first run.
 ////
-Warm migration from {rhv-short} fails if a snapshot operation is performed on the source VM. If the user performs a snapshot operation on the source VM at the time when a migration snapshot is scheduled, the migration fails instead of waiting for the user’s snapshot operation to finish. link:https://issues.redhat.com/browse/MTV-456[(MTV-456)]
+Warm migration from {rhv-short} fails if a snapshot operation is performed on the source VM. If a user performs a snapshot operation on the source VM at the time when a migration snapshot is scheduled, the migration fails instead of waiting for the user’s snapshot operation to finish. link:https://issues.redhat.com/browse/MTV-456[(MTV-456)]
 
 .Unable to schedule migrated VM with multiple disks to more than one storage classes of type hostPath
 
-When migrating a VM with multiple disks to more than one storage classes of type hostPath, it may result in a VM that cannot be scheduled. Workaround: It is recommended to use shared storage on the target OCP cluster.
+When migrating a VM with multiple disks to more than one storage classes of type `hostPath`, it might happen that a VM cannot be scheduled. Workaround: Use shared storage on the target {ocp} cluster.
 
 .Non-supported guest operating systems in warm migrations
 
-Warm migrations and migrations to remote OCP clusters from vSphere do not support all types of guest operating systems that are supported in cold migrations to the local OCP cluster. It is a consequence of using RHEL 8 in the former case and RHEL 9 in the latter case. +
+Warm migrations and migrations to remote {ocp} clusters from vSphere do not support all types of guest operating systems that are supported in cold migrations to the local {ocp} cluster. This is a consequence of using RHEL 8 in the former case and RHEL 9 in the latter case. +
 See link:https://access.redhat.com/articles/1351473[Converting virtual machines from other hypervisors to KVM with virt-v2v in RHEL 7, RHEL 8, and RHEL 9] for the list of supported guest operating systems.
 
 .VMs from vSphere with RHEL 9 guest operating system may start with network interfaces that are down
 
-When migrating VMs that are installed with RHEL 9 as guest operating system from vSphere, their network interfaces could be disabled when they start in {ocp-name} Virtualization. link:https://issues.redhat.com/browse/MTV-491[(MTV-491)]
+When migrating VMs that are installed with RHEL 9 as guest operating system from vSphere, the network interfaces of the VMs could be disabled when they start in {ocp-name} Virtualization. link:https://issues.redhat.com/browse/MTV-491[(MTV-491)]
 
 .Import OVA: ConnectionTestFailed message appears when adding OVA provider
 
-When adding an OVA provider, the error message `ConnectionTestFailed` may instantly appear, although the provider is created successfully. If after a few minutes, the message does not disappear and the provider status does not move to `ready` condition, the `ova server pod creation` has failed. link:https://issues.redhat.com/browse/MTV-671[MTV-671]
+When adding an OVA provider, the error message `ConnectionTestFailed` may instantly appear, although the provider is created successfully. If the message does not disappear after a few minutes and the provider status does not move to `Ready`, this means that the `ova server pod creation` has failed. link:https://issues.redhat.com/browse/MTV-671[(MTV-671)]
 
-.OVA migration with multiple disks is not functioning
+.OVA migration with multiple disks does not function as expected
 
-OVA migration with multiple disks is not functioning as expected. When trying to migrate an OVA VM, with more than one disk, the migration becomes stuck at the `allocate disks` phase. link:https://issues.redhat.com/browse/MTV-676[MTV-676]
+OVA migration with multiple disks does not function as expected. When trying to migrate an OVA VM with more than one disk, the migration becomes stuck at the `allocate disks` phase. link:https://issues.redhat.com/browse/MTV-676[(MTV-676)]
 
 For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/browse/MTV-562?filter=12419159[Known Issues] in Jira.
 
 [id="resolved-issues-25_{context}"]
 == Resolved issues
 
+This release has the following resolved issues:
+
 // are there any resolved issues you want to highlight in this release?
 .Ensure up-to-date data is displayed in the create and update provider forms
 
 In previous releases of {project-short}, the create and update provider forms could have presented stale data.
 
-This issue is resolved in {project-short} {project-version}, the new forms of create and update provider display up-to-date properties of the provider. link:https://issues.redhat.com/browse/MTV-603[MTV-603]
+This issue is resolved in {project-short} {project-version}, the new forms of create and update provider display up-to-date properties of the provider. link:https://issues.redhat.com/browse/MTV-603[(MTV-603)]
 
-.Snapshots that are created during the migration in OpenStack are not deleted
+.Snapshots that are created during a migration in OpenStack are not deleted
 
-In previous releases of {project-short}, the Migration Controller service did not delete snapshots that were created during the migration of source virtual machines in OpenStack automatically.
+In previous releases of {project-short}, the `Migration Controller` service did not delete snapshots that were created during a migration of source virtual machines in OpenStack automatically.
 
-This issue is resolved in {project-short} {project-version}, all the snapshots created during the migration are removed after the migration has been completed. link:https://issues.redhat.com/browse/MTV-620[MTV-620]
+This issue is resolved in {project-short} {project-version}, all the snapshots created during the migration are removed after the migration has been completed. link:https://issues.redhat.com/browse/MTV-620[(MTV-620)]
 
 .{rhv-short} snapshots are not deleted after a successful migration
 
-In previous releases of {project-short}, the Migration Controller service did not delete snapshots automatically after a successful warm migration of a VM from {rhv-short}.
+In previous releases of {project-short}, the `Migration Controller` service did not delete snapshots automatically after a successful warm migration of a VM from {rhv-short}.
 
 This issue is resolved in {project-short} {project-version}, the snapshots generated during migration are removed after a successful migration, and the original snapshots are not removed after a successful migration. link:https://issues.redhat.com/browse/MTV-349[(MTV-349)]
-
 
 .Warm migration fails when cutover conflicts with precopy
 
 In previous releases of {project-short}, the cutover operation failed when it was triggered while precopy was being performed. The VM was locked in {rhv-short} and therefore the `ovirt-engine` rejected the snapshot creation, or disk transfer, operation.
 
-This issue is resolved in {project-short} {project-version}, the cutover operation is triggered, but it is not performed that time because the VM is locked. Once the precopy operation completes, the cutover operation is triggered. link:https://issues.redhat.com/browse/MTV-686[MTV-686]
+This issue is resolved in {project-short} {project-version}, the cutover operation is triggered, but it is not performed at that time because the VM is locked. Once the precopy operation completes, the cutover operation is triggered. link:https://issues.redhat.com/browse/MTV-686[(MTV-686)]
 
 .Warm migration fails when VM is locked
 
-In previous release of {project-short}, when triggering warm migration while there was an ongoing operation in {rhv-short} that locked the VM. The migration failed because the snapshot creation could not be triggered.
+In previous releases of {project-short}, triggering a warm migration while there was an ongoing operation in {rhv-short} that locked the VM caused the migration to fail because the snapshot creation could not be triggered.
 
-This issue is resolved in {project-short} {project-version}, warm migration does not fail when an operation that locks the VM is performed in {rhv-short}. The migration does not fail, but starts when the VM is unlocked. link:https://issues.redhat.com/browse/MTV-687[MTV-687]
-
+This issue is resolved in {project-short} {project-version}, warm migration does not fail when an operation that locks the VM is performed in {rhv-short}. The migration does not fail, but starts when the VM is unlocked. link:https://issues.redhat.com/browse/MTV-687[(MTV-687)]
 
 .Deleting migrated VM does not remove PVC and PV
 
 In previous releases of {project-short}, when removing a VM that was migrated, its persistent volume claims (PVCs) and physical volumes (PV) were not deleted.
 
-This issue is resolved in {project-short} {project-version}, PVC and PV are deleted when deleting migrated VM.link:https://issues.redhat.com/browse/MTV-492[(MTV-492)]
+This issue is resolved in {project-short} {project-version}, PVCs and PVs are deleted when deleting migrated VM.link:https://issues.redhat.com/browse/MTV-492[(MTV-492)]
 
 .PVC deletion hangs after archiving and deleting migration plan
 
@@ -173,12 +180,11 @@ This issue is resolved in {project-short} {project-version}, PVCs are deleted wh
 
 .VM with multiple disks may boot from non-bootable disk after migration
 
-In previous releases of {project-short}, VM with multiple disks that were migrated might not have been able to boot on the target OCP cluster.
+In previous releases of {project-short}, VM with multiple disks that were migrated might not have been able to boot on the target {ocp} cluster.
 
-This issue is resolved in {project-short} {project-version}, VM with multiple disks that are migrated are able to boot on the target OCP cluster. link:https://issues.redhat.com/browse/MTV-433[(MTV-433)]
+This issue is resolved in {project-short} {project-version}, VM with multiple disks that are migrated are able to boot on the target {ocp} cluster. link:https://issues.redhat.com/browse/MTV-433[(MTV-433)]
 
 For a complete list of all resolved issues in this release, see the list of link:https://issues.redhat.com/browse/MTV-433?filter=12419160[Resolved Issues] in Jira.
-This release has the following resolved issues:
 
 [id="upgrade-notes-25_{context}"]
 == Upgrade notes
@@ -188,15 +194,20 @@ It is recommended to upgrade from {project-short} 2.4.2 to {project-short} {proj
 
 .Upgrade from 2.4.0 fails
 
-When upgrading from MTV 2.4.0 to a later version, the operation fails with an error that says the field 'spec.selector' of deployment `forklift-controller` is immutable. Workaround: remove the custom resource `forklift-controller` of type `ForkliftController` from the installed namespace, and recreate it. The user needs to refresh the OCP Console once the `forklift-console-plugin` pod runs to load the upgraded {project-short} web console. link:https://issues.redhat.com/browse/MTV-518[(MTV-518)]
+When upgrading from MTV 2.4.0 to a later version, the operation fails with an error that says the field 'spec.selector' of deployment `forklift-controller` is immutable. Workaround: Remove the custom resource `forklift-controller` of type `ForkliftController` from the installed namespace, and recreate it. Refresh the {ocp} console once the `forklift-console-plugin` pod runs to load the upgraded {project-short} web console. link:https://issues.redhat.com/browse/MTV-518[(MTV-518)]
 
 [NOTE]
 ====
 There is an issue with upgrading from 2.4.1 or 2.4.2.
-When upgrading from 2.4 (2.4.z), after the 2.5 operator starts, the `mutatingwebhookconfiguration` and `validatingwebhookconfiguration` named `forklift-api` should be removed:
+When upgrading from 2.4 (2.4.z), after the 2.5 operator starts
 
-* `oc -n openshift-mtv delete mutatingwebhookconfiguration forklift-api`
-* `oc -n openshift-mtv delete validatingwebhookconfiguration forklift-api`
+. Remove the `mutatingwebhookconfiguration` named `forklift-api` by running the following command:
++
+`$ oc -n openshift-mtv delete mutatingwebhookconfiguration forklift-api`
 
-And restart the {project-short} operator.
+. Remove the `validatingwebhookconfiguration` named `forklift-api` by running the following command:
++
+`$ oc -n openshift-mtv delete validatingwebhookconfiguration forklift-api`
+
+. Restart the {project-short} operator.
 ====


### PR DESCRIPTION
MTV 2.5

Resolves https://issues.redhat.com/browse/MTV-706 by making a number of small changes to the MTV 2.5 user guide and release notes.

Previews:

1. https://file.emea.redhat.com/rhoch/compat/html-single/#mtv-overview-page_mtv [The redundant word "total" removed from the descriptions of "Migrations" and "Virtual Machine Migrations"
2. https://file.emea.redhat.com/rhoch/compat/html-single/#mtv-settings_mtv [Removed the period after the word "Disabled" in the table]
3. https://file.emea.redhat.com/rhoch/compat/html-single/#non-admin-permissions_cli [Clarified that all elements of Table 5.1 are examples, not only the actions]
4. https://file.emea.redhat.com/rhoch/compat/html-single/#collected-logs-cr-info_mtv [Fixed the formatting in the entry for `hook-job`]
5. https://file.emea.redhat.com/rhoch/compat/html-single/#accessing-logs-ui_mtv [Updated step 1 of the procedure]
6. https://file.emea.redhat.com/rhoch/25_fixes/html-single/#rn-2.5_release-notes [Release notes]
