### PR TITLE
MTV 2.6.2 attributes

### DIFF
--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -17,7 +17,7 @@
 :project-short: MTV
 :project-first: {project-full} ({project-short})
 :project-version: 2.6
-:project-z-version: 2.6.1
+:project-z-version: 2.6.2
 :the: The
 :the-lc: the
 :virt: OpenShift Virtualization


### PR DESCRIPTION
MTV 2.6.2

Resolves https://issues.redhat.com/browse/MTV-1112 by changing the value of the `project-z-version` attribute to 2.6.2.

