### PR TITLE
MTV-788: Updating Z-stream attributes for 2.5.2

### DIFF
--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -17,7 +17,7 @@
 :project-short: MTV
 :project-first: {project-full} ({project-short})
 :project-version: 2.5
-:project-z-version: 2.5.1
+:project-z-version: 2.5.2
 :the: The
 :the-lc: the
 :virt: OpenShift Virtualization


### PR DESCRIPTION
### Jira

* [MTV-788](https://issues.redhat.com/browse/MTV-788)

Updating Z-Stream attribute to 2.5.2:

```
:project-z-version: 2.5.2
```

Please note, I cannot use this in the release notes for MTV 2.5.2, as I need to keep the version static.