### PR TITLE
Align description of provider properties with the UI

### DIFF
--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -78,9 +78,9 @@ ifdef::vmware[]
 . Specify the following fields:
 
 * *Provider resource name*: Name of the source provider.
-* *URL*: vCenter host name or IP address - if a certificate for FQDN is specified, the value of this field needs to match the FQDN in the certificate.
+* *URL*: URL of the SDK endpoint of the vCenter on which the source VM is mounted. Ensure that the URL includes the `sdk` path, usually `/sdk`. For example, `https://vCenter-host-example.com/sdk`. If a certificate for FQDN is specified, the value of this field needs to match the FQDN in the certificate.
 * *VDDK init image*: `VDDKInitImage` path. It is strongly recommended to create a VDDK init image to accelerate migrations. For more information, see xref:../master.adoc#creating-vddk-image_mtv[Creating a VDDK image].
-* *Username*: vCenter user, for example, `user@vsphere.local`.
+* *Username*: vCenter user. For example, `user@vsphere.local`.
 * *Password*: vCenter user password.
 * *SHA-1 fingerprint*: The provider currently requires the SHA-1 fingerprint of the vCenter Server's TLS certificate in all circumstances. vSphere calls this the server's thumbprint.
 +
@@ -97,12 +97,10 @@ ifdef::rhv[]
 . Click *Red Hat Virtualization*
 . Specify the following fields:
 
-* *Provider resource name*: Name of the source provider
-+
-include::snip-provider-names.adoc[]
-* *URL*: API endpoint of the {rhv-short} Manager on which the source VM is mounted
-* *Username*: Username
-* *Password*: Password
+* *Provider resource name*: Name of the source provider.
+* *URL*: URL of the API endpoint of the {rhv-full} Manager (RHVM) on which the source VM is mounted. Ensure that the URL includes the path leading to the RHVM API server, usually `/ovirt-engine/api`. For example, `https://rhv-host-example.com/ovirt-engine/api`.
+* *Username*: Username.
+* *Password*: Password.
 
 . Choose one of the following options for validating CA certificates:
 
@@ -117,8 +115,6 @@ ifdef::ova[]
 . Specify the following fields:
 
 * *Provider resource name*: Name of the source provider
-+
-include::snip-provider-names.adoc[]
 * *URL*: URL of the NFS file share that serves the OVA
 endif::[]
 ifdef::ostack[]
@@ -126,9 +122,7 @@ ifdef::ostack[]
 . Specify the following fields:
 
 * *Provider resource name*: Name of the source provider.
-+
-include::snip-provider-names.adoc[]
-* *URL*: {osp} Identity (Keystone) endpoint, for example, `http://controller:5000/v3`.
+* *URL*: URL of the {osp} Identity (Keystone) endpoint. For example, `http://controller:5000/v3`.
 * *Authentication type*: Choose one of the following methods of authentication and supply the information related to your choice. For example, if you choose *Application credential ID* as the authentication type, the *Application credential ID* and the *Application credential secret* fields become active, and you need to supply the ID and the secret.
 
 ** *Application credential ID*
@@ -171,9 +165,7 @@ ifdef::cnv[]
 . Specify the following fields:
 
 * *Provider resource name*: Name of the source provider
-+
-include::snip-provider-names.adoc[]
-* *URL*: Endpoint of the API server
+* *URL*: URL of the endpoint of the API server
 * *Service account bearer token*: Token for a service account with `cluster-admin` privileges
 +
 If both *URL* and *Service account bearer token* are left blank, the local {ocp-short} cluster is used.
@@ -183,9 +175,7 @@ ifdef::cnv2[]
 . Specify the following fields:
 
 * *Provider resource name*: Name of the source provider
-+
-include::snip-provider-names.adoc[]
-* *URL*: Endpoint of the API server
+* *URL*: URL of the endpoint of the API server
 * *Service account bearer token*: Token for a service account with `cluster-admin` privileges
 +
 If both *URL* and *Service account bearer token* are left blank, the local {ocp-short} cluster is used.

--- a/documentation/modules/creating-validation-rule.adoc
+++ b/documentation/modules/creating-validation-rule.adoc
@@ -121,7 +121,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `ovirt`, `vsphere`, and `openstack`.
-<2> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere, `https://<engine_host>/ovirt-engine/api/` for {rhv-short}, or `https://<identity_service>/v3` for {osp}.
+<2> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere, `https://<engine_host>/ovirt-engine/api` for {rhv-short}, or `https://<identity_service>/v3` for {osp}.
 <3> Specify the name of the provider `Secret` CR.
 
 You must update the rules version after creating a custom rule so that the `Inventory` service detects the changes and validates the VMs.

--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -73,7 +73,7 @@ EOF
 <8> {osp} only: Specify the project name.
 <9> {osp} only: Specify the name of the {osp} region.
 <10> {rhv-short} and {osp} only: For {rhv-short}, enter the {manager} CA certificate unless it was replaced by a third-party certificate, in which case enter the {manager} Apache CA certificate. You can retrieve the {manager} CA certificate at https://<engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA. For {osp}, enter the CA certificate for connecting to the source environment. The certificate is not used when `insecureSkipVerify` is set to `<true>`.
-<11> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere, `https://<engine_host>/ovirt-engine/api/` for {rhv-short}, or `https://<identity_service>/v3` for {osp}.
+<11> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere, `https://<engine_host>/ovirt-engine/api` for {rhv-short}, or `https://<identity_service>/v3` for {osp}.
 <12> VMware only: Specify the vCenter SHA-1 fingerprint.
 +
 [NOTE]
@@ -110,7 +110,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `ovirt`, `vsphere`, and `openstack`.
-<2> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere, `https://<engine_host>/ovirt-engine/api/` for {rhv-short}, or `https://<identity_service>/v3` for {osp}.
+<2> Specify the API end point URL, for example, `https://<vCenter_host>/sdk` for vSphere, `https://<engine_host>/ovirt-engine/api` for {rhv-short}, or `https://<identity_service>/v3` for {osp}.
 <3> VMware only: Specify the VDDK image that you created.
 <4> Specify the name of provider `Secret` CR.
 

--- a/documentation/modules/snip-provider-names.adoc
+++ b/documentation/modules/snip-provider-names.adoc
@@ -1,7 +1,0 @@
-:_content-type: SNIPPET
-
-[NOTE]
-====
-Provider names must start with an alphabetic character and cannot include the following character: +
-`.`
-====


### PR DESCRIPTION
MTV 2.5.1

Resolves: https://issues.redhat.com/browse/MTV-717 and https://issues.redhat.com/browse/MTV-703 by:
1. Changing the description of the URL field for vSphere source providers.
2. Changing the description of the URL field for RHV source providers.
3. Removing note that said provider names cannot include "."
4-6: Removing an inconsistent "/" in some URLs. 

Previews:
1. https://file.emea.redhat.com/rhoch/251_provider_fixes/html-single/#adding-source-providers [See definitions of "URL"  for vSphere and RHV source providers; also see that note about provider names was removed]
2. https://file.emea.redhat.com/rhoch/251_provider_fixes/html-single/#migrating-virtual-machines-cli_mtv [Step 1, callout 11 and steep 2, callout 2] 
3. https://file.emea.redhat.com/rhoch/251_provider_fixes/html-single/#migrating-virtual-machines-cli_mtv [step 6, callout 2]
