### PR TITLE
Separate CLI migration procedure per source provider

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -18,7 +18,7 @@ ifeval::["{build}" == "downstream"]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 endif::[]
 :_content-type: ASSEMBLY
-[id="about-mtv"]
+[id="about-mtv_{context}"]
 == About {the-lc} {project-full}
 
 You can use {the-lc} {project-first} to migrate virtual machines from the following source providers to {virt} destination providers:
@@ -28,8 +28,6 @@ You can use {the-lc} {project-first} to migrate virtual machines from the follow
 * {osp}
 * Open Virtual Appliances (OVAs) that were created by VMware vSphere
 * Remote {virt} clusters
-
-include::modules/snippet_ova_tech_preview.adoc[]
 
 [NOTE]
 ====
@@ -43,12 +41,12 @@ Migration using {osp} source providers only supports VMs that use only Cinder vo
 
 include::modules/about-cold-warm-migration.adoc[leveloffset=+2]
 
-[id="prerequisites"]
+[id="prerequisites_{context}"]
 == Prerequisites
 
 Review the following prerequisites to ensure that your environment is prepared for migration.
 
-[id="software-requirements"]
+[id="software-requirements_{context}"]
 === Software requirements
 
 You must install xref:compatibility-guidelines_{context}[compatible versions] of {ocp} and {virt}.
@@ -59,6 +57,7 @@ include::modules/source-vm-prerequisites.adoc[leveloffset=+2]
 include::modules/rhv-prerequisites.adoc[leveloffset=+2]
 include::modules/openstack-prerequisites.adoc[leveloffset=+2]
 
+[id="additional-authentication-for-osp_{context}"]
 ==== Additional authentication methods for migrations with {osp} source providers
 
 {project-short} versions 2.6 and later support the following authentication methods for migrations with {osp} source providers in addition to the standard username and password credential set:
@@ -68,21 +67,31 @@ include::modules/openstack-prerequisites.adoc[leveloffset=+2]
 
 You can use these methods to migrate virtual machines with {osp} source providers using the CLI the same way you migrate other virtual machines, except for how you prepare the `Secret` manifest.
 
+:!mtv:
+:context: ostack
+:ostack:
+
 include::modules/ostack-token-auth.adoc[leveloffset=+4]
 include::modules/ostack-app-cred-auth.adoc[leveloffset=+4]
 
+:!ostack:
+:context: mtv
+:mtv:
+
 include::modules/vmware-prerequisites.adoc[leveloffset=+2]
 include::modules/creating-vddk-image.adoc[leveloffset=+3]
+:!mtv:
 :context: prereqs
 :prereqs:
 include::modules/obtaining-vmware-fingerprint.adoc[leveloffset=+3]
+:!prereqs:
 :context: mtv
 :mtv:
 include::modules/increasing-nfc-memory-vmware-host.adoc[leveloffset=+3]
 include::modules/ova-prerequisites.adoc[leveloffset=+2]
 include::modules/compatibility-guidelines.adoc[leveloffset=+2]
 
-[id="installing-the-operator"]
+[id="installing-the-operator_{context}"]
 == Installing and configuring the {operator-name}
 
 You can install the {operator-name} by using the {ocp} web console or the command line interface (CLI).
@@ -106,14 +115,14 @@ include::modules/installing-mtv-operator.adoc[leveloffset=+2]
 
 include::modules/configuring-mtv-operator.adoc[leveloffset=+2]
 
-[id="migrating-vms-web-console"]
+[id="migrating-vms-web-console_{context}"]
 == Migrating virtual machines by using the {ocp} web console
 
 You can migrate virtual machines (VMs) to {virt} by using the {ocp} web console.
 
 [IMPORTANT]
 ====
-You must ensure that all xref:prerequisites[prerequisites] are met.
+You must ensure that all xref:prerequisites_{context}[prerequisites] are met.
 
 VMware only: You must have the minimal set of xref:vmware-privileges_{context}[VMware privileges].
 
@@ -124,12 +133,12 @@ include::modules/mtv-ui.adoc[leveloffset=+2]
 include::modules/mtv-overview-page.adoc[leveloffset=+2]
 include::modules/mtv-settings.adoc[leveloffset=+2]
 
-[id="adding-providers"]
+[id="adding-providers_{context}"]
 === Adding providers
 
 You can add source providers and destination providers for a virtual machine migration by using the {ocp} web console.
 
-[id="adding-source-providers"]
+[id="adding-source-providers_{context}"]
 ==== Adding source providers
 
 You can use {project-short} to migrate VMs from the following source providers:
@@ -142,34 +151,33 @@ You can use {project-short} to migrate VMs from the following source providers:
 
 You can add a source provider by using the {ocp} web console.
 
-:mtv!:
+:!mtv:
 :context: vmware
 :vmware:
 include::modules/adding-source-provider.adoc[leveloffset=+4]
-:vmware!:
+:!vmware:
 :context: rhv
 :rhv:
 include::modules/adding-source-provider.adoc[leveloffset=+4]
-:rhv!:
+:!rhv:
 :context: ostack
 :ostack:
 include::modules/adding-source-provider.adoc[leveloffset=+4]
-:ostack!:
+:!ostack:
 :context: ova
-
 :ova:
 include::modules/adding-source-provider.adoc[leveloffset=+4]
-:ova!:
+:!ova:
 :context: cnv
 :cnv:
 include::modules/adding-source-provider.adoc[leveloffset=+4]
 :cnv!:
 :context: mtv
 
-[id="adding-destination-providers"]
+[id="adding-destination-providers_{context}"]
 ==== Adding destination providers
 
-You can add  a {virt} destination provider by using the {ocp} web console.
+You can add a {virt} destination provider by using the {ocp} web console.
 
 :mtv!:
 :context: cnv2
@@ -187,20 +195,14 @@ include::modules/running-migration-plan.adoc[leveloffset=+2]
 include::modules/migration-plan-options-ui.adoc[leveloffset=+2]
 include::modules/canceling-migration-ui.adoc[leveloffset=+2]
 
-[id="migrating-virtual-machines-from-cli"]
+[id="migrating-virtual-machines-from-the-command-line_{context}"]
 == Migrating virtual machines from the command line
 
 You can migrate virtual machines to {virt} from the command line.
 
 [IMPORTANT]
 ====
-*  VMware only: You must have the minimal set of xref:vmware-privileges_{context}[VMware privileges].
-
-*  VMware only: You must have the xref:obtaining-vmware-fingerprint_{context}[vCenter SHA-1 fingerprint].
-
-*  VMware only:  Creating a xref:creating-vddk-image_{context}[VMware Virtual Disk Development Kit (VDDK)] image will increase migration speed.
-
-*  You must ensure that all xref:prerequisites[prerequisites] are met.
+You must ensure that all xref:prerequisites_{context}[prerequisites] are met.
 ====
 
 :mtv!:
@@ -209,18 +211,50 @@ include::modules/non-admin-permissions-for-ui.adoc[leveloffset=+2]
 :cli!:
 :context: mtv
 
-include::modules/migrating-virtual-machines-cli.adoc[leveloffset=+2]
-include::modules/obtaining-vmware-fingerprint.adoc[leveloffset=+2]
+[id="migrating-virtual-machines_{context}"]
+=== Migrating virtual machines
 
+You migrate virtual machines (VMs) from the command line (CLI) by creating {project-short} custom resources (CRs). The CRs and the migration procedure vary by source provider.
+
+[IMPORTANT]
+====
+You must specify a name for cluster-scoped CRs.
+
+You must specify both a name and a namespace for namespace-scoped CRs.
+====
+
+:mtv!:
+:context: vmware
+:vmware:
+include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
+:vmware!:
+:context: rhv
+:rhv:
+include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
+:rhv!:
+:context: ova
+:ova:
+include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
+:ova!:
+:context: ostack
+:ostack:
+include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
+:ostack!:
+:context: cnv
+:cnv:
+include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
+:cnv!:
+:context: mtv
+:mtv:
 
 include::modules/canceling-migration-cli.adoc[leveloffset=+2]
 
-[id="advanced-migration-options"]
+[id="advanced-migration-options_{context}"]
 == Advanced migration options
 
 include::modules/changing-precopy-intervals.adoc[leveloffset=+2]
 
-[id="creating-custom-rules-for-validation-service"]
+[id="creating-custom-rules-for-validation-service_{context}"]
 === Creating custom rules for the Validation service
 
 The `Validation` service uses Open Policy Agent (OPA) policy rules to check the suitability of each virtual machine (VM) for migration. The `Validation` service generates a list of _concerns_ for each VM, which are stored in the `Provider Inventory` service as VM attributes. The web console displays the concerns for each VM in the provider inventory.
@@ -235,7 +269,7 @@ include::modules/updating-validation-rules-version.adoc[leveloffset=+3]
 
 include::modules/upgrading-mtv-ui.adoc[leveloffset=+1]
 
-[id="uninstalling-mtv"]
+[id="uninstalling-mtv_{context}"]
 == Uninstalling {the-lc} {project-full}
 
 You can uninstall {the-lc} {project-first} by using the {ocp} web console or the command line interface (CLI).
@@ -243,7 +277,7 @@ You can uninstall {the-lc} {project-first} by using the {ocp} web console or the
 include::modules/uninstalling-mtv-ui.adoc[leveloffset=+2]
 include::modules/uninstalling-mtv-cli.adoc[leveloffset=+2]
 
-[id="troubleshooting"]
+[id="troubleshooting_{context}"]
 == Troubleshooting
 
 This section provides information for troubleshooting common migration issues.
@@ -251,7 +285,7 @@ This section provides information for troubleshooting common migration issues.
 include::modules/error-messages.adoc[leveloffset=+2]
 include::modules/using-must-gather.adoc[leveloffset=+2]
 
-[id="architecture"]
+[id="architecture_{context}"]
 === Architecture
 
 This section describes {project-short} custom resources, services, and workflows.
@@ -260,7 +294,7 @@ include::modules/mtv-resources-and-services.adoc[leveloffset=+3]
 include::modules/mtv-workflow.adoc[leveloffset=+3]
 include::modules/virt-migration-workflow.adoc[leveloffset=+3]
 
-[id="logs-and-crs"]
+[id="logs-and-crs_{context}"]
 === Logs and custom resources
 
 You can download logs and custom resource (CR) information for troubleshooting. For more information, see the xref:virt-migration-workflow_{context}[detailed migration workflow].

--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -31,7 +31,6 @@ ifdef::ova[]
 
 You can add Open Virtual Appliance (OVA) files that were created by VMware vSphere as a source provider by using the {ocp} web console.
 
-include::snippet_ova_tech_preview.adoc[]
 endif::[]
 ifdef::ostack[]
 = Adding an {osp} source provider
@@ -42,6 +41,7 @@ You can add an {osp} source provider by using the {ocp} web console.
 ====
 Migration using {osp} source providers only supports VMs that use only Cinder volumes.
 ====
+
 endif::[]
 ifdef::cnv[]
 = Adding a Red Hat {virt} source provider

--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -14,8 +14,6 @@ You must specify a name for cluster-scoped CRs.
 You must specify both a name and a namespace for namespace-scoped CRs.
 ====
 
-include::snippet_ova_tech_preview.adoc[]
-
 [NOTE]
 ====
 Migration using {osp} source providers only supports VMs that use only Cinder volumes.

--- a/documentation/modules/new-migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/new-migrating-virtual-machines-cli.adoc
@@ -1,0 +1,1034 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+
+:_content-type: PROCEDURE
+[id="new-migrating-virtual-machines-cli_{context}"]
+
+ifdef::vmware[]
+= Migrating from a VMware vSphere source provider
+
+You can migrate from a VMware vSphere source provider using the CLI.
+
+endif::[]
+ifdef::rhv[]
+= Migrating from a {rhv-full} source provider
+
+You can migrate from a {rhv-full} ({rhv-short}) source provider using the CLI.
+
+.Prerequisites
+
+If you are migrating a virtual machine with a direct LUN disk, ensure that the nodes in the {virt} destination cluster that the VM is expected to run on can access the backend storage.
+
+include::snip-migrating-luns.adoc[]
+
+endif::[]
+ifdef::ova[]
+= Migrating from an Open Virtual Appliance (OVA) source provider
+
+You can migrate from Open Virtual Appliance (OVA) files that were created by VMware vSphere as a source provider using the CLI.
+
+endif::[]
+ifdef::ostack[]
+= Migrating from an {osp} source provider
+
+You can migrate from an {osp} source provider using the CLI.
+endif::[]
+ifdef::cnv[]
+= Migrating from a Red Hat {virt} source provider
+
+You can use a Red Hat {virt} provider as a source provider as well as a destination provider.
+endif::[]
+
+.Procedure
+. Create a `Secret` manifest for the source provider credentials:
++
+ifdef::vmware[]
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret>
+  namespace: <namespace>
+  ownerReferences: <1>
+    - apiVersion: forklift.konveyor.io/v1beta1
+      kind: Provider
+      name: <provider_name>
+      uid: <provider_uid>
+  labels:
+    createdForProviderType: vsphere
+    createdForResourceType: providers
+type: Opaque
+stringData:
+  user: <user> <2>
+  password: <password> <3>
+  insecureSkipVerify: <true/false> <4>
+  cacert: | <5>
+    <ca_certificate>
+  url: <api_end_point> <6>
+EOF
+----
+<1> The `ownerReferences` section is optional.
+<2> Specify the vCenter user or the ESX/ESXi user.
+<3> Specify the password of the vCenter user or the ESX/ESXi user.
+<4> Specify `<true>` to skip certificate verification, specify `false` to verify the certificate. Defaults to `false` if not specified. Skipping certificate verification proceeds with an insecure migration and then the certificate is not required. Insecure migration means that the transferred data is sent over an insecure connection and potentially sensitive data could be exposed.
+<5> When this field is not set and 'skip certificate verification' is disabled, {project-short} attempts to use the system CA.
+<6>  Specify the API endpoint URL of the vCenter or the ESX/ESX, for example, `https://<vCenter_host>/sdk`.
+endif::[]
+ifdef::rhv[]
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret>
+  namespace: <namespace>
+  ownerReferences: <1>
+    - apiVersion: forklift.konveyor.io/v1beta1
+      kind: Provider
+      name: <provider_name>
+      uid: <provider_uid>
+  labels:
+    createdForProviderType: ovirt
+    createdForResourceType: providers
+type: Opaque
+stringData:
+  user: <user> <2>
+  password: <password> <3>
+  insecureSkipVerify: <true/false> <4>
+  cacert: | <5>
+    <ca_certificate>
+  url: <api_end_point> <6>
+EOF
+----
+<1> The `ownerReferences` section is optional.
+<2> Specify the {rhv-short} {manager} user.
+<3> Specify the user password.
+<4> Specify `<true>` to skip certificate verification, specify `false` to verify the certificate. Defaults to `false` if not specified. Skipping certificate verification proceeds with an insecure migration and then the certificate is not required. Insecure migration means that the transferred data is sent over an insecure connection and potentially sensitive data could be exposed.
+<5>  Enter the {manager} CA certificate, unless it was replaced by a third-party certificate, in which case, enter the {manager} Apache CA certificate. You can retrieve the {manager} CA certificate at https://<engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA.
+<6> Specify the API endpoint URL, for example, `https://<engine_host>/ovirt-engine/api`.
+endif::[]
+ifdef::ova[]
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret>
+  namespace: <namespace>
+  ownerReferences: <1>
+    - apiVersion: forklift.konveyor.io/v1beta1
+      kind: Provider
+      name: <provider_name>
+      uid: <provider_uid>
+  labels:
+    createdForProviderType: ova
+    createdForResourceType: providers
+type: Opaque
+stringData:
+  url: <nfs_server:/nfs_path> <2>
+EOF
+----
+<1> The `ownerReferences` section is optional.
+<2> where: `nfs_server` is an IP or hostname of the server where the share was created and `nfs_path` is the path on the server where the OVA files are stored.
+endif::[]
+ifdef::ostack[]
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret>
+  namespace: <namespace>
+  ownerReferences: <1>
+    - apiVersion: forklift.konveyor.io/v1beta1
+      kind: Provider
+      name: <provider_name>
+      uid: <provider_uid>
+  labels:
+    createdForProviderType: openstack
+    createdForResourceType: providers
+type: Opaque
+stringData:
+  user: <user> <2>
+  password: <password> <3>
+  insecureSkipVerify: <true/false> <4>
+  domainName: <domain_name>
+  projectName: <project_name>
+  regionName: <region_name>
+  cacert: | <5>
+    <ca_certificate>
+  url: <api_end_point> <6>
+EOF
+----
+<1> The `ownerReferences` section is optional.
+<2> Specify the {osp} user.
+<3> Specify the user {osp} password.
+<4> Specify `<true>` to skip certificate verification, specify `false` to verify the certificate. Defaults to `false` if not specified. Skipping certificate verification proceeds with an insecure migration and then the certificate is not required. Insecure migration means that the transferred data is sent over an insecure connection and potentially sensitive data could be exposed.
+<5> When this field is not set and 'skip certificate verification' is disabled, {project-short} attempts to use the system CA.
+<6> Specify the API endpoint URL, for example, `https://<identity_service>/v3`.
+endif::[]
+
+ifdef::cnv[]
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret>
+  namespace: <namespace>
+  ownerReferences: <1>
+    - apiVersion: forklift.konveyor.io/v1beta1
+      kind: Provider
+      name: <provider_name>
+      uid: <provider_uid>
+  labels:
+    createdForProviderType: openshift
+    createdForResourceType: providers
+type: Opaque
+stringData:
+  user: <user> <2>
+  password: <password> <3>
+  insecureSkipVerify: <true/false> <4>
+  cacert: | <5>
+    <ca_certificate>
+  url: <api_end_point> <6>
+EOF
+----
+<1> The `ownerReferences` section is optional.
+<2> Specify the {virt} user.
+<3> Specify the user password.
+<4> Specify `<true>` to skip certificate verification, specify `false` to verify the certificate. Defaults to `false` if not specified. Skipping certificate verification proceeds with an insecure migration and then the certificate is not required. Insecure migration means that the transferred data is sent over an insecure connection and potentially sensitive data could be exposed.
+<5> When this field is not set and 'skip certificate verification' is disabled, {project-short} attempts to use the system CA.
+<6> Specify the URL of the endpoint of the API server.
+endif::[]
+
+[start=2]
+. Create a `Provider` manifest for the source provider:
++
+ifdef::vmware[]
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Provider
+metadata:
+  name: <source_provider>
+  namespace: <namespace>
+spec:
+  type: vsphere
+  url: <api_end_point> <1>
+  settings:
+    vddkInitImage: <VDDK_image> <2>
+    sdkEndpoint: vcenter <3>
+  secret:
+    name: <secret> <4>
+    namespace: <namespace>
+EOF
+----
+<1> Specify the URL of the API endpoint, for example, `https://<vCenter_host>/sdk`.
+<2> Optional, but it is strongly recommended to create a VDDK image to accelerate migrations. Follow OpenShift documentation to specify the VDDK image you created.
+<3> Options: `vcenter` or `esxi`.
+<4> Specify the name of the provider `Secret` CR.
+endif::[]
+
+ifdef::rhv[]
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Provider
+metadata:
+  name: <source_provider>
+  namespace: <namespace>
+spec:
+  type: ovirt
+  url: <api_end_point> <1>
+  secret:
+    name: <secret> <2>
+    namespace: <namespace>
+EOF
+----
+<1> Specify the URL of the API endpoint, for example, `https://<engine_host>/ovirt-engine/api`.
+<2> Specify the name of provider `Secret` CR.
+endif::[]
+
+ifdef::ova[]
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Provider
+metadata:
+  name: <source_provider>
+  namespace: <namespace>
+spec:
+  type: ova
+  url:  <nfs_server:/nfs_path> <1>
+  secret:
+    name: <secret> <2>
+    namespace: <namespace>
+EOF
+----
+<1>  where: `nfs_server` is an IP or hostname of the server where the share was created and `nfs_path` is the path on the server where the OVA files are stored.
+<2> Specify the name of provider `Secret` CR.
+endif::[]
+
+ifdef::ostack[]
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Provider
+metadata:
+  name: <source_provider>
+  namespace: <namespace>
+spec:
+  type: openstack
+  url: <api_end_point> <1>
+  secret:
+    name: <secret> <2>
+    namespace: <namespace>
+EOF
+----
+endif::[]
+
+ifdef::cnv[]
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Provider
+metadata:
+  name: <source_provider>
+  namespace: <namespace>
+spec:
+  type: openshift
+  url: <api_end_point> <1>
+  secret:
+    name: <secret> <2>
+    namespace: <namespace>
+EOF
+----
+<1> Specify the URL of the endpoint of the API server.
+<2> Specify the name of provider `Secret` CR.
+endif::[]
+
+ifdef::vmware[]
+[start=3]
+. Create a `Host` manifest:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Host
+metadata:
+  name: <vmware_host>
+  namespace: <namespace>
+spec:
+  provider:
+    namespace: <namespace>
+    name: <source_provider> <1>
+  id: <source_host_mor> <2>
+  ipAddress: <source_network_ip> <3>
+EOF
+----
+<1> Specify the name of the VMware vSphere `Provider` CR.
+<2> Specify the managed object reference (MOR) of the VMware vSphere host.
+<3> Specify the IP address of the VMware vSphere migration network.
+
+[start=4]
+. Create a `NetworkMap` manifest to map the source and destination networks:
++
+[source,yaml,subs="attributes+"]
+----
+$  cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: NetworkMap
+metadata:
+  name: <network_map>
+  namespace: <namespace>
+spec:
+  map:
+    - destination:
+        name: <network_name>
+        type: pod <1>
+      source: <2>
+        id: <source_network_id>
+        name: <source_network_name>
+    - destination:
+        name: <network_attachment_definition> <3>
+        namespace: <network_attachment_definition_namespace> <4>
+        type: multus
+      source:
+        id: <source_network_id>
+        name: <source_network_name>
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+EOF
+----
+<1> Allowed values are `pod` and `multus`.
+<2> You can use either the `id` _or_ the `name` parameter to specify the source network. For `id`, specify the VMware vSphere network MOR.
+<3> Specify a network attachment definition for each additional {virt} network.
+<4> Required only when `type` is `multus`. Specify the namespace of the {virt} network attachment definition.
+endif::[]
+
+ifdef::rhv[]
+[start=3]
+. Create a `NetworkMap` manifest to map the source and destination networks:
++
+[source,yaml,subs="attributes+"]
+----
+$  cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: NetworkMap
+metadata:
+  name: <network_map>
+  namespace: <namespace>
+spec:
+  map:
+    - destination:
+        name: <network_name>
+        type: pod <1>
+      source: <2>
+        id: <source_network_id>
+        name: <source_network_name>
+    - destination:
+        name: <network_attachment_definition> <3>
+        namespace: <network_attachment_definition_namespace> <4>
+        type: multus
+      source:
+        id: <source_network_id>
+        name: <source_network_name>
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+EOF
+----
+<1> Allowed values are `pod` and `multus`.
+<2> You can use either the `id` _or_ the `name` parameter to specify the source network. For `id`, specify the {rhv-short} network UUID.
+<3> Specify a network attachment definition for each additional {virt} network.
+<4> Required only when `type` is `multus`. Specify the namespace of the {virt} network attachment definition.
+endif::[]
+
+ifdef::ova[]
+[start=3]
+. Create a `NetworkMap` manifest to map the source and destination networks:
++
+[source,yaml,subs="attributes+"]
+----
+$  cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: NetworkMap
+metadata:
+  name: <network_map>
+  namespace: <namespace>
+spec:
+  map:
+    - destination:
+        name: <network_name>
+        type: pod <1>
+      source:
+        id: <source_network_id>
+    - destination:
+        name: <network_attachment_definition> <2>
+        namespace: <network_attachment_definition_namespace> <3>
+        type: multus
+      source:
+        id: <source_network_id>
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+EOF
+----
+<1> Allowed values are `pod` and `multus`.
+<2> Specify a network attachment definition for each additional {virt} network.
+<3> Required only when `type` is `multus`. Specify the namespace of the {virt} network attachment definition.
+endif::[]
+
+ifdef::ostack[]
+[start=3]
+. Create a `NetworkMap` manifest to map the source and destination networks:
++
+[source,yaml,subs="attributes+"]
+----
+$  cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: NetworkMap
+metadata:
+  name: <network_map>
+  namespace: <namespace>
+spec:
+  map:
+    - destination:
+        name: <network_name>
+        type: pod <1>
+      source:<2>
+        id: <source_network_id>
+        name: <source_network_name>
+    - destination:
+        name: <network_attachment_definition> <3>
+        namespace: <network_attachment_definition_namespace> <4>
+        type: multus
+      source:
+        id: <source_network_id>
+        name: <source_network_name>
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+EOF
+----
+<1> Allowed values are `pod` and `multus`.
+<2> You can use either the `id` _or_ the `name` parameter to specify the source network. For `id`, specify the {osp} network UUID.
+<3> Specify a network attachment definition for each additional {virt} network.
+<4> Required only when `type` is `multus`. Specify the namespace of the {virt} network attachment definition.
+endif::[]
+
+ifdef::cnv[]
+[start=3]
+. Create a `NetworkMap` manifest to map the source and destination networks:
++
+[source,yaml,subs="attributes+"]
+----
+$  cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: NetworkMap
+metadata:
+  name: <network_map>
+  namespace: <namespace>
+spec:
+  map:
+    - destination:
+        name: <network_name>
+        type: pod <1>
+      source:
+        name: <network_name>
+        type: pod
+    - destination:
+        name: <network_attachment_definition> <2>
+        namespace: <network_attachment_definition_namespace> <3>
+        type: multus
+      source:
+        name: <network_attachment_definition>
+        namespace: <network_attachment_definition_namespace>
+        type: multus
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+EOF
+----
+<1> Allowed values are `pod` and `multus`.
+<2> Specify a network attachment definition for each additional {virt} network. Specify the
+`namespace` either by using the `namespace property` or with a name built as follows: `<network_namespace>/<network_name>`.
+<3> Required only when `type` is `multus`. Specify the namespace of the {virt} network attachment definition.
+endif::[]
+
+ifdef::vmware[]
+[start=5]
+. Create a `StorageMap` manifest to map source and destination storage:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: StorageMap
+metadata:
+  name: <storage_map>
+  namespace: <namespace>
+spec:
+  map:
+    - destination:
+        storageClass: <storage_class>
+        accessMode: <access_mode> <1>
+      source:
+        id: <source_datastore> <2>
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+EOF
+----
+<1> Allowed values are `ReadWriteOnce` and `ReadWriteMany`.
+<2> Specify the VMware vSphere data storage MOR. For example, `f2737930-b567-451a-9ceb-2887f6207009`.
+endif::[]
+
+ifdef::rhv[]
+[start=4]
+. Create a `StorageMap` manifest to map source and destination storage:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: StorageMap
+metadata:
+  name: <storage_map>
+  namespace: <namespace>
+spec:
+  map:
+    - destination:
+        storageClass: <storage_class>
+        accessMode: <access_mode> <1>
+      source:
+        id: <source_storage_domain> <2>
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+EOF
+----
+<1> Allowed values are `ReadWriteOnce` and `ReadWriteMany`.
+<2> Specify the {rhv-short} storage domain UUID. For example, `f2737930-b567-451a-9ceb-2887f6207009`.
+endif::[]
+
+ifdef::ova[]
+[start=4]
+. Create a `StorageMap` manifest to map source and destination storage:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: StorageMap
+metadata:
+  name: <storage_map>
+  namespace: <namespace>
+spec:
+  map:
+    - destination:
+        storageClass: <storage_class>
+        accessMode: <access_mode> <1>
+      source:
+        name:  Dummy storage for source provider <provider_name> <2>
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+EOF
+----
+<1> Allowed values are `ReadWriteOnce` and `ReadWriteMany`.
+<2> For OVA, the `StorageMap` can map only a single storage, which all the disks from the OVA are associated with, to a storage class at the destination. For this reason, the storage is referred to in the UI as "Dummy storage for source provider <provider_name>". In the YAML, write the phrase as it appears above, without the quotation marks and replacing <provider_name> with the actual name of the provider.
+endif::[]
+
+ifdef::ostack[]
+[start=4]
+. Create a `StorageMap` manifest to map source and destination storage:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: StorageMap
+metadata:
+  name: <storage_map>
+  namespace: <namespace>
+spec:
+  map:
+    - destination:
+        storageClass: <storage_class>
+        accessMode: <access_mode> <1>
+      source:
+        id: <source_volume_type> <2>
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+EOF
+----
+<1> Allowed values are `ReadWriteOnce` and `ReadWriteMany`.
+<2> Specify the {osp} `volume_type` UUID. For example, `f2737930-b567-451a-9ceb-2887f6207009`.
+endif::[]
+
+ifdef::cnv[]
+[start=4]
+. Create a `StorageMap` manifest to map source and destination storage:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: StorageMap
+metadata:
+  name: <storage_map>
+  namespace: <namespace>
+spec:
+  map:
+    - destination:
+        storageClass: <storage_class>
+        accessMode: <access_mode> <1>
+      source:
+        name: <storage_class>
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+EOF
+----
+<1> Allowed values are `ReadWriteOnce` and `ReadWriteMany`.
+endif::[]
++
+. Optional: Create a `Hook` manifest to run custom code on a VM during the phase specified in the `Plan` CR:
++
+[source,yaml,subs="attributes+"]
+----
+$  cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Hook
+metadata:
+  name: <hook>
+  namespace: <namespace>
+spec:
+  image: quay.io/konveyor/hook-runner
+  playbook: |
+    LS0tCi0gbmFtZTogTWFpbgogIGhvc3RzOiBsb2NhbGhvc3QKICB0YXNrczoKICAtIG5hbWU6IExv
+    YWQgUGxhbgogICAgaW5jbHVkZV92YXJzOgogICAgICBmaWxlOiAiL3RtcC9ob29rL3BsYW4ueW1s
+    IgogICAgICBuYW1lOiBwbGFuCiAgLSBuYW1lOiBMb2FkIFdvcmtsb2FkCiAgICBpbmNsdWRlX3Zh
+    cnM6CiAgICAgIGZpbGU6ICIvdG1wL2hvb2svd29ya2xvYWQueW1sIgogICAgICBuYW1lOiB3b3Jr
+    bG9hZAoK
+EOF
+----
++
+where:
++
+`playbook` refers to an optional Base64-encoded Ansible playbook. If you specify a playbook, the `image` must be `hook-runner`.
++
+[NOTE]
+====
+You can use the default `hook-runner` image or specify a custom image. If you specify a custom image, you do not have to specify a playbook.
+====
+
+ifdef::vmware[]
+[start=7]
+. Create a `Plan` manifest for the migration:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Plan
+metadata:
+  name: <plan> <1>
+  namespace: <namespace>
+spec:
+  warm: false <2>
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+  map: <3>
+    network: <4>
+      name: <network_map> <5>
+      namespace: <namespace>
+    storage: <6>
+      name: <storage_map> <7>
+      namespace: <namespace>
+  targetNamespace: <target_namespace>
+  vms: <8>
+    - id: <source_vm> <9>
+    - name: <source_vm>
+      hooks: <10>
+        - hook:
+            namespace: <namespace>
+            name: <hook> <11>
+          step: <step> <12>
+EOF
+----
+<1> Specify the name of the `Plan` CR.
+<2> Specify whether the migration is warm - `true` - or cold - `false`. If you specify a warm migration without specifying a value for the `cutover` parameter in the `Migration` manifest, only the precopy stage will run.
+<3> Specify only one network map and one storage map per plan.
+<4> Specify a network mapping even if the VMs to be migrated are not assigned to a network. The mapping can be empty in this case.
+<5> Specify the name of the `NetworkMap` CR.
+<6> Specify a storage mapping even if the VMs to be migrated are not assigned with disk images. The mapping can be empty in this case.
+<7> Specify the name of the `StorageMap` CR.
+<8> You can use either the `id` _or_ the `name` parameter to specify the source VMs. +
+<9> Specify the VMware vSphere VM MOR..
+<10> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
+<11> Specify the name of the `Hook` CR.
+<12> Allowed values are `PreHook`, before the migration plan starts, or `PostHook`, after the migration is complete.
+endif::[]
+
+ifdef::rhv[]
+[start=6]
+. Create a `Plan` manifest for the migration:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Plan
+metadata:
+  name: <plan> <1>
+  namespace: <namespace>
+  preserveClusterCpuModel: true <2>
+spec:
+  warm: false <3>
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+  map: <4>
+    network: <5>
+      name: <network_map> <6>
+      namespace: <namespace>
+    storage: <7>
+      name: <storage_map> <8>
+      namespace: <namespace>
+  targetNamespace: <target_namespace>
+  vms: <9>
+    - id: <source_vm> <10>
+    - name: <source_vm>
+      hooks: <11>
+        - hook:
+            namespace: <namespace>
+            name: <hook> <12>
+          step: <step> <13>
+EOF
+----
+<1> Specify the name of the `Plan` CR.
+<2> See note below.
+<3> Specify whether the migration is warm or cold. If you specify a warm migration without specifying a value for the `cutover` parameter in the `Migration` manifest, only the precopy stage will run.
+<4> Specify only one network map and one storage map per plan.
+<5> Specify a network mapping even if the VMs to be migrated are not assigned to a network. The mapping can be empty in this case.
+<6> Specify the name of the `NetworkMap` CR.
+<7> Specify a storage mapping even if the VMs to be migrated are not assigned with disk images. The mapping can be empty in this case.
+<8> Specify the name of the `StorageMap` CR.
+<9> You can use either the `id` _or_ the `name` parameter to specify the source VMs.
+<10> Specify the {rhv-short} VM UUID.
+<11> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
+<12> Specify the name of the `Hook` CR.
+<13> Allowed values are `PreHook`, before the migration plan starts, or `PostHook`, after the migration is complete.
++
+[NOTE]
+====
+* If the migrated machines are set with a custom CPU model, they will be set with that CPU model in the destination cluster, regardless of the setting of `preserveClusterCpuModel`.
+
+* If the migrated machine are _not_ set with a custom CPU model:
+
+** If `preserveClusterCpuModel` is set to 'true`, {project-short} checks the CPU model of the VM when it runs in {rhv-short}, based on the cluster's configuration, and then sets the migrated VM with that CPU model.
+** If `preserveClusterCpuModel` is set to 'false`, {project-short} does not set a CPU type and the VMs are set with the default CPU model of the destination cluster.
+====
+endif::[]
+
+ifdef::ova[]
+[start=6]
+. Create a `Plan` manifest for the migration:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Plan
+metadata:
+  name: <plan> <1>
+  namespace: <namespace>
+spec:
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+  map: <2>
+    network: <3>
+      name: <network_map> <4>
+      namespace: <namespace>
+    storage: <5>
+      name: <storage_map> <6>
+      namespace: <namespace>
+  targetNamespace: <target_namespace>
+  vms: <7>
+    - id: <source_vm> <8>
+    - name: <source_vm>
+      hooks: <9>
+        - hook:
+            namespace: <namespace>
+            name: <hook> <10>
+          step: <step> <11>
+EOF
+----
+<1> Specify the name of the `Plan` CR.
+<2> Specify only one network map and one storage map per plan.
+<3> Specify a network mapping, even if the VMs to be migrated are not assigned to a network. The mapping can be empty in this case.
+<4> Specify the name of the `NetworkMap` CR.
+<5> Specify a storage mapping even if the VMs to be migrated are not assigned with disk images. The mapping can be empty in this case.
+<6> Specify the name of the `StorageMap` CR.
+<7> You can use either the `id` _or_ the `name` parameter to specify the source VMs.
+<8> Specify the OVA VM UUID.
+<9> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
+<10> Specify the name of the `Hook` CR.
+<11> Allowed values are `PreHook`, before the migration plan starts, or `PostHook`, after the migration is complete.
+endif::[]
+
+ifdef::ostack[]
+[start=6]
+. Create a `Plan` manifest for the migration:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Plan
+metadata:
+  name: <plan> <1>
+  namespace: <namespace>
+spec:
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+  map: <2>
+    network: <3>
+      name: <network_map> <4>
+      namespace: <namespace>
+    storage: <5>
+      name: <storage_map> <6>
+      namespace: <namespace>
+  targetNamespace: <target_namespace>
+  vms: <7>
+    - id: <source_vm> <8>
+    - name: <source_vm>
+      hooks: <9>
+        - hook:
+            namespace: <namespace>
+            name: <hook> <10>
+          step: <step> <11>
+EOF
+----
+<1> Specify the name of the `Plan` CR.
+<2> Specify only one network map and one storage map per plan.
+<3> Specify a network mapping, even if the VMs to be migrated are not assigned to a network. The mapping can be empty in this case.
+<4> Specify the name of the `NetworkMap` CR.
+<5> Specify a storage mapping, even if the VMs to be migrated are not assigned with disk images. The mapping can be empty in this case.
+<6> Specify the name of the `StorageMap` CR.
+<7> You can use either the `id` _or_ the `name` parameter to specify the source VMs.
+<8> Specify the {osp} VM UUID.
+<9> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
+<10> Specify the name of the `Hook` CR.
+<11> Allowed values are `PreHook`, before the migration plan starts, or `PostHook`, after the migration is complete.
+endif::[]
+
+ifdef::cnv[]
+[start=6]
+. Create a `Plan` manifest for the migration:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Plan
+metadata:
+  name: <plan> <1>
+  namespace: <namespace>
+spec:
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+  map: <2>
+    network: <3>
+      name: <network_map> <4>
+      namespace: <namespace>
+    storage: <5>
+      name: <storage_map> <6>
+      namespace: <namespace>
+  targetNamespace: <target_namespace>
+  vms:
+    - name: <source_vm>
+      namespace: <namespace>
+      hooks: <7>
+        - hook:
+            namespace: <namespace>
+            name: <hook> <8>
+          step: <step> <9>
+EOF
+----
+<1> Specify the name of the `Plan` CR.
+<2> Specify only one network map and one storage map per plan.
+<3> Specify a network mapping, even if the VMs to be migrated are not assigned to a network. The mapping can be empty in this case.
+<4> Specify the name of the `NetworkMap` CR.
+<5> Specify a storage mapping, even if the VMs to be migrated are not assigned with disk images. The mapping can be empty in this case.
+<6> Specify the name of the `StorageMap` CR.
+<7> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
+<8> Specify the name of the `Hook` CR.
+<9> Allowed values are `PreHook`, before the migration plan starts, or `PostHook`, after the migration is complete.
+endif::[]
+
+. Create a `Migration` manifest to run the `Plan` CR:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Migration
+metadata:
+  name: <name_of_migration_cr>
+  namespace: <namespace>
+spec:
+  plan:
+    name: <name_of_plan_cr>
+    namespace: <namespace>
+  cutover: <optional_cutover_time>
+EOF
+----
++
+[NOTE]
+====
+If you specify a cutover time, use the ISO 8601 format with the UTC time offset, for example, `2024-04-04T01:23:45.678+09:00`.
+====
+

--- a/documentation/modules/ostack-app-cred-auth.adoc
+++ b/documentation/modules/ostack-app-cred-auth.adoc
@@ -91,5 +91,4 @@ stringData:
   url: <OS_AUTH_URL_from_openstack_rc_file>
 EOF
 ----
-
-. Continue migrating your virtual machine according to the procedure in xref:migrating-virtual-machines-from-cli[Migrating virtual machines], starting with step 2, "Create a `Provider` manifest for the source provider."
+. Continue migrating your virtual machine according to the procedure in xref:new-migrating-virtual-machines-cli_ostack[Migrating virtual machines], starting with step 2, "Create a `Provider` manifest for the source provider."

--- a/documentation/modules/ostack-token-auth.adoc
+++ b/documentation/modules/ostack-token-auth.adoc
@@ -92,4 +92,4 @@ stringData:
 EOF
 ----
 
-. Continue migrating your virtual machine according to the procedure in xref:migrating-virtual-machines-from-cli[Migrating virtual machines], starting with step 2, "Create a `Provider` manifest for the source provider."
+. Continue migrating your virtual machine according to the procedure in xref:new-migrating-virtual-machines-cli_ostack[Migrating virtual machines], starting with step 2, "Create a `Provider` manifest for the source provider."


### PR DESCRIPTION
MTV 2.6

Resolves https://issues.redhat.com/browse/MTV-859 by writing a separate CLI migration procedure per source provider.

Previews:
1. VMware: https://file.emea.redhat.com/rhoch/experiment/html-single/#new-migrating-virtual-machines-cli_vmware
2. RHV: https://file.emea.redhat.com/rhoch/experiment/html-single/#new-migrating-virtual-machines-cli_rhv
3. OVA:https://file.emea.redhat.com/rhoch/experiment/html-single/#new-migrating-virtual-machines-cli_ova
4. OpenStack: https://file.emea.redhat.com/rhoch/experiment/html-single/#new-migrating-virtual-machines-cli_ostack
5. OpenShift: https://file.emea.redhat.com/rhoch/experiment/html-single/#new-migrating-virtual-machines-cli_cnv