### PR TITLE
Note about qemu-guest-agent for VM migrations

### DIFF
--- a/documentation/modules/about-cold-warm-migration.adoc
+++ b/documentation/modules/about-cold-warm-migration.adoc
@@ -20,6 +20,11 @@
 
 Cold migration is the default migration type. The source virtual machines are shut down while the data is copied.
 
+[NOTE]
+====
+include::snip_qemu-guest-agent.adoc[]
+====
+
 [id="warm-migration_{context}"]
 == Warm migration
 

--- a/documentation/modules/snip_qemu-guest-agent.adoc
+++ b/documentation/modules/snip_qemu-guest-agent.adoc
@@ -1,0 +1,7 @@
+:_content-type: SNIPPET
+
+VMware only: In cold migrations, in situations in which a package manager cannot be used during the migration, {project-short} does not install the `qemu-guest-agent` daemon on the migrated VMs. This has some impact on the functionality of the migrated VMs, but overall, they are still expected to function.
+
+To enable {project-short} to automatically install `qemu-guest-agent` on the migrated VMs, ensure that your package manager can install the daemon during the first boot of the VM after migration.
+
+If that is not possible, use your preferred automated or manual procedure to install `qemu-guest-agent` manually.


### PR DESCRIPTION
MTV 2.7

Resolves https://issues.redhat.com/browse/MTV-491 by adding a note about the `qemu-guest-agent ` daemon not being installed on some VMware migrations.

Preview: https://file.corp.redhat.com/rhoch/qemu_guest_agent/html-single/#cold-migration_mtv [note at end of "Cold migration".] 