### PR TITLE
MTV-1608: Missing permissions not correctly applied on VMware resources

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -239,6 +239,7 @@ include::modules/snip_plan-limits.adoc[]
 :mtv!:
 :context: cli
 include::modules/non-admin-permissions-for-ui.adoc[leveloffset=+2]
+include::modules/snip_vmware-permissions.adoc[]
 :cli!:
 :context: mtv
 

--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -258,10 +258,12 @@ You must specify both a name and a namespace for namespace-scoped CRs.
 To migrate to or from an {ocp-short} cluster that is different from the one the migration plan is defined on, you must have an {virt} service account token with `cluster-admin` privileges.
 ====
 
+
 :mtv!:
 :context: vmware
 :vmware:
 include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
+include::modules/snip_vmware-permissions.adoc[]
 :vmware!:
 :context: rhv
 :rhv:

--- a/documentation/modules/snip_vmware-permissions.adoc
+++ b/documentation/modules/snip_vmware-permissions.adoc
@@ -7,5 +7,5 @@ There is an issue with the `forklift-controller` consistently failing to reconci
 
 In {project-short}, you need to add permissions at the datacenter level, which includes storage, networks, switches, and so on, which are used by the VM. You must then propagate the permissions to the child elements.
 
-If you do want to add this level of permissions, you must manually add the permissions to each object on the VM host required.
+If you do not want to add this level of permissions, you must manually add the permissions to each object on the VM host required.
 ====

--- a/documentation/modules/snip_vmware-permissions.adoc
+++ b/documentation/modules/snip_vmware-permissions.adoc
@@ -1,0 +1,11 @@
+:_content-type: SNIPPET
+
+[IMPORTANT]
+.`forklift-controller` consistently failing to reconcile a plan, and returning an HTTP 500 error
+====
+There is an issue with the `forklift-controller` consistently failing to reconcile a Migration Plan, and subsequently returning an HTTP 500 error. This issue is caused when you specify the user permissions only on the virtual machine (VM).
+
+In {project-short}, you need to add permissions at the datacenter level, which includes storage, networks, switches, and so on, which are used by the VM. You must then propagate the permissions to the child elements.
+
+If you do want to add this level of permissions, you must manually add the permissions to each object on the VM host required.
+====


### PR DESCRIPTION
### JIRA

* [MTV-1608](https://issues.redhat.com/browse/MTV-1608)

### PREVIEW

* [Migrating from a VMware vSphere source provider](https://anarnold97.github.io/MTA-Preview/MTV/MTV-1608-Missing-permissions.html#new-migrating-virtual-machines-cli_vmware)

* [Permissions needed by non-administrators to work with migration plan components](https://anarnold97.github.io/MTA-Preview/MTV/MTV-1608-Missing-permissions.html#non-admin-permissions_cli) 

| Admonition |
| ----------------- |
| ![image](https://github.com/user-attachments/assets/3fd9bd14-9114-4596-bc4c-d178c20b937b) |