### PR TITLE
Remove comment that FC is not supported for LUNs

### DIFF
--- a/documentation/modules/snip-migrating-luns.adoc
+++ b/documentation/modules/snip-migrating-luns.adoc
@@ -5,6 +5,4 @@
 * Unlike disk images that _are copied_ from a source provider to a target provider, LUNs are _detached_, _but not removed_, from virtual machines in the source provider and then attached to the virtual machines (VMs) that are created in the target provider.
 
 * LUNs are not removed from the source provider during the migration in case fallback to the source provider is required. However, before re-attaching the LUNs to VMs in the source provider, ensure that the LUNs are not used by VMs on the target environment at the same time, which might lead to data corruption.
-
-* Migration of Fibre Channel LUNs is not supported.
 ====


### PR DESCRIPTION
MTV 2.6

Resolves https://issues.redhat.com/browse/MTV-806 by removing the following sentence for the MTV user guide:  "Migration of Fibre Channel LUNs is not supported." 

Previews:
1. https://file.emea.redhat.com/rhoch/fc_luns_ok/html-single/#rhv-prerequisites_mtv [Note in RHV prerequisites]

2. https://file.emea.redhat.com/rhoch/fc_luns_ok/html-single/#migrating-virtual-machines-cli_mtv [Note in prerequisites for migrations using the CLI]