### PR TITLE
MTV-1433: Creating source and destination providers, separated by provider

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -34,9 +34,8 @@ You can use {the-lc} {project-first} to migrate virtual machines from the follow
 * link:https://access.redhat.com/articles/6242511[Performance recommendations for migrating from VMware vSphere to OpenShift Virtualization].
 * link:https://access.redhat.com/articles/6380311[Performance recommendations for migrating from Red Hat Virtualization to OpenShift Virtualization].
 
-// cold vs warm introduction
+
 include::modules/cold-warm-migration.adoc[leveloffset=+1]
-// cold vs warm migration speed comparison
 include::modules/mtv-migration-speed-comparison.adoc[leveloffset=+2]
 
 include::modules/about-cold-warm-migration.adoc[leveloffset=+2]
@@ -46,15 +45,24 @@ include::modules/about-cold-warm-migration.adoc[leveloffset=+2]
 
 Review the following prerequisites to ensure that your environment is prepared for migration.
 
-[id="software-requirements_{context}"]
+[id="mtv-software-requirements_{context}"]
 === Software requirements
+
+{project-first} has software requirements for all providers as well as specific software requirements per provider.
+
+[id="mtv-software-requirements-all-providers_{context}"]
+==== Software requirements for all providers
 
 You must install xref:compatibility-guidelines_{context}[compatible versions] of {ocp} and {virt}.
 
 include::modules/storage-support.adoc[leveloffset=+2]
+
 include::modules/network-prerequisites.adoc[leveloffset=+2]
+
 include::modules/source-vm-prerequisites.adoc[leveloffset=+2]
+
 include::modules/rhv-prerequisites.adoc[leveloffset=+2]
+
 include::modules/openstack-prerequisites.adoc[leveloffset=+2]
 
 
@@ -82,10 +90,9 @@ include::modules/ostack-app-cred-auth.adoc[leveloffset=+4]
 include::modules/vmware-prerequisites.adoc[leveloffset=+2]
 include::modules/creating-vddk-image.adoc[leveloffset=+3]
 include::modules/increasing-nfc-memory-vmware-host.adoc[leveloffset=+3]
-
 include::modules/vddk-validator-containers.adoc[leveloffset=+3]
-
 include::modules/ova-prerequisites.adoc[leveloffset=+2]
+
 include::modules/compatibility-guidelines.adoc[leveloffset=+2]
 
 [id="installing-the-operator_{context}"]
@@ -113,14 +120,28 @@ include::modules/installing-mtv-operator.adoc[leveloffset=+2]
 include::modules/configuring-mtv-operator.adoc[leveloffset=+2]
 include::modules/max-concurrent-vms.adoc[leveloffset=+3]
 
-[id="migrating-vms-web-console_{context}"]
+[id="migrating-vms-ocp-web-console_{context}"]
 == Migrating virtual machines by using the {ocp} web console
 
-You can migrate virtual machines (VMs) by using the {ocp} web console to:
+You can migrate virtual machines (VMs) by using the {project-short} user interface, which is located in the *Migration* section of the {ocp} web console.
 
-. xref:adding-source-providers[Create source providers]
-. xref:adding-destination-providers[Create destination providers]
-. xref:creating-migration-plans-ui[Create migration plans]
+include::modules/mtv-ui.adoc[leveloffset=+2]
+include::modules/mtv-overview-page.adoc[leveloffset=+3]
+include::modules/mtv-settings.adoc[leveloffset=+3]
+
+
+[id="migrating-vms-mtv-ui_{context}"]
+=== Migrating virtual machines using the MTV user interface
+
+You can use the {project-short} user interface to migrate VMs from the following providers:
+
+* VMware vSphere
+* {rhv-full} ({rhv-short})
+* {osp}
+* Open Virtual Appliances (OVAs) that were created by VMware vSphere
+* Remote {virt} clusters
+
+For all migrations, you specify the source provider, the destination provider, and the migration plan. The specific procedures vary per provider.
 
 [IMPORTANT]
 ====
@@ -131,78 +152,89 @@ VMware only: You must have the minimal set of xref:vmware-privileges_{context}[V
 VMware only: Creating a xref:creating-vddk-image_{context}[VMware Virtual Disk Development Kit (VDDK)] image will increase migration speed.
 ====
 
-include::modules/mtv-ui.adoc[leveloffset=+2]
-include::modules/mtv-overview-page.adoc[leveloffset=+2]
-include::modules/mtv-settings.adoc[leveloffset=+2]
-
-[id="adding-providers"]
-=== Adding providers
-
-You can add source providers and destination providers for a virtual machine migration by using the {ocp} web console.
-
-[id="adding-source-providers"]
-==== Adding source providers
-
-You can use {project-short} to migrate VMs from the following source providers:
-
-* VMware vSphere
-* {rhv-full}
-* {osp}
-* Open Virtual Appliances (OVAs) that were created by VMware vSphere
-* {virt}
-
-You can add a source provider by using the {ocp} web console.
-
 :!mtv:
 :context: vmware
 :vmware:
+
+[id="migrating-vmware-ui"]
+==== Migrating virtual machines from VMware vSphere
 include::modules/adding-source-provider.adoc[leveloffset=+4]
 include::modules/selecting-migration-network-for-vmware-source-provider.adoc[leveloffset=+5]
+
 :!vmware:
+:context: dest_vwmware
+:dest_vmware:
+
+include::modules/adding-source-provider.adoc[leveloffset=+4]
+include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+4]
+:!dest_vmware:
+
+==== Migrating virtual machines from {rhv-full}
+
 :context: rhv
 :rhv:
 include::modules/adding-source-provider.adoc[leveloffset=+4]
 :!rhv:
+:context: dest_rhv
+:dest_rhv:
+include::modules/adding-source-provider.adoc[leveloffset=+4]
+include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+4]
+:!dest_rhv:
+
+
+==== Migrating virtual machines from {osp}
+
 :context: ostack
 :ostack:
 include::modules/adding-source-provider.adoc[leveloffset=+4]
 :!ostack:
+:context: dest_ostack
+:dest_ostack:
+include::modules/adding-source-provider.adoc[leveloffset=+4]
+include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+4]
+:!dest_ostack:
+
+==== Migrating virtual machines from OVA
+
 :context: ova
 :ova:
 include::modules/adding-source-provider.adoc[leveloffset=+4]
 :!ova:
+:context: dest_ova
+:dest_ova:
+include::modules/adding-source-provider.adoc[leveloffset=+4]
+include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+4]
+:!dest_ova:
+
+==== Migrating virtual machines from {virt}
+
 :context: cnv
 :cnv:
+
 include::modules/adding-source-provider.adoc[leveloffset=+4]
-:cnv!:
-:context: mtv
+:!cnv:
+:context: dest_cnv
+:dest_cnv:
 
-[id="adding-destination-providers"]
-==== Adding destination providers
-
-You can add a {virt} destination provider by using the {ocp} web console.
-
-:mtv!:
-:context: cnv2
-:cnv2:
 include::modules/adding-source-provider.adoc[leveloffset=+4]
-:cnv!:
-:context: mtv
-
 include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+4]
+
+:!dest_cnv:
+:context: mtv
+:mtv:
 
 // include::modules/creating-network-mapping.adoc[leveloffset=+2]
 // include::modules/creating-storage-mapping.adoc[leveloffset=+2]
 
-[id="creating-migration-plans-ui"]
+[id="creating-migration-plans-ui_{context}"]
 === Creating migration plans
 
 You can create a migration plan by using the {ocp} web console to specify a source provider, the virtual machines (VMs) you want to migrate, and other plan details.
 
 For your convenience, there are two procedures to create migration plans, starting with either a source provider or with specific VMs:
 
-* To start with a source provider, see xref:creating-migration-plan-2-7_provider[Creating a migration plan starting with a source provider].
-* To start with specific VMs, see xref:creating-migration-plan-2-7_vms[Creating a migration plan starting with specific VMs].
+* To start with a source provider, see xref:creating-migration-plan-2-8_provider[Creating a migration plan starting with a source provider].
+* To start with specific VMs, see xref:creating-migration-plan-2-8_vms[Creating a migration plan starting with specific VMs].
 
 [WARNING]
 ====
@@ -217,12 +249,12 @@ include::modules/snip_plan-limits.adoc[]
 :context: provider
 :provider:
 
-include::modules/creating-migration-plan-2-7.adoc[leveloffset=+3]
+include::modules/creating-migration-plan-2-8.adoc[leveloffset=+3]
 
 :provider!:
 :context: vms
 :vms:
-include::modules/creating-migration-plan-2-7.adoc[leveloffset=+3]
+include::modules/creating-migration-plan-2-8.adoc[leveloffset=+3]
 
 :vms!:
 :context: mtv
@@ -285,10 +317,6 @@ include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
 :ostack!:
 :context: ova
 :ova:
-//include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
-//:ova!:
-//:context: ostack
-//:ostack:
 include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
 :ova!:
 :context: cnv

--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -41,7 +41,6 @@ You can add an {osp} source provider by using the {ocp} web console.
 ====
 When you migrate an image-based VM from an {osp} provider, a snapshot is created for the image that is attached to the source VM and the data from the snapshot is copied over to the target VM. This means that the target VM will have the same state as that of the source VM at the time the snapshot was created.
 ====
-
 endif::[]
 ifdef::cnv[]
 = Adding a Red Hat {virt} source provider
@@ -56,9 +55,8 @@ You can migrate VMs from the cluster that {project-short} is deployed on to anot
 ====
 The {ocp} cluster version of the source provider must be 4.13 or later.
 ====
-
 endif::[]
-ifdef::cnv2[]
+ifdef::dest_vmware,dest_rhv,dest_ostack,dest_ova[]
 = Adding {a-virt} destination provider
 
 You can use a Red Hat {virt} provider as both a source provider and destination provider.
@@ -90,6 +88,7 @@ ifdef::vmware[]
 * *URL*: URL of the SDK endpoint of the vCenter on which the source VM is mounted. Ensure that the URL includes the `sdk` path, usually `/sdk`. For example, `https://vCenter-host-example.com/sdk`. If a certificate for FQDN is specified, the value of this field needs to match the FQDN in the certificate.
 * *VDDK init image*: `VDDKInitImage` path. It is strongly recommended to create a VDDK init image to accelerate migrations. For more information, see xref:../master.adoc#creating-vddk-image_mtv[Creating a VDDK image].
 
+
 +
 *Provider credentials*
 
@@ -100,6 +99,7 @@ ifdef::vmware[]
 include::snip-certificate-options.adoc[]
 
 endif::[]
+
 ifdef::rhv[]
 . Click *Red Hat Virtualization*
 . Specify the following fields:
@@ -167,7 +167,7 @@ If both *URL* and *Service account bearer token* are left blank, the local {ocp-
 +
 include::snip-certificate-options.adoc[]
 endif::[]
-ifdef::cnv2[]
+ifdef::dest_vmware,dest_rhv,dest_ostack,dest_ova,dest_cnv[]
 . Click *{virt}*.
 . Specify the following fields:
 

--- a/documentation/modules/creating-migration-plan-2-8.adoc
+++ b/documentation/modules/creating-migration-plan-2-8.adoc
@@ -1,7 +1,7 @@
 // * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="creating-migration-plan-2-7_{context}"]
+[id="creating-migration-plan-2-8_{context}"]
 ifdef::provider[]
 = Creating a migration plan starting with a source provider
 
@@ -38,31 +38,23 @@ The *Create migration plan* pane opens. It displays the source provider's name a
 . Click *Add mapping* to edit a suggested network mapping or a storage mapping, or to add one or more additional mappings.
 . Click *Create migration plan*.
 +
-{project-short} validates the migration plan, and the *Plan details* page opens, indicating whether the plan is ready for use or contains an error. The details of the plan are listed, and you can edit the items you filled in on the previous page. If you make any changes, {project-short} validates the plan again.
+{project-short} validates the migration plan and the *Plan details* page opens, indicating whether the plan is ready for use or contains an error. The details of the plan are listed, and you can edit the items you filled in on the previous page. If you make any changes, {project-short} validates the plan again.
 
 . VMware source providers only (All optional):
 
-* *Preserving static IPs of VMs*: By default, virtual network interface controllers (vNICs) change during the migration process. This results in vNICs that are set with a static IP in vSphere losing their IP. To avoid this by preserving static IPs of VMs, click the Edit icon next to *Preserve static IPs* and toggle the *Whether to preserve the static IPs* switch in the window that opens. Then click *Save*.
+* *Preserving static IPs of VMs*: By default, virtual network interface controllers (vNICs) change during the migration process.  As a result, vNICs that are configured with a static IP linked to the interface name in the guest VM lose their IP. To avoid this, click the Edit icon next to *Preserve static IPs* and toggle the *Whether to preserve the static IPs* switch in the window that opens. Then click *Save*.
 +
-{project-short} then issues a warning message about any VMs with a Windows operating system for which vNIC properties are missing. To retrieve any missing vNIC properties, run those VMs in vSphere in order for the vNIC properties to be reported to {project-short}.
+{project-short} then issues a warning message about any VMs for which vNIC properties are missing. To retrieve any missing vNIC properties, run those VMs in vSphere in order for the vNIC properties to be reported to {project-short}.
 
-* *Entering a list of decryption passphrases for disks encrypted using Linux Unified Key Setup (LUKS)*: To enter a list of decryption passphrases for LUKS-encrypted devices, in the *Settings* section, click the Edit icon next to *Disk decryption passphrases*, enter the passphrases, and then click *Save*.
-+
-You do not need to enter the passphrases in a specific order. For each LUKS-encrypted device, {project-short} tries each passphrase until one unlocks the device.
+* *Entering a list of decryption passphrases for disks encrypted using Linux Unified Key Setup (LUKS)*: To enter a list of decryption passphrases for LUKS-encrypted devices, in the *Settings* section, click the Edit icon next to *Disk decryption passphrases*, enter the passphrases, and then click *Save*. You do not need to enter the passphrases in a specific order - for each LUKS-encrypted device, {project-short} tries each passphrase until one unlocks the device.
 
 * *Specifying a root device*: Applies to multi-boot VM migrations only. By default, {project-short} uses the first bootable device detected as the root device.
 +
-To specify a different root device, in the *Settings* section, click the Edit icon next to *Root device* and select a device from the list of commonly used options, or enter a device in the text box.
+To specify a different root device, in the *Settings* section, click the Edit icon next to *Root device* and choose a device from the list of commonly used options, or enter a device in the text box.
 +
 {project-short} uses the following format for disk location: `/dev/sd<disk_identifier><disk_partition>`. For example, if the second disk is the root device and the operating system is on the disk's second partition, the format would be: `/dev/sdb2`. After you enter the boot device, click *Save*.
 +
-If the conversation fails because the boot device is incorrect, review the conversation pod logs for the correct information.
-
-* *{ocp-short} transfer network*: You can configure an {ocp-short} network in the {ocp-short} web console by clicking *Networking > NetworkAttachmentDefinitions*.
-+
-To learn more about the different types of networks {ocp-short} supports, see link:https://docs.openshift.com/container-platform/{ocp-version}/networking/multiple_networks/understanding-multiple-networks.html#additional-networks-provided_understanding-multiple-networks[Additional Networks in OpenShift Container Platform].
-+
-If you want to adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network. For more information see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
+If the conversion fails because the boot device provided is incorrect, it is possible to get the correct information by looking at the conversion pod logs.
 
 . {rhv-short} source providers only (Optional):
 
@@ -74,3 +66,5 @@ To preserve the cluster-level CPU model of your {rhv-short} VMs, in the *Setting
 . If the plan is valid,
 .. You can run the plan now by clicking *Start migration*.
 .. You can run the plan later by selecting it on the *Plans for virtualization* page and following the procedure in xref:running-migration-plan_mtv[Running a migration plan].
++
+include::snip_vmware-name-change.adoc[]

--- a/documentation/modules/network-prerequisites.adoc
+++ b/documentation/modules/network-prerequisites.adoc
@@ -17,6 +17,8 @@ The following prerequisites apply to all migrations:
 
 The firewalls must enable traffic over the following ports:
 
+// ANDY: The comments are for later, when I separate the ports by vendor.
+// ifdef::wmware[]
 [cols="1,1,1,1,2a",options="header"]
 .Network ports required for migrating from VMware vSphere
 |===
@@ -42,7 +44,9 @@ Disk transfer authentication
 |VMware ESXi hosts
 |Disk transfer data copy
 |===
+// endif::[]
 
+// ifdef::rhv[]
 [cols="1,1,1,1,2a",options="header"]
 .Network ports required for migrating from {rhv-full}
 |===
@@ -68,3 +72,4 @@ Disk transfer authentication
 |{rhv-short} hosts
 |Disk transfer data copy
 |===
+// endif::[]

--- a/documentation/modules/snip-mtu-value.adoc
+++ b/documentation/modules/snip-mtu-value.adoc
@@ -2,5 +2,5 @@
 
 [NOTE]
 ====
-If you input any value of maximum transmission unit (MTU) besides the default value in your migration network, you must also input the same value in the {ocp-short} transfer network that you use. For more information about the {ocp-short} transfer network, see xref:creating-migration-plan-2-7_provider[Creating a migration plan starting with a source provider] or xref:creating-migration-plan-2-7_vms[Creating a migration plan starting with specific VMs].
+If you input any value of maximum transmission unit (MTU) besides the default value in your migration network, you must also input the same value in the {ocp-short} transfer network that you use. For more information about the {ocp-short} transfer network, see xref:creating-migration-plan-2-8_provider[Creating a migration plan starting with a source provider] or xref:creating-migration-plan-2-8_vms[Creating a migration plan starting with specific VMs].
 ====

--- a/documentation/modules/storage-support.adoc
+++ b/documentation/modules/storage-support.adoc
@@ -6,7 +6,7 @@
 [id="about-storage_{context}"]
 = Storage support and default modes
 
-{project-short} uses the following default volume and access modes for supported storage.
+{project-first} uses the following default volume and access modes for supported storage.
 
 .Default volume and access modes
 [cols="1,1,1", options="header"]
@@ -79,7 +79,7 @@ If your migration uses block storage and persistent volumes created with an EXT4
 
 [NOTE]
 ====
-When migrating from OpenStack or running a cold-migration from RHV to the OCP cluster that MTV is deployed on, the migration allocates persistent volumes without CDI. In these cases, you might need to adjust the file system overhead.
+When you migrate from {osp}, or when you run a cold migration from {rhv-full} to the {ocp} cluster that {project-short} is deployed on, the migration allocates persistent volumes without CDI. In these cases, you might need to adjust the file system overhead.
 
 If the configured file system overhead, which has a default value of 10%, is too low, the disk transfer will fail due to lack of space. In such a case, you would want to increase the file system overhead.
 
@@ -87,3 +87,6 @@ In some cases, however, you might want to decrease the file system overhead to r
 
 You can change the file system overhead by changing the value of the `controller_filesystem_overhead` in the `spec` portion of the `forklift-controller` CR, as described in xref:configuring-mtv-operator_{context}[Configuring the MTV Operator].
 ====
+
+
+


### PR DESCRIPTION
MTV 2.8 

Partially resolves https://issues.redhat.com/browse/MTV-1433

Previews: 

- https://file.corp.redhat.com/rhoch/WIP_section_4/html-single/#migrating-vms-ocp-web-console_mtv  [new intro to section]
- https://file.corp.redhat.com/rhoch/WIP_section_4/html-single/#migrating-vms-mtv-ui_mtv [slightly changed intro]
- https://file.corp.redhat.com/rhoch/WIP_section_4/html-single/#migrating-vmware-ui [VMware section, all titles my abbreviations]
- https://file.corp.redhat.com/rhoch/WIP_section_4/html-single/#migrating_virtual_machines_from_rhv [RHV section]
- https://file.corp.redhat.com/rhoch/WIP_section_4/html-single/#migrating_virtual_machines_from_ostack [OpenStack]
- https://file.corp.redhat.com/rhoch/WIP_section_4/html-single/#migrating_virtual_machines_from_ova [OVA]
- https://file.corp.redhat.com/rhoch/WIP_section_4/html-single/#migrating_virtual_machines_from_cnv [CNV]

In this PR, I have grouped the procedures for creating source and a destination provider per vendor.  You can ignore creating-migration-plans-2.8.adoc. I work with it in https://github.com/kubev2v/forklift-documentation/pull/585 .
