### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You must have Podman installed.
 
 1. Clone the repository:
   ```console
-  $ git clone -b source https://github.com/konveyor/forklift-documentation.git && cd forklift-documentation
+  $ git clone [https://github.com/konveyor/forklift-documentation.git](https://github.com/kubev2v/forklift-documentation) && cd forklift-documentation
   ```
 2. Create `.jekyll-cache` and `_site` directories:
   ```console


### PR DESCRIPTION
Updated documentation repo to point to https://github.com/kubev2v/forklift-documentation from "konveyor" repo earlier and removed branch "source"