### PR TITLE
Adding secrets permissions for non-admins

### DIFF
--- a/documentation/modules/non-admin-permissions-for-ui.adoc
+++ b/documentation/modules/non-admin-permissions-for-ui.adoc
@@ -38,32 +38,36 @@ As a more comprehensive example, you can grant non-administrators the following 
 |Actions |API group |Resource
 
 |`get`, `list`, `watch`, `create`, `update`, `patch`, `delete`
-|`forklift.konveyer.io`
+|`forklift.konveyor.io`
 |`plans`
 
 | `get`, `list`, `watch`, `create`, `update`, `patch`, `delete`
-|`forklift.konveyer.io`
+|`forklift.konveyor.io`
 |`migrations`
 
 |`get`, `list`, `watch`, `create`, `update`, `patch`, `delete`
-|`forklift.konveyer.io`
+|`forklift.konveyor.io`
 |`hooks`
 
 |`get`, `list`, `watch`
-|`forklift.konveyer.io`
+|`forklift.konveyor.io`
 |`providers`
 
 |`get`, `list`, `watch`, `create`, `update`, `patch`, `delete`
-|`forklift.konveyer.io`
+|`forklift.konveyor.io`
 |`networkmaps`
 
 | `get`, `list`, `watch`, `create`, `update`, `patch`, `delete`
-|`forklift.konveyer.io`
+|`forklift.konveyor.io`
 |`storagemaps`
 
 |`get`, `list`, `watch`
-|`forklift.konveyer.io`
+|`forklift.konveyor.io`
 |`forkliftcontrollers`
+
+|`create`, `patch`, `delete`
+| Empty string
+|`secrets`
 |===
 
 [NOTE]


### PR DESCRIPTION
MTV 2,.6

Resolves https://issues.redhat.com/browse/MTV-945 by adding `secrets` permissions to Table 5.2.,  "Example permissions required for non-adminstrators to work with migration plan components but not create providers"

Preview: https://file.emea.redhat.com/rhoch/secrets/html-single/#non-admin-permissions_cli [last row of Table 5.2]