### PR TITLE
Migration plan limits

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -201,6 +201,8 @@ Virtual machines with guest initiated storage connections, such as Internet Smal
 This is to ensure that no issues arise due to the addition or newly migrated VM accessing this storage.
 ====
 
+include::modules/snip_plan-limits.adoc[]
+
 :mtv!:
 :context: provider
 :provider:
@@ -230,6 +232,8 @@ You can migrate virtual machines to {virt} from the command line.
 ====
 You must ensure that all xref:prerequisites_{context}[prerequisites] are met.
 ====
+
+include::modules/snip_plan-limits.adoc[]
 
 :mtv!:
 :context: cli

--- a/documentation/modules/snip_plan-limits.adoc
+++ b/documentation/modules/snip_plan-limits.adoc
@@ -1,0 +1,6 @@
+:_content-type: SNIPPET
+
+[IMPORTANT]
+====
+A plan cannot contain more than 500 VMs or 500 disks.
+====


### PR DESCRIPTION
MTV 2.6

Resolves https://issues.redhat.com/browse/MTV-1341 by adding an admonition about plan size to the instructions for migrating vms by the UI and by the CLI.

Previews:

- https://file.corp.redhat.com/rhoch/plan_limits/html-single/#creating-migration-plans-ui [Note labeled "Important"]
- https://file.corp.redhat.com/rhoch/plan_limits/html-single/#migrating-virtual-machines-from-the-command-line_mtv [Second note labeled "Important"] 

