### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,9 @@ gem "jekyll-paginate"
 #
 gem "github-pages", group: :jekyll_plugins
 
+# Add the webrick gem - this is a requirement as the podman image creation fails without it
+gem "webrick"
+
 # ensures that jekyll-asciidoc is loaded first
 group :jekyll_plugins do
   gem 'jekyll-asciidoc'


### PR DESCRIPTION
/usr/gem/gems/jekyll-3.9.5/lib/jekyll/commands/serve/servlet.rb:3:in `require': cannot load such file -- webrick (LoadError) - Getting this error during the image run. This happens because webrick is no longer a bundled gem in Ruby 3.0. From 
[https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/](url) 

Adding gem "**webrick**" to Gemfile solves the problem, but Jekyll should include it in its gemspec

```
podman run -it --rm --name jekyll -p 4000:4000 -v $(pwd):/srv/jekyll jekyll/jekyll jekyll serve --watch --future

fatal: detected dubious ownership in repository at '/srv/jekyll'
To add an exception for this directory, call:

	git config --global --add safe.directory /srv/jekyll
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies......
Fetching base64 0.2.0
Fetching bigdecimal 3.1.8
Installing base64 0.2.0
Fetching concurrent-ruby 1.2.3
Installing bigdecimal 3.1.8 with native extensions
Installing concurrent-ruby 1.2.3
Fetching connection_pool 2.4.1
Installing connection_pool 2.4.1
Fetching drb 2.2.1
Installing drb 2.2.1
Fetching minitest 5.22.3
Installing minitest 5.22.3
Fetching mutex_m 0.2.0
Installing mutex_m 0.2.0
Fetching public_suffix 5.0.5
Installing public_suffix 5.0.5
Fetching asciidoctor 2.0.22
Installing asciidoctor 2.0.22
Fetching ast 2.4.2
Installing ast 2.4.2
Using bundler 2.3.25
Using coffee-script-source 1.12.2
Fetching execjs 2.9.1
Installing execjs 2.9.1
Using colorator 1.1.0
Fetching commonmarker 0.23.10
Installing commonmarker 0.23.10 with native extensions
Fetching unf_ext 0.0.9.1
Installing unf_ext 0.0.9.1 with native extensions
Using eventmachine 1.2.7
Using http_parser.rb 0.8.0
Fetching ffi 1.16.3
Installing ffi 1.16.3 with native extensions
Fetching uri 0.13.0
Installing uri 0.13.0
Using forwardable-extended 2.6.0
Fetching gemoji 4.1.0
Installing gemoji 4.1.0
Using rb-fsevent 0.11.2
Fetching rexml 3.2.6
Installing rexml 3.2.6
Fetching liquid 4.0.4
Installing liquid 4.0.4
Using mercenary 0.3.6
Using rouge 3.30.0
Using safe_yaml 1.0.5
Fetching racc 1.7.3
Installing racc 1.7.3 with native extensions
Using jekyll-paginate 1.1.0
Fetching rubyzip 2.3.2
Installing rubyzip 2.3.2
Fetching jekyll-swiss 1.0.0
Installing jekyll-swiss 1.0.0
Using unicode-display_width 1.8.0
Fetching parallel 1.24.0
Installing parallel 1.24.0
Using rainbow 3.1.1
Using yell 2.2.2
Fetching json 2.7.2
Installing json 2.7.2 with native extensions
Fetching regexp_parser 2.9.1
Installing regexp_parser 2.9.1
Fetching ruby-progressbar 1.13.0
Installing ruby-progressbar 1.13.0
Fetching i18n 1.14.5
Installing i18n 1.14.5
Fetching tzinfo 2.0.6
Installing tzinfo 2.0.6
Fetching addressable 2.8.6
Installing addressable 2.8.6
Using coffee-script 2.4.1
Using jekyll-commonmark 1.4.0
Using em-websocket 0.5.3
Fetching unf 0.1.4
Installing unf 0.1.4
Fetching net-http 0.4.1
Installing net-http 0.4.1
Using pathutil 0.16.2
Using kramdown 2.4.0
Fetching nokogiri 1.16.4 (x86_64-linux)
Installing nokogiri 1.16.4 (x86_64-linux)
Fetching parser 3.3.1.0
Installing parser 3.3.1.0
Fetching terminal-table 1.8.0
Installing terminal-table 1.8.0
Fetching activesupport 7.1.3.2
Installing activesupport 7.1.3.2
Fetching jekyll-coffeescript 1.2.2
Installing jekyll-coffeescript 1.2.2
Fetching simpleidn 0.2.2
Installing simpleidn 0.2.2
Fetching faraday-net_http 3.1.0
Installing faraday-net_http 3.1.0
Using kramdown-parser-gfm 1.1.0
Fetching w3c_validators 1.3.7
Installing w3c_validators 1.3.7
Fetching rubocop-ast 1.31.3
Installing rubocop-ast 1.31.3
Using html-pipeline 2.14.3
Fetching dnsruby 1.72.1
Installing dnsruby 1.72.1
Fetching faraday 2.9.0
Installing faraday 2.9.0
Fetching rubocop 0.93.1
Installing rubocop 0.93.1
Fetching sawyer 0.9.2
Installing sawyer 0.9.2
Fetching octokit 4.25.1
Installing octokit 4.25.1
Fetching jekyll-gist 1.5.0
Installing jekyll-gist 1.5.0
Using ethon 0.16.0
Using rb-inotify 0.10.1
Using sass-listen 4.0.0
Fetching typhoeus 1.4.1
Fetching listen 3.9.0
Installing typhoeus 1.4.1
Installing listen 3.9.0
Using sass 3.7.4
Using jekyll-watch 2.2.1
Using jekyll-sass-converter 1.5.2
Fetching jekyll 3.9.5
Fetching github-pages-health-check 1.18.2
Installing github-pages-health-check 1.18.2
Installing jekyll 3.9.5
Fetching html-proofer 3.19.4
Fetching jekyll-avatar 0.8.0
Installing html-proofer 3.19.4
Installing jekyll-avatar 0.8.0
Fetching jekyll-commonmark-ghpages 0.4.0
Fetching jekyll-default-layout 0.1.5
Installing jekyll-commonmark-ghpages 0.4.0
Installing jekyll-default-layout 0.1.5
Using jekyll-feed 0.17.0
Fetching jekyll-github-metadata 2.16.1
Fetching jekyll-include-cache 0.2.1
Installing jekyll-github-metadata 2.16.1
Using jekyll-mentions 1.6.0
Installing jekyll-include-cache 0.2.1
Fetching jekyll-optional-front-matter 0.3.2
Fetching jekyll-readme-index 0.3.0
Installing jekyll-optional-front-matter 0.3.2
Using jekyll-redirect-from 0.16.0
Fetching jekyll-relative-links 0.6.1
Installing jekyll-readme-index 0.3.0
Fetching jekyll-remote-theme 0.4.3
Installing jekyll-relative-links 0.6.1
Installing jekyll-remote-theme 0.4.3
Using jekyll-seo-tag 2.8.0
Using jekyll-sitemap 1.4.0
Fetching jekyll-titles-from-headings 0.5.3
Fetching jemoji 0.13.0
Installing jekyll-titles-from-headings 0.5.3
Fetching jekyll-asciidoc 3.0.1
Installing jemoji 0.13.0
Fetching jekyll-theme-architect 0.2.0
Installing jekyll-asciidoc 3.0.1
Using jekyll-theme-cayman 0.1.1 from source at `.`
Fetching jekyll-theme-dinky 0.2.0
Installing jekyll-theme-architect 0.2.0
Fetching jekyll-theme-hacker 0.2.0
Installing jekyll-theme-dinky 0.2.0
Fetching jekyll-theme-leap-day 0.2.0
Installing jekyll-theme-hacker 0.2.0
Fetching jekyll-theme-merlot 0.2.0
Installing jekyll-theme-leap-day 0.2.0
Installing jekyll-theme-merlot 0.2.0
Fetching jekyll-theme-midnight 0.2.0
Fetching jekyll-theme-minimal 0.2.0
Installing jekyll-theme-minimal 0.2.0
Fetching jekyll-theme-modernist 0.2.0
Installing jekyll-theme-midnight 0.2.0
Installing jekyll-theme-modernist 0.2.0
Fetching jekyll-theme-primer 0.6.0
Installing jekyll-theme-primer 0.6.0
Fetching jekyll-theme-slate 0.2.0
Fetching jekyll-theme-tactile 0.2.0
Installing jekyll-theme-slate 0.2.0
Fetching jekyll-theme-time-machine 0.2.0
Installing jekyll-theme-tactile 0.2.0
Using minima 2.5.1
Installing jekyll-theme-time-machine 0.2.0
Fetching github-pages 231
Installing github-pages 231
Your lockfile doesn't include a valid resolution.
You can fix this by regenerating your lockfile or trying to manually editing the bad locked gems to a version that satisfies all dependencies.
The unmet dependencies are:
* jekyll-theme-cayman (= 0.2.0), depended upon github-pages-231, unsatisfied by jekyll-theme-cayman-0.1.1
Bundle complete! 8 Gemfile dependencies, 109 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
ruby 3.1.1p18 (2022-02-18 revision 53f5fc4236) [x86_64-linux-musl]
fatal: detected dubious ownership in repository at '/srv/jekyll'
To add an exception for this directory, call:

	git config --global --add safe.directory /srv/jekyll
Configuration file: /srv/jekyll/_config.yml
            Source: /srv/jekyll
       Destination: /srv/jekyll/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
       Jekyll Feed: Generating feed for posts
fatal: detected dubious ownership in repository at '/srv/jekyll'
To add an exception for this directory, call:

	git config --global --add safe.directory /srv/jekyll
asciidoctor: WARNING: modules/installing-mtv-operator.adoc: line 13: id assigned to section already in use: installing-mtv-operator_forklift
asciidoctor: WARNING: modules/adding-source-provider.adoc: line 21: id assigned to section already in use: adding-source-provider_forklift
asciidoctor: WARNING: modules/adding-source-provider.adoc: line 36: id assigned to section already in use: adding-source-provider_forklift
asciidoctor: WARNING: modules/adding-source-provider.adoc: line 30: id assigned to section already in use: adding-source-provider_forklift
asciidoctor: WARNING: modules/adding-source-provider.adoc: line 47: id assigned to section already in use: adding-source-provider_forklift
asciidoctor: WARNING: modules/adding-source-provider.adoc: line 62: id assigned to section already in use: adding-source-provider_forklift
asciidoctor: WARNING: modules/new-migrating-virtual-machines-cli.adoc: line 15: id assigned to section already in use: new-migrating-virtual-machines-cli_forklift
asciidoctor: WARNING: modules/new-migrating-virtual-machines-cli.adoc: line 33: id assigned to section already in use: new-migrating-virtual-machines-cli_forklift
asciidoctor: WARNING: modules/new-migrating-virtual-machines-cli.adoc: line 27: id assigned to section already in use: new-migrating-virtual-machines-cli_forklift
asciidoctor: WARNING: modules/new-migrating-virtual-machines-cli.adoc: line 38: id assigned to section already in use: new-migrating-virtual-machines-cli_forklift
asciidoctor: ERROR: obtaining-console-url.adoc: line 21: include file not found: /srv/jekyll/snippet_getting_web_console_url_web.adoc
asciidoctor: ERROR: obtaining-console-url.adoc: line 25: include file not found: /srv/jekyll/snippet_getting_web_console_url_cli.adoc
asciidoctor: ERROR: obtaining-console-url.adoc: line 21: include file not found: /srv/jekyll/snippet_getting_web_console_url_web.adoc
asciidoctor: ERROR: obtaining-console-url.adoc: line 25: include file not found: /srv/jekyll/snippet_getting_web_console_url_cli.adoc
asciidoctor: ERROR: obtaining-console-url.adoc: line 21: include file not found: /srv/jekyll/snippet_getting_web_console_url_web.adoc
asciidoctor: ERROR: obtaining-console-url.adoc: line 25: include file not found: /srv/jekyll/snippet_getting_web_console_url_cli.adoc
asciidoctor: ERROR: obtaining-console-url.adoc: line 21: include file not found: /srv/jekyll/snippet_getting_web_console_url_web.adoc
asciidoctor: ERROR: obtaining-console-url.adoc: line 25: include file not found: /srv/jekyll/snippet_getting_web_console_url_cli.adoc
asciidoctor: ERROR: rhv-prerequisites.adoc: line 30: include file not found: /srv/jekyll/snip-migrating-luns.adoc
asciidoctor: ERROR: rhv-prerequisites.adoc: line 30: include file not found: /srv/jekyll/snip-migrating-luns.adoc
asciidoctor: ERROR: rhv-prerequisites.adoc: line 30: include file not found: /srv/jekyll/snip-migrating-luns.adoc
asciidoctor: ERROR: rhv-prerequisites.adoc: line 30: include file not found: /srv/jekyll/snip-migrating-luns.adoc
asciidoctor: ERROR: rn-2.5.adoc: line 58: include file not found: /srv/jekyll/snippet_ova_tech_preview.adoc
asciidoctor: ERROR: rn-2.5.adoc: line 58: include file not found: /srv/jekyll/snippet_ova_tech_preview.adoc
asciidoctor: ERROR: rn-2.5.adoc: line 58: include file not found: /srv/jekyll/snippet_ova_tech_preview.adoc
asciidoctor: ERROR: rn-2.5.adoc: line 58: include file not found: /srv/jekyll/snippet_ova_tech_preview.adoc
                    done in 2.824 seconds.
 Auto-regeneration: enabled for '/srv/jekyll'
/usr/gem/gems/jekyll-3.9.5/lib/jekyll/commands/serve/servlet.rb:3:in `require': cannot load such file -- webrick (LoadError)
	from /usr/gem/gems/jekyll-3.9.5/lib/jekyll/commands/serve/servlet.rb:3:in `<top (required)>'
	from /usr/gem/gems/jekyll-3.9.5/lib/jekyll/commands/serve.rb:184:in `require_relative'
	from /usr/gem/gems/jekyll-3.9.5/lib/jekyll/commands/serve.rb:184:in `setup'
	from /usr/gem/gems/jekyll-3.9.5/lib/jekyll/commands/serve.rb:102:in `process'
	from /usr/gem/gems/jekyll-3.9.5/lib/jekyll/commands/serve.rb:93:in `block in start'
	from /usr/gem/gems/jekyll-3.9.5/lib/jekyll/commands/serve.rb:93:in `each'
	from /usr/gem/gems/jekyll-3.9.5/lib/jekyll/commands/serve.rb:93:in `start'
	from /usr/gem/gems/jekyll-3.9.5/lib/jekyll/commands/serve.rb:75:in `block (2 levels) in init_with_program'
	from /usr/gem/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
	from /usr/gem/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
	from /usr/gem/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
	from /usr/gem/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
# frozen_string_literal: true
	from /usr/gem/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
	from /usr/gem/gems/jekyll-3.9.5/exe/jekyll:15:in `<top (required)>'
	from /usr/local/bundle/bin/jekyll:27:in `load'
	from /usr/local/bundle/bin/jekyll:27:in `<main>'
```