### PR TITLE
MTV-790: Updating Z-Stream attributes for 2.4 to 2.4.3

### DIFF
--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -17,7 +17,7 @@
 :project-short: MTV
 :project-first: {project-full} ({project-short})
 :project-version: 2.4
-:project-z-version: 2.4.2
+:project-z-version: 2.4.3
 :the: The
 :the-lc: the
 :virt: OpenShift Virtualization


### PR DESCRIPTION
## Jira

* [MTV-790](https://issues.redhat.com/browse/MTV-790)

Updating 2.4 Z stream attributes to 2.4.3

```
:project-z-version: 2.4.3
```