### PR TITLE
Configurable filesystem overhead

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -83,11 +83,13 @@ include::modules/ova-prerequisites.adoc[leveloffset=+2]
 include::modules/compatibility-guidelines.adoc[leveloffset=+2]
 
 [id="installing-the-operator"]
-== Installing the {operator-name}
+== Installing and configuring the {operator-name}
 
 You can install the {operator-name} by using the {ocp} web console or the command line interface (CLI).
 
 In {project-first} version 2.4 and later, the {operator-name} includes the {project-short} plugin for the {ocp} web console.
+
+After you install the {operator-name} by using either the {ocp} web console or the CLI, you can configure the Operator.
 
 :!mtv:
 :context: web
@@ -101,6 +103,8 @@ include::modules/installing-mtv-operator.adoc[leveloffset=+2]
 :!cli:
 :context: mtv
 :mtv:
+
+include::modules/configuring-mtv-operator.adoc[leveloffset=+2]
 
 [id="migrating-vms-web-console"]
 == Migrating virtual machines by using the {ocp} web console

--- a/documentation/modules/configuring-mtv-operator.adoc
+++ b/documentation/modules/configuring-mtv-operator.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+
+:_content-type: PROCEDURE
+[id="configuring-mtv-operator_{context}"]
+= Configuring the {operator-name}
+
+You can configure the following settings of the {operator-name} using either the CLI or the user interface.
+
+* Maximum number of virtual machines (VMs) per plan that can be migrated simultaneously
+* How long `must gather` reports are retained before being automatically deleted
+* CPU limit allocated to the main controller container
+* Memory limit allocated to the main controller container
+* Interval at which a new snapshot is requested before initiating a warm migration
+* Frequency with which the system checks the status of snapshot creation or removal during a warm migration
+* Percentage of space in persistent volumes allocated as file system overhead when the `storageclass` is `filesystem` (CLI only)
+
+These settings are configured by changing the default of the appropriate parameter in the `spec` part of the `forklift-controller` CR.
+
+The procedure for configuring these settings using the user interface is presented in xref:mtv-overview-page_{context}[Configuring MTV settings]. The procedure for configuring these settings using the CLI is presented following.
+
+.Procedure
+
+* Change a parameter's value in  the `spec` portion of the `forklift-controller` CR by adding the label and value as follows:
+[source, YAML]
+----
+spec:
+  label: value <1>
+----
+<1> Labels you can configure using the CLI are shown in the table that follows, along with a description of each label and its default value.
+
+.{operator-name} labels
+[cols="1,1,1",options="header"]
+|===
+|Label |Description |Default value
+
+|`controller_max_vm_in_flight`
+|The maximum number of VMs per plan that can be migrated simultaneously.
+|`20`
+
+|`must_gather_api_cleanup_max_age`
+|The duration in hours for retaining `must gather` reports before they are automatically deleted.
+|`-1` (disabled)
+
+|`controller_container_limits_cpu`
+|The CPU limit allocated to the main controller container.
+|`500m`
+
+|`controller_container_limits_memory`
+|The memory limit allocated to the main controller container.
+|`800Mi`
+
+|`controller_precopy_interval`
+|The interval in minutes at which a new snapshot is requested before initiating a warm migration.
+|`60`
+
+|`controller_snapshot_status_check_rate_seconds`
+|The frequency in seconds with which the system checks the status of snapshot creation or removal during a warm migration.
+|`10`
+
+|`controller_filesystem_overhead`
+|Percentage of space in persistent volumes allocated as file system overhead when the `storageclass` is `filesystem`. Note, this label can only be changed using the CLI
+|`10`
+|===
+
+

--- a/documentation/modules/mtv-settings.adoc
+++ b/documentation/modules/mtv-settings.adoc
@@ -34,7 +34,7 @@ If you have Administrator privileges, you can access the *Overview* page and cha
 |60
 
 |Snapshot polling interval (seconds)
-|The frequency with which the system checks the status of snapshot creation or removal during warm migration
+|The frequency with which the system checks the status of snapshot creation or removal during a warm migration
 |10
 |===
 

--- a/documentation/modules/storage-support.adoc
+++ b/documentation/modules/storage-support.adoc
@@ -8,26 +8,6 @@
 
 {project-short} uses the following default volume and access modes for supported storage.
 
-[NOTE]
-====
-If the {virt} storage does not support link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/storage/dynamic-provisioning[dynamic provisioning], you must apply the following settings:
-
-* `Filesystem` volume mode
-+
-`Filesystem` volume mode is slower than `Block` volume mode.
-* `ReadWriteOnce` access mode
-+
-`ReadWriteOnce` access mode does not support live virtual machine migration.
-
-See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/virtualization/virtual-machines#virt-customizing-storage-profile_virt-creating-data-volumes[Enabling a statically-provisioned storage class] for details on editing the storage profile.
-====
-
-[NOTE]
-====
-If your migration uses block storage and persistent volumes created with an EXT4 file system, increase the file system overhead in CDI to be more than 10%. The default overhead that is assumed by CDI does not completely include the reserved place for the root partition. If you do not increase the file system overhead in CDI by this amount, your migration might fail.
-====
-
-
 .Default volume and access modes
 [cols="1,1,1", options="header"]
 |===
@@ -77,3 +57,33 @@ If your migration uses block storage and persistent volumes created with an EXT4
 |Block
 |ReadWriteOnce
 |===
+
+[NOTE]
+====
+If the {virt} storage does not support link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/storage/dynamic-provisioning[dynamic provisioning], you must apply the following settings:
+
+* `Filesystem` volume mode
++
+`Filesystem` volume mode is slower than `Block` volume mode.
+* `ReadWriteOnce` access mode
++
+`ReadWriteOnce` access mode does not support live virtual machine migration.
+
+See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/virtualization/virtual-machines#virt-customizing-storage-profile_virt-creating-data-volumes[Enabling a statically-provisioned storage class] for details on editing the storage profile.
+====
+
+[NOTE]
+====
+If your migration uses block storage and persistent volumes created with an EXT4 file system, increase the file system overhead in CDI to be more than 10%. The default overhead that is assumed by CDI does not completely include the reserved place for the root partition. If you do not increase the file system overhead in CDI by this amount, your migration might fail.
+====
+
+[NOTE]
+====
+When migrating from OpenStack or running a cold-migration from RHV to the OCP cluster that MTV is deployed on, the migration allocates persistent volumes without CDI. In these cases, you might need to adjust the file system overhead.
+
+If the configured file system overhead, which has a default value of 10%, is too low, the disk transfer will fail due to lack of space. In such a case, you would want to increase to increase the file system overhead.
+
+In some cases, however, you might want to decrease the file system overhead to reduce storage consumption.
+
+You can change the file system overhead by changing the value of the `controller_filesystem_overhead` in the `spec` portion of the `forklift-controller` CR, as described in xref:configuring-mtv-operator_{context}[Configuring the MTV Operator].
+====


### PR DESCRIPTION
MTV 2.5.3

Resolves https://issues.redhat.com/browse/MTV-810 by adding a note describing how filesystem overhead can be configured for a migration that allocates persistent volumes without CDI and whose  `storageclass` is `filesystem`.

Added scope (after comment by Arik and Liran, and clarifications with Arik): Added a new section, "Configuring the MTV Operator" to Chapter 3, which is now called "Installing and configuring the MTV Operator" 

Previews: 
1. https://file.emea.redhat.com/rhoch/overhead_config/html-single/#about-storage_mtv [third note -- notice I moved all the notes to follow the table]
2. https://file.emea.redhat.com/rhoch/overhead_config/html-single/#installing-the-operator [new introduction to Chapter 3]
3. https://file.emea.redhat.com/rhoch/overhead_config/html-single/#configuring-mtv-operator_mtv [new section]