### PR TITLE
Getting logs from MTV UI

### DIFF
--- a/documentation/modules/migration-plan-options-ui.adoc
+++ b/documentation/modules/migration-plan-options-ui.adoc
@@ -8,30 +8,37 @@
 
 On the *Plans for virtualization* page of the {ocp} web console, you can click the {kebab} beside a migration plan to access the following options:
 
-* *Get logs*: Retrieves the logs of a migration. When you click *Get logs*, a confirmation window opens. After you click *Get logs* in the window, wait until *Get logs* changes to *Download logs* and then click the button to download the logs.
-* *Edit*: Edit the details of a migration plan. You cannot edit a migration plan while it is running or after it has completed successfully.
-* *Duplicate*: Create a new migration plan with the same virtual machines (VMs), parameters, mappings, and hooks as an existing plan. You can use this feature for the following tasks:
+* *Edit Plan*: Edit the details of a migration plan. If the plan is running or has completed successfully, you cannot edit the following options:
+
+** All properties on the *Settings* section of the *Plan details* page. For example, warm or cold migration, target namespace, and preserved static IPs.
+** The plan's mapping on the *Mappings* tab.
+** The hooks listed on the *Hooks* tab.
+
+* *Start migration*: Active only if relevant.
+* *Restart migration*: Restart a migration that was interrupted. Before choosing this option, make sure there are no error messages. If there are, you need to edit the plan.
+* *Cutover*: Warm migrations only. Active only if relevant. Clicking *Cutover* opens the *Cutover* window, which supports the following options:
+
+** *Set cutover*: Set the date and time for a cutover.
+** *Remove cutover*: Cancel a scheduled cutover. Active only if relevant.
+
+* *Duplicate Plan*: Create a new migration plan with the same virtual machines (VMs), parameters, mappings, and hooks as an existing plan. You can use this feature for the following tasks:
 
 ** Migrate VMs to a different namespace.
 ** Edit an archived migration plan.
 ** Edit a migration plan with a different status, for example, failed, canceled, running, critical, or ready.
 
-* *Archive*: Delete the logs, history, and metadata of a migration plan. The plan cannot be edited or restarted. It can only be viewed.
+* *Archive Plan*: Delete the logs, history, and metadata of a migration plan. The plan cannot be edited or restarted. It can only be viewed, duplicated, or deleted.
 +
 [NOTE]
 ====
-The *Archive* option is irreversible. However, you can duplicate an archived plan.
+*Archive Plan* is irreversible. However, you can duplicate an archived plan.
 ====
 
-* *Delete*: Permanently remove a migration plan. You cannot delete a running migration plan.
+* *Delete Plan*: Permanently remove a migration plan. You cannot delete a running migration plan.
 +
 [NOTE]
 ====
-The *Delete* option is irreversible.
+*Delete Plan* is irreversible.
 
-Deleting a migration plan does not remove temporary resources such as `importer` pods, `conversion` pods, config maps, secrets, failed VMs, and data volumes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2018974[*BZ#2018974*]) You must archive a migration plan before deleting it in order to clean up the temporary resources.
+Deleting a migration plan does not remove temporary resources. To remove temporary resources, archive the plan first before deleting it.
 ====
-
-* *View details*: Display the details of a migration plan.
-* *Restart*: Restart a failed or canceled migration plan.
-* *Cancel scheduled cutover*: Cancel a scheduled cutover migration for a warm migration plan.

--- a/documentation/modules/running-migration-plan.adoc
+++ b/documentation/modules/running-migration-plan.adoc
@@ -16,31 +16,53 @@ You can run a migration plan and view its progress in the {ocp} web console.
 
 . In the {ocp} web console, click *Migration* -> *Plans for virtualization*.
 +
-The *Plans* list displays the source and target providers, the number of virtual machines (VMs) being migrated, the status, and the description of each plan.
+The *Plans* list displays the source and target providers, the number of virtual machines (VMs) being migrated, the status, the date that the migration started, and the description of each plan.
 
 . Click *Start* beside a migration plan to start the migration.
 . Click *Start* in the confirmation window that opens.
 +
-The *Migration details by VM* screen opens, displaying the migration's progress
+The plan's *Status* changes to *Running*, and the migration's progress is displayed.
 +
 Warm migration only:
 
 * The precopy stage starts.
 * Click *Cutover* to complete the migration.
 
-. If the migration fails:
-.. Click *Get logs* to retrieve the migration logs.
-.. Click *Get logs* in the confirmation window that opens.
-.. Wait until *Get logs*  changes to *Download logs* and then click the button to download the logs.
+. Optional: Click the links in the migration's *Status* to see its overall status and the status of each VM:
 
-. Click a migration's *Status*, whether it failed or succeeded or is still ongoing, to view the details of the migration.
+** The link on the left indicates whether the migration failed, succeeded, or is ongoing. It also reports the number of VMs whose migration succeeded, failed, or was canceled.
+** The link on the right opens the *Virtual Machines* tab of the *Plan Details* page. For each VM, the tab displays the following data:
+
+*** The name of the VM
+*** The start and end times of the migration
+*** The amount of data copied
+*** A progress pipeline for the VM's migration
 +
-The *Migration details by VM* screen opens, displaying the start and end times of the migration, the amount of data copied, and a progress pipeline for each VM being migrated.
-. Expand an individual VM to view its steps and the elapsed time and state of each step.
-
-
 [WARNING]
 ====
 vMotion, including svMotion, and relocation must be disabled for VMs that are being imported to avoid data corruption.
-// Some backup solutions explicitly prevent vMotion, storage vMotion, and relocation during backups by adding an entry to the `VPX_DISABLED_METHODS` table in vCenter.
 ====
+
+. Optional: To view your migration's logs, either as it is running or after it is completed, perform the following actions:
+
+.. Click the *Virtual Machines* tab.
+.. Click the arrow (*>*) to the left of the virtual machine whose migration progress you want to check.
++
+The VM's details are displayed.
++
+.. In the *Pods* section, in the *Pod links* column, click the *Logs* link.
++
+The *Logs* tab opens.
++
+[NOTE]
+====
+Logs are not always available. The following are common reasons for logs not being available:
+
+* The migration is from {virt} to {virt}. In this case, `virt-v2v` is not involved, so no pod is required.
+* No pod was created.
+* The pod was deleted.
+* The migration failed before running the pod.
+====
+
+.. To see the raw logs, click the *Raw* link.
+.. To download the logs, click the *Download* link.


### PR DESCRIPTION
MTV 2.7

Resolves https://issues.redhat.com/browse/MTV-808 by updating the description of how to view and download logs from the UI.
Also updates the descriptions of running migration plans and of plan options.
Previews:

-  https://file.corp.redhat.com/rhoch/get_logs_ui/html-single/#running-migration-plan_mtv [Running migration plans, includes getting logs from the Ui]
- https://file.corp.redhat.com/rhoch/get_logs_ui/html-single/#migration-plan-options-ui_mtv [Plan options]
 
