### PR TITLE
Retrieve the moRef of a datastore 

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -209,6 +209,8 @@ include::modules/non-admin-permissions-for-ui.adoc[leveloffset=+2]
 :cli!:
 :context: mtv
 
+include::modules/retrieving-vmware-moref.adoc[leveloffset=+2]
+
 include::modules/migrating-virtual-machines-cli.adoc[leveloffset=+2]
 include::modules/obtaining-vmware-fingerprint.adoc[leveloffset=+2]
 
@@ -229,9 +231,10 @@ You can create custom rules to extend the default ruleset of the `Validation` se
 
 include::modules/about-rego-files.adoc[leveloffset=+3]
 include::modules/accessing-default-validation-rules.adoc[leveloffset=+3]
-include::modules/retrieving-validation-service-json.adoc[leveloffset=+3]
 include::modules/creating-validation-rule.adoc[leveloffset=+3]
 include::modules/updating-validation-rules-version.adoc[leveloffset=+3]
+
+include::modules/retrieving-validation-service-json.adoc[leveloffset=+2]
 
 include::modules/upgrading-mtv-ui.adoc[leveloffset=+1]
 

--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -2,6 +2,7 @@
 //
 // * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
 
+:_mod_docs_content-type: PROCEDURE
 [id="migrating-virtual-machines-cli_{context}"]
 = Migrating virtual machines
 
@@ -135,7 +136,7 @@ spec:
 EOF
 ----
 <1> Specify the name of the VMware `Provider` CR.
-<2> Specify the managed object reference (MOR) of the VMware host.
+<2> Specify the managed object reference (moRef) of the VMware host. To retrieve the moRef, see xref:retrieving-vmware-moref_{context}[Retrieving a VMware vSphere moRef].
 <3> Specify the IP address of the VMware migration network.
 
 . Create a `NetworkMap` manifest to map the source and destination networks:
@@ -175,7 +176,7 @@ EOF
 ----
 <1> Allowed values are `pod` and `multus`.
 <2> You can use either the `id` _or_ the `name` parameter to specify the source network.
-<3> Specify the VMware network MOR, the {rhv-short} network UUID, or the {osp} network UUID.
+<3> Specify the VMware network moRef, the {rhv-short} network UUID, or the {osp} network UUID. To retrieve the moRef, see xref:retrieving-vmware-moref_{context}[Retrieving a VMware vSphere moRef].
 <4> Specify a network attachment definition for each additional {virt} network.
 <5> Required only when `type` is `multus`. Specify the namespace of the {virt} network attachment definition.
 <6> Specify a network attachment definition for each additional {virt} network.
@@ -214,7 +215,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `ReadWriteOnce` and `ReadWriteMany`.
-<2> Specify the VMware data storage MOR, the {rhv-short} storage domain UUID, or the {osp} `volume_type` UUID. For example, `f2737930-b567-451a-9ceb-2887f6207009`.
+<2> Specify the VMware datastore moRef, the {rhv-short} storage domain UUID, or the {osp} `volume_type` UUID. For example, `f2737930-b567-451a-9ceb-2887f6207009`. To retrieve the moRef, see xref:retrieving-vmware-moref_{context}[Retrieving a VMware vSphere moRef].
 +
 [NOTE]
 ====
@@ -242,7 +243,7 @@ spec:
 EOF
 ----
 <1> You can use the default `hook-runner` image or specify a custom image. If you specify a custom image, you do not have to specify a playbook.
-<2> Optional: Base64-encoded Ansible playbook. If you specify a playbook, the `image` must be `hook-runner`.
+<2> Optional: Base64-encoded Ansible Playbook. If you specify a playbook, the `image` must be `hook-runner`.
 
 . Create a `Plan` manifest for the migration:
 +
@@ -291,7 +292,7 @@ EOF
 <7> Specify the name of the `StorageMap` CR.
 <8> For all source providers except for {virt}, you can use either the `id` _or_ the `name` parameter to specify the source VMs. +
 {virt} source provider only: You can use only the `name` parameter, not the `id.` parameter to specify the source VMs.
-<9> Specify the VMware VM MOR, {rhv-short} VM UUID or the {osp} VM UUID.
+<9> Specify the VMware VM moRef, {rhv-short} VM UUID or the {osp} VM UUID. To retrieve the moRef, see xref:retrieving-vmware-moref_{context}[Retrieving a VMware vSphere moRef].
 <10> {virt} source provider only.
 <11> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
 <12> Specify the name of the `Hook` CR.

--- a/documentation/modules/retrieving-validation-service-json.adoc
+++ b/documentation/modules/retrieving-validation-service-json.adoc
@@ -63,7 +63,7 @@ $ curl -H "Authorization: Bearer $TOKEN"  https://<inventory_service_route>/prov
 ----
 +
 .Example output
-[source,yaml,subs="attributes+"]]
+[source,yaml,subs="attributes+"]
 ----
 {
     "input": {

--- a/documentation/modules/retrieving-vmware-moref.adoc
+++ b/documentation/modules/retrieving-vmware-moref.adoc
@@ -1,0 +1,80 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="retrieving-vmware-moref_{context}"]
+= Retrieving a VMware vSphere moRef
+
+When you migrate VMs with a VMware vSphere source provider using {project-first} from the CLI, you need to know the managed object reference (moRef) of certain entities in vSphere, such as datastores, networks, and VMs.
+
+You can retrieve the moRef of one or more vSphere entities from the Inventory service. You can then use each moRef as a reference for retrieving the moRef of another entity.
+
+.Procedure
+
+. Retrieve the routes for the project:
++
+[source,terminal]
+----
+oc get route -n openshift-mtv
+----
+
+. Retrieve the `Inventory` service route:
++
+[source,terminal,subs="attributes+"]
+----
+$ {oc} get route <inventory_service> -n {namespace}
+----
+
+. Retrieve the access token:
++
+[source,terminal]
+----
+$ TOKEN=$(oc whoami -t)
+----
+
+. Retrieve the moRef of a VMware vSphere provider:
++
+[source,terminal]
+----
+$ curl -H "Authorization: Bearer $TOKEN"  https://<inventory_service_route>/providers/vsphere -k
+----
+
+. Retrieve the datastores of a VMware vSphere source provider:
++
+[source,terminal]
+----
+$ curl -H "Authorization: Bearer $TOKEN"  https://<inventory_service_route>/providers/vsphere/<provider id>/datastores/ -k
+----
++
+.Example output
+[source,terminal]
+----
+[
+  {
+    "id": "datastore-11",
+    "parent": {
+      "kind": "Folder",
+      "id": "group-s5"
+    },
+    "path": "/Datacenter/datastore/v2v_general_porpuse_ISCSI_DC",
+    "revision": 46,
+    "name": "v2v_general_porpuse_ISCSI_DC",
+    "selfLink": "providers/vsphere/01278af6-e1e4-4799-b01b-d5ccc8dd0201/datastores/datastore-11"
+  },
+  {
+    "id": "datastore-730",
+    "parent": {
+      "kind": "Folder",
+      "id": "group-s5"
+    },
+    "path": "/Datacenter/datastore/f01-h27-640-SSD_2",
+    "revision": 46,
+    "name": "f01-h27-640-SSD_2",
+    "selfLink": "providers/vsphere/01278af6-e1e4-4799-b01b-d5ccc8dd0201/datastores/datastore-730"
+  },
+ ...
+----
+
+In this example, the moRef of the datastore `v2v_general_porpuse_ISCSI_DC` is `datastore-11` and the moRef of the datastore `f01-h27-640-SSD_2` is `datastore-730`.
+

--- a/documentation/modules/rhv-prerequisites.adoc
+++ b/documentation/modules/rhv-prerequisites.adoc
@@ -11,7 +11,7 @@ The following prerequisites apply to {rhv-full} migrations:
 * You must use a xref:compatibility-guidelines_{context}[compatible version] of {rhv-full}.
 * You must have the {manager} CA certificate, unless it was replaced by a third-party certificate, in which case, specify the {manager} Apache CA certificate.
 +
-You can obtain the {manager}  CA certificate by navigating to https://<engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA in a browser.
+You can obtain the {manager} CA certificate by navigating to `https://<engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA` in a browser.
 
 * If you are migrating a virtual machine with a direct LUN disk, ensure that the nodes in the {virt} destination cluster that the VM is expected to run on can access the backend storage.
 


### PR DESCRIPTION
### JIRA

* [MTV-1099](https://issues.redhat.com/browse/MTV-1099)

### MTV 2.5.6

Resolves https://issues.redhat.com/browse/MTV-1099 by adding instructions in the CLI migration procedures that explain how a user can retrieve a moRef of a datastore.

Also fixes a few minor formatting issues. 

Previews:
1. New section: https://file.emea.redhat.com/rhoch/mor/html-single/#retrieving-vmware-mor_mtv 
2. Note directing users to new section: https://file.emea.redhat.com/rhoch/mor/html-single/#migrating-virtual-machines-cli_mtv [search for "moRef"] 