### PR TITLE
Fix max_vm_inflight setting name

### DIFF
--- a/documentation/modules/configuring-mtv-operator.adoc
+++ b/documentation/modules/configuring-mtv-operator.adoc
@@ -36,7 +36,7 @@ spec:
 |===
 |Label |Description |Default value
 
-|`controller_max_vm_in_flight`
+|`controller_max_vm_inflight`
 |The maximum number of VMs per plan that can be migrated simultaneously.
 |`20`
 


### PR DESCRIPTION
MTV 2.6

Resolves https://issues.redhat.com/browse/MTV-1103 for MTV 2.6.x 