### PR TITLE
VMware name change and static IP

### DIFF
--- a/documentation/modules/creating-migration-plan-2-6-3.adoc
+++ b/documentation/modules/creating-migration-plan-2-6-3.adoc
@@ -42,9 +42,9 @@ The *Create migration plan* pane opens. It displays the source provider's name a
 
 . VMware source providers only (All optional):
 
-* *Preserving static IPs of VMs*: By default, virtual network interface controllers (vNICs) change during the migration process. This results in vNICs that are set with a static IP in vSphere losing their IP. To avoid this by preserving static IPs of VMs, click the Edit icon next to *Preserve static IPs* and toggle the *Whether to preserve the static IPs* switch in the window that opens. Then click *Save*.
+* *Preserving static IPs of VMs*: By default, virtual network interface controllers (vNICs) change during the migration process.  As a result, vNICs that are configured with a static IP linked to the interface name in the guest VM lose their IP. To avoid this, click the Edit icon next to *Preserve static IPs* and toggle the *Whether to preserve the static IPs* switch in the window that opens. Then click *Save*.
 +
-{project-short} then issues a warning message about any VMs with a Windows operating system for which vNIC properties are missing. To retrieve any missing vNIC properties, run those VMs in vSphere in order for the vNIC properties to be reported to {project-short}.
+{project-short} then issues a warning message about any VMs for which vNIC properties are missing. To retrieve any missing vNIC properties, run those VMs in vSphere in order for the vNIC properties to be reported to {project-short}.
 
 * *Entering a list of decryption passphrases for disks encrypted using Linux Unified Key Setup (LUKS)*: To enter a list of decryption passphrases for LUKS-encrypted devices, in the *Settings* section, click the Edit icon next to *Disk decryption passphrases*, enter the passphrases, and then click *Save*. You do not need to enter the passphrases in a specific order - for each LUKS-encrypted device, {project-short} tries each passphrase until one unlocks the device.
 
@@ -66,3 +66,6 @@ To preserve the cluster-level CPU model of your {rhv-short} VMs, in the *Setting
 . If the plan is valid,
 .. You can run the plan now by clicking *Start migration*.
 .. You can run the plan later by selecting it on the *Plans for virtualization* page and following the procedure in xref:running-migration-plan_mtv[Running a migration plan].
++
+[discrete]
+include::snip_vmware-name-change.adoc[]

--- a/documentation/modules/new-migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/new-migrating-virtual-machines-cli.adoc
@@ -781,15 +781,16 @@ spec:
     storage: <6>
       name: <storage_map> <7>
       namespace: <namespace>
+  preserveStaticIPs: <8>
   targetNamespace: <target_namespace>
-  vms: <8>
-    - id: <source_vm> <9>
+  vms: <9>
+    - id: <source_vm> <10>
     - name: <source_vm>
-      hooks: <10>
+      hooks: <11>
         - hook:
             namespace: <namespace>
-            name: <hook> <11>
-          step: <step> <12>
+            name: <hook> <12>
+          step: <step> <13>
 EOF
 ----
 <1> Specify the name of the `Plan` CR.
@@ -799,11 +800,16 @@ EOF
 <5> Specify the name of the `NetworkMap` CR.
 <6> Specify a storage mapping even if the VMs to be migrated are not assigned with disk images. The mapping can be empty in this case.
 <7> Specify the name of the `StorageMap` CR.
-<8> You can use either the `id` _or_ the `name` parameter to specify the source VMs. +
-<9> Specify the VMware vSphere VM moRef. To retrieve the moRef, see xref:retrieving-vmware-moref_mtv[Retrieving a VMware vSphere moRef].
-<10> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
-<11> Specify the name of the `Hook` CR.
-<12> Allowed values are `PreHook`, before the migration plan starts, or `PostHook`, after the migration is complete.
+<8> By default, virtual network interface controllers (vNICs) change during the migration process. As a result, vNICs that are configured with a static IP linked to the interface name in the guest VM lose their IP.
+To avoid this, set `preserveStaticIPs` to `true`. {project-short} issues a warning message about any VMs for which vNIC properties are missing. To retrieve any missing vNIC properties, run those VMs in vSphere in order for the vNIC properties to be reported to {project-short}.
+<9> You can use either the `id` _or_ the `name` parameter to specify the source VMs.
+<10> Specify the VMware vSphere VM moRef. To retrieve the moRef, see xref:retrieving-vmware-moref_mtv[Retrieving a VMware vSphere moRef].
+<11> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
+<12> Specify the name of the `Hook` CR.
+<13> Allowed values are `PreHook`, before the migration plan starts, or `PostHook`, after the migration is complete.
++
+[discrete]
+include::snip_vmware-name-change.adoc[]
 endif::[]
 
 ifdef::rhv[]


### PR DESCRIPTION
MTV 2.7.0

Resolves https://issues.redhat.com/browse/MTV-1317 (in light of https://issues.redhat.com/browse/MTV-1463) by adding a note about an issue with CentOS 7.9 and VMware migrations. 

The PR also adds a label that was previously missing from the procedure to migrate VMware VMs from the CLI.

Previews:
UI procedures:

- https://file.corp.redhat.com/rhoch/vm_name_change/html-single/#creating-migration-plan-2-6-3_provider [Admonition at end]
- https://file.corp.redhat.com/rhoch/vm_name_change/html-single/#creating-migration-plan-2-6-3_vms [Admonition at end]

CLI procedure:

- https://file.corp.redhat.com/rhoch/vm_name_change/html-single/#new-migrating-virtual-machines-cli_vmware [Step 7, callout 8 and Admonition at end of `Plan` manifest]