### PR TITLE
Restoring "Selecting a migration network for a VMware source provider" to the MTV user guide

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -147,6 +147,7 @@ You can add a source provider by using the {ocp} web console.
 :context: vmware
 :vmware:
 include::modules/adding-source-provider.adoc[leveloffset=+4]
+include::modules/selecting-migration-network-for-vmware-source-provider.adoc[leveloffset=+4]
 :!vmware:
 :context: rhv
 :rhv:

--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -147,7 +147,7 @@ You can add a source provider by using the {ocp} web console.
 :context: vmware
 :vmware:
 include::modules/adding-source-provider.adoc[leveloffset=+4]
-include::modules/selecting-migration-network-for-vmware-source-provider.adoc[leveloffset=+4]
+include::modules/selecting-migration-network-for-vmware-source-provider.adoc[leveloffset=+5]
 :!vmware:
 :context: rhv
 :rhv:


### PR DESCRIPTION
MTV 2.6

Restores the section "Selecting a migration network for a VMware source provider" to the MTV user guide.

Preview: https://file.emea.redhat.com/rhoch/vmware_mig_network/html-single/#adding-source-providers  [section 4.4.1.1.1]
