### PR TITLE
MTV-809: OCP to OCP migrations require a minimum cluster version of 4.13

### DIFF
--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -52,6 +52,11 @@ Specifically, the host cluster that is automatically added as a {virt} provider 
 
 You can migrate VMs from the cluster that {project-short} is deployed on to another cluster, or from a remote cluster to the cluster that {project-short} is deployed on.
 
+[NOTE]
+====
+The {ocp} cluster version of the source provider must be 4.13 or later.
+====
+
 endif::[]
 ifdef::cnv2[]
 = Adding {a-virt} destination provider


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTV-809
MTV 2.6.0
Preview: