### PR TITLE
MTV 2.6: Retrieving the moRef of a datastore

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -230,6 +230,8 @@ include::modules/non-admin-permissions-for-ui.adoc[leveloffset=+2]
 :cli!:
 :context: mtv
 
+include::modules/retrieving-vmware-moref.adoc[leveloffset=+2]
+
 [id="migrating-virtual-machines_{context}"]
 === Migrating virtual machines
 
@@ -288,9 +290,9 @@ You can create custom rules to extend the default ruleset of the `Validation` se
 
 include::modules/about-rego-files.adoc[leveloffset=+3]
 include::modules/accessing-default-validation-rules.adoc[leveloffset=+3]
-include::modules/retrieving-validation-service-json.adoc[leveloffset=+3]
 include::modules/creating-validation-rule.adoc[leveloffset=+3]
 include::modules/updating-validation-rules-version.adoc[leveloffset=+3]
+include::modules/retrieving-validation-service-json.adoc[leveloffset=+2]
 
 [id="adding-hooks-migration-plan-using-api"]
 === Adding hooks to a migration plan

--- a/documentation/modules/new-migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/new-migrating-virtual-machines-cli.adoc
@@ -2,19 +2,19 @@
 //
 // * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="new-migrating-virtual-machines-cli_{context}"]
 
 ifdef::vmware[]
 = Migrating from a VMware vSphere source provider
 
-You can migrate from a VMware vSphere source provider using the CLI.
+You can migrate from a VMware vSphere source provider by using the CLI.
 
 endif::[]
 ifdef::rhv[]
 = Migrating from a {rhv-full} source provider
 
-You can migrate from a {rhv-full} ({rhv-short}) source provider using the CLI.
+You can migrate from a {rhv-full} ({rhv-short}) source provider by using the CLI.
 
 .Prerequisites
 
@@ -26,18 +26,18 @@ endif::[]
 ifdef::ova[]
 = Migrating from an Open Virtual Appliance (OVA) source provider
 
-You can migrate from Open Virtual Appliance (OVA) files that were created by VMware vSphere as a source provider using the CLI.
+You can migrate from Open Virtual Appliance (OVA) files that were created by VMware vSphere as a source provider by using the CLI.
 
 endif::[]
 ifdef::ostack[]
 = Migrating from an {osp} source provider
 
-You can migrate from an {osp} source provider using the CLI.
+You can migrate from an {osp} source provider by using the CLI.
 endif::[]
 ifdef::cnv[]
 = Migrating from a Red Hat {virt} source provider
 
-You can use a Red Hat {virt} provider as a source provider as well as a destination provider.
+You can use a Red Hat {virt} provider as either a source provider or as a destination provider.
 endif::[]
 
 .Procedure
@@ -76,7 +76,7 @@ EOF
 <3> Specify the password of the vCenter user or the ESX/ESXi user.
 <4> Specify `"true"` to skip certificate verification, specify `"false"` to verify the certificate. Defaults to `"false"` if not specified. Skipping certificate verification proceeds with an insecure migration and then the certificate is not required. Insecure migration means that the transferred data is sent over an insecure connection and potentially sensitive data could be exposed.
 <5> When this field is not set and 'skip certificate verification' is disabled, {project-short} attempts to use the system CA.
-<6>  Specify the API endpoint URL of the vCenter or the ESX/ESX, for example, `https://<vCenter_host>/sdk`.
+<6>  Specify the API endpoint URL of the vCenter or the ESX/ESXi, for example, `https://<vCenter_host>/sdk`.
 endif::[]
 ifdef::rhv[]
 +
@@ -353,7 +353,7 @@ spec:
 EOF
 ----
 <1> Specify the name of the VMware vSphere `Provider` CR.
-<2> Specify the Managed Object Reference (MoRef) of the VMware vSphere host.
+<2> Specify the Managed Object Reference (moRef) of the VMware vSphere host. To retrieve the moRef, see xref:retrieving-vmware-moref_mtv[Retrieving a VMware vSphere moRef].
 <3> Specify the IP address of the VMware vSphere migration network.
 
 [start=4]
@@ -392,7 +392,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `pod` and `multus`.
-<2> You can use either the `id` _or_ the `name` parameter to specify the source network. For `id`, specify the VMware vSphere network Managed Object Reference (MoRef).
+<2> You can use either the `id` _or_ the `name` parameter to specify the source network. For `id`, specify the VMware vSphere network Managed Object Reference (moRef). To retrieve the moRef, see xref:retrieving-vmware-moref_mtv[Retrieving a VMware vSphere moRef].
 <3> Specify a network attachment definition for each additional {virt} network.
 <4> Required only when `type` is `multus`. Specify the namespace of the {virt} network attachment definition.
 endif::[]
@@ -593,7 +593,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `ReadWriteOnce` and `ReadWriteMany`.
-<2> Specify the VMware vSphere data storage MoRef. For example, `f2737930-b567-451a-9ceb-2887f6207009`.
+<2> Specify the VMware vSphere datastore moRef. For example, `f2737930-b567-451a-9ceb-2887f6207009`. To retrieve the moRef, see xref:retrieving-vmware-moref_mtv[Retrieving a VMware vSphere moRef].
 endif::[]
 
 ifdef::rhv[]
@@ -746,7 +746,7 @@ EOF
 +
 where:
 +
-`playbook` refers to an optional Base64-encoded Ansible playbook. If you specify a playbook, the `image` must be `hook-runner`.
+`playbook` refers to an optional Base64-encoded Ansible Playbook. If you specify a playbook, the `image` must be `hook-runner`.
 +
 [NOTE]
 ====
@@ -800,7 +800,7 @@ EOF
 <6> Specify a storage mapping even if the VMs to be migrated are not assigned with disk images. The mapping can be empty in this case.
 <7> Specify the name of the `StorageMap` CR.
 <8> You can use either the `id` _or_ the `name` parameter to specify the source VMs. +
-<9> Specify the VMware vSphere VM MoRef.
+<9> Specify the VMware vSphere VM moRef. To retrieve the moRef, see xref:retrieving-vmware-moref_mtv[Retrieving a VMware vSphere moRef].
 <10> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
 <11> Specify the name of the `Hook` CR.
 <12> Allowed values are `PreHook`, before the migration plan starts, or `PostHook`, after the migration is complete.

--- a/documentation/modules/retrieving-validation-service-json.adoc
+++ b/documentation/modules/retrieving-validation-service-json.adoc
@@ -2,7 +2,7 @@
 //
 // * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="retrieving-validation-service-json_{context}"]
 = Retrieving the Inventory service JSON
 
@@ -63,7 +63,7 @@ $ curl -H "Authorization: Bearer $TOKEN"  https://<inventory_service_route>/prov
 ----
 +
 .Example output
-[source,yaml,subs="attributes+"]]
+[source,yaml,subs="attributes+"]
 ----
 {
     "input": {

--- a/documentation/modules/retrieving-vmware-moref.adoc
+++ b/documentation/modules/retrieving-vmware-moref.adoc
@@ -1,0 +1,80 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="retrieving-vmware-moref_{context}"]
+= Retrieving a VMware vSphere moRef
+
+When you migrate VMs with a VMware vSphere source provider using {project-first} from the CLI, you need to know the managed object reference (moRef) of certain entities in vSphere, such as datastores, networks, and VMs.
+
+You can retrieve the moRef of one or more vSphere entities from the Inventory service. You can then use each moRef as a reference for retrieving the moRef of another entity.
+
+.Procedure
+
+. Retrieve the routes for the project:
++
+[source,terminal]
+----
+oc get route -n openshift-mtv
+----
+
+. Retrieve the `Inventory` service route:
++
+[source,terminal,subs="attributes+"]
+----
+$ {oc} get route <inventory_service> -n {namespace}
+----
+
+. Retrieve the access token:
++
+[source,terminal]
+----
+$ TOKEN=$(oc whoami -t)
+----
+
+. Retrieve the moRef of a VMware vSphere provider:
++
+[source,terminal]
+----
+$ curl -H "Authorization: Bearer $TOKEN"  https://<inventory_service_route>/providers/vsphere -k
+----
+
+. Retrieve the datastores of a VMware vSphere source provider:
++
+[source,terminal]
+----
+$ curl -H "Authorization: Bearer $TOKEN"  https://<inventory_service_route>/providers/vsphere/<provider id>/datastores/ -k
+----
++
+.Example output
+[source,terminal]
+----
+[
+  {
+    "id": "datastore-11",
+    "parent": {
+      "kind": "Folder",
+      "id": "group-s5"
+    },
+    "path": "/Datacenter/datastore/v2v_general_porpuse_ISCSI_DC",
+    "revision": 46,
+    "name": "v2v_general_porpuse_ISCSI_DC",
+    "selfLink": "providers/vsphere/01278af6-e1e4-4799-b01b-d5ccc8dd0201/datastores/datastore-11"
+  },
+  {
+    "id": "datastore-730",
+    "parent": {
+      "kind": "Folder",
+      "id": "group-s5"
+    },
+    "path": "/Datacenter/datastore/f01-h27-640-SSD_2",
+    "revision": 46,
+    "name": "f01-h27-640-SSD_2",
+    "selfLink": "providers/vsphere/01278af6-e1e4-4799-b01b-d5ccc8dd0201/datastores/datastore-730"
+  },
+ ...
+----
+
+In this example, the moRef of the datastore `v2v_general_porpuse_ISCSI_DC` is `datastore-11` and the moRef of the datastore `f01-h27-640-SSD_2` is `datastore-730`.
+

--- a/documentation/modules/rhv-prerequisites.adoc
+++ b/documentation/modules/rhv-prerequisites.adoc
@@ -2,7 +2,7 @@
 //
 // * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="rhv-prerequisites_{context}"]
 = {rhv-full} prerequisites
 
@@ -23,7 +23,7 @@ You must keep the `UserRole` and `ReadOnlyAdmin` roles until the virtual machine
 ** You must use a xref:compatibility-guidelines_{context}[compatible version] of {rhv-full}.
 ** You must have the {manager} CA certificate, unless it was replaced by a third-party certificate, in which case, specify the {manager} Apache CA certificate.
 +
-You can obtain the {manager}  CA certificate by navigating to https://<engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA in a browser.
+You can obtain the {manager} CA certificate by navigating to https://<engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA in a browser.
 
 ** If you are migrating a virtual machine with a direct LUN disk, ensure that the nodes in the {virt} destination cluster that the VM is expected to run on can access the backend storage.
 


### PR DESCRIPTION
MTV 2.6.3
Resolves https://issues.redhat.com/browse/MTV-1099 for MTV 2.6.x

Based on https://github.com/kubev2v/forklift-documentation/pull/507.

Previews:
New section: https://file.emea.redhat.com/rhoch/mor_26/html-single/#retrieving-vmware-moref_mtv
Notes directing users to new section: https://file.emea.redhat.com/rhoch/mor_26/html-single/#new-migrating-virtual-machines-cli_vmware [search for "moRef"]
