### PR TITLE
NFC-enabled vmkernel NIC migration option for MTV 2.5

### DIFF
--- a/documentation/modules/migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/migrating-virtual-machines-cli.adoc
@@ -137,6 +137,8 @@ EOF
 <1> Specify the name of the VMware `Provider` CR.
 <2> Specify the managed object reference (MOR) of the VMware host.
 <3> Specify the IP address of the VMware migration network.
++
+include::snip_vmware_esxi_nfc.adoc[]
 
 . Create a `NetworkMap` manifest to map the source and destination networks:
 +

--- a/documentation/modules/selecting-migration-network-for-vmware-source-provider.adoc
+++ b/documentation/modules/selecting-migration-network-for-vmware-source-provider.adoc
@@ -10,6 +10,8 @@ You can select a migration network in the {ocp} web console for a source provide
 
 Using the default network for migration can result in poor performance because the network might not have sufficient bandwidth. This situation can have a negative effect on the source platform because the disk transfer operation might saturate the network.
 
+include::snip_vmware_esxi_nfc.adoc[]
+
 .Prerequisites
 
 * The migration network must have sufficient throughput, minimum speed of 10 Gbps, for disk transfer.

--- a/documentation/modules/snip_vmware_esxi_nfc.adoc
+++ b/documentation/modules/snip_vmware_esxi_nfc.adoc
@@ -1,0 +1,6 @@
+:_content-type: SNIPPET
+
+[NOTE]
+====
+You can also control the network from which disks are transferred from a host by using the Network File Copy (NFC) service in vSphere.
+====


### PR DESCRIPTION
MTV 2.5

Resolves https://issues.redhat.com/browse/MTV-1200 for MTV 2.5 by adding a note to the MTV UI and CLI migration procedures about configuring a host on the vmWare site, rather than via MTV.

Previews:

- https://file.emea.redhat.com/rhoch/mtv_1200_25/html-single/#adding-source-providers [see note in section 4.4.1.1.1, "Selecting a migration network for a VMware source provider"]
- https://file.emea.redhat.com/rhoch/mtv_1200_25/html-single/#new-migrating-virtual-machines-cli_vmware [see note at the end of step 3]