### PR TITLE
MTV 2.6.2 release notes fixed after rebase went wrong

### DIFF
--- a/documentation/modules/rn-2.6.adoc
+++ b/documentation/modules/rn-2.6.adoc
@@ -163,13 +163,52 @@ When vSphere does not receive updates about the guest operating system from the 
 
 The migration process fails when migrating an image-based VM from {osp} to the `default` project. link:https://issues.redhat.com/browse/MTV-964[(MTV-964)]
 
-For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/issues/?filter=12435571[Known Issues] in Jira.
+For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/issues/?filter=12436209[Known Issues] in Jira.
 
 
 [id="resolved-issues-26_{context}"]
 == Resolved issues
 
 This release has the following resolved issues:
+
+.CVE-2023-45288: Golang `net/http, x/net/http2`: unlimited number of `CONTINUATION` frames can cause a denial-of-service (DoS) attack
+
+A flaw was discovered with the implementation of the `HTTP/2` protocol in the Go programming language, which impacts previous versions of {project-short}. There were insufficient limitations on the number of CONTINUATION frames sent within a single stream. An attacker could potentially exploit this to cause a denial-of-service (DoS) attack. This flaw has been resolved in {project-short} 2.6.2.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2023-45288[(CVE-2023-45288)].
+
+.CVE-2024-24785: `mtv-api-container`: Golang `html/template: errors` returned from `MarshalJSON` methods may break template escaping
+
+A flaw was found in the `html/template` Golang standard library package, which impacts previous versions of {project-short}. If errors returned from `MarshalJSON` methods contain user-controlled data, they may be used to break the contextual auto-escaping behavior of the HTML/template package, allowing subsequent actions to inject unexpected content into the templates. This flaw has been resolved in {project-short} 2.6.2.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2024-24785[(CVE-2024-24785)].
+
+.CVE-2024-24784: `mtv-validation-container`: Golang `net/mail`: comments in display names are incorrectly handled
+
+A flaw was found in the `net/mail` Golang standard library package, which impacts previous versions of {project-short}. The `ParseAddressList` function incorrectly handles comments, text in parentheses, and display names. As this is a misalignment with conforming address parsers, it can result in different trust decisions being made by programs using different parsers. This flaw has been resolved in {project-short} 2.6.2.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2024-24784[(CVE-2024-24784)].
+
+
+.CVE-2024-24783: `mtv-api-container`: Golang `crypto/x509`: Verify panics on certificates with an unknown public key algorithm
+
+A flaw was found in the `crypto/x509` Golang standard library package, which impacts previous versions of {project-short}. Verifying a certificate chain that contains a certificate with an unknown public key algorithm causes `Certificate.Verify` to panic. This affects all `crypto/tls` clients and servers that set `Config.ClientAuth` to `VerifyClientCertIfGiven` or `RequireAndVerifyClientCert`. The default behavior is for TLS servers to not verify client certificates. This flaw has been resolved in {project-short} 2.6.2.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2024-24783[(CVE-2024-24783)].
+
+.CVE-2023-45290: `mtv-api-container`: Golang `net/http` memory exhaustion in `Request.ParseMultipartForm`
+
+A flaw was found in the `net/http` Golang standard library package, which impacts previous versions of {project-short}. When parsing a `multipart` form, either explicitly with `Request.ParseMultipartForm` or implicitly with `Request.FormValue`, `Request.PostFormValue`, or `Request.FormFile`, limits on the total size of the parsed form are not applied to the memory consumed while reading a single form line. This permits a maliciously crafted input containing long lines to cause the allocation of arbitrarily large amounts of memory, potentially leading to memory exhaustion. This flaw has been resolved in {project-short} 2.6.2.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2023-45290[(CVE-2023-45290)].
+
+.ImageConversion does not run when target storage is set with wait-for-first-consumer
+
+In earlier releases of {project-short}, migration of VMs failed because the migration was stuck in the `AllocateDisks` phase. As a result of being stuck, the migration did not progress, and PVCs were not bound. The root cause of the problem was that `ImageConversion` did not run when target storage was set for `wait-for-first-consumer`. The problem was resolved in {project-short} 2.6.2. link:https://issues.redhat.com/browse/MTV-1126[(MTV-1126)]
+
+.forklift-controller panics when importing VMs with direct LUNs
+
+In earlier releases of {project-short}, `forklift-controller` panicked when a user attempted to import VMs that had direct LUNs. The problem was resolved in {project-short} 2.6.2. link:https://issues.redhat.com/browse/MTV-1134[(MTV-1134)]
 
 .VMs with multiple disks that are migrated from vSphere and OVA files are not being fully copied
 
@@ -236,4 +275,4 @@ In earlier releases of {project-short}, the error logs lacked clear information 
 In earlier releases of {project-short}, an earlier failed migration could have left an outdated `ovirtvolumepopulator`. When starting a new plan for the same VM to the same project,  the `CreateDataVolumes` phase did not create populator PVCs when transitioning to `CopyDisks`, causing the `CopyDisks` phase to stay indefinitely. This issue was resolved in {project-short} 2.6.0. link:https://issues.redhat.com/browse/MTV-929[(MTV-929)]
 
 
-For a complete list of all resolved issues in this release, see the list of link:https://issues.redhat.com/issues/?filter=12435572[Resolved Issues] in Jira.
+For a complete list of all resolved issues in this release, see the list of link:https://issues.redhat.com/issues/?filter=12436210[Resolved Issues] in Jira.


### PR DESCRIPTION

### JIRA 

* MTV 2.6.2 release notes

* [MTV-1111](https://issues.redhat.com/browse/MTV-1111)

Resolves https://issues.redhat.com/browse/MTV-1111 by adding new text to the 2.6 release notes that is relevant to 2.6.2 (resolved issues and links to all open and resolved issues for versions 2.6.2)
