### PR TITLE
MTV-965: doc improvement - VMware prerequisites section reowrded as it is no longer required

### DIFF
--- a/documentation/modules/vmware-prerequisites.adoc
+++ b/documentation/modules/vmware-prerequisites.adoc
@@ -11,7 +11,7 @@ The following prerequisites apply to VMware migrations:
 
 * You must use a xref:compatibility-guidelines_{context}[compatible version] of VMware vSphere.
 * You must be logged in as a user with at least the minimal set of xref:vmware-privileges_{context}[VMware privileges].
-* You must install link:https://www.vmware.com/support/ws5/doc/new_guest_tools_ws.html[VMware Tools] on all source virtual machines (VMs).
+* To access the virtual machine using a pre-migration hook, link:https://www.vmware.com/support/ws5/doc/new_guest_tools_ws.html[VMware Tools] must be installed on the source virtual machine.
 * The VM operating system must be certified and supported for use as a link:https://access.redhat.com/articles/973163#ocpvirt[guest operating system with {virt}] _and_ for link:https://access.redhat.com/articles/1351473[conversion to KVM with `virt-v2v`].
 * If you are running a warm migration, you must enable link:https://kb.vmware.com/s/article/1020128[changed block tracking (CBT)] on the VMs and on the VM disks.
 * You must obtain the SHA-1 fingerprint of the vCenter host.


### PR DESCRIPTION
### JIRA

* [MTV-965](https://issues.redhat.com/browse/MTV-965)

### CHANGES

```
* To access the virtual machine using a pre-migration hook, link:https://www.vmware.com/support/ws5/doc/new_guest_tools_ws.html[VMware Tools] must be installed on the source virtual machine.
```