### PR TITLE
MTV-1211 Max concurrent virtual machine migrations

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -105,7 +105,7 @@ include::modules/installing-mtv-operator.adoc[leveloffset=+2]
 :mtv:
 
 include::modules/configuring-mtv-operator.adoc[leveloffset=+2]
-
+include::modules/max-concurrent-vms.adoc[leveloffset=+3]
 
 [id="migrating-vms-web-console_{context}"]
 == Migrating virtual machines by using the {ocp} web console

--- a/documentation/modules/configuring-mtv-operator.adoc
+++ b/documentation/modules/configuring-mtv-operator.adoc
@@ -8,7 +8,7 @@
 
 You can configure all of the following settings of the {operator-name} by modifying the `ForkliftController` CR, or in the *Settings* section of the *Overview* page, unless otherwise indicated.
 
-* Maximum number of virtual machines (VMs) per plan that can be migrated simultaneously.
+* Maximum number of virtual machines (VMs) or disks per plan that {project-first} can migrate simultaneously.
 * How long `must gather` reports are retained before being automatically deleted.
 * CPU limit allocated to the main controller container.
 * Memory limit allocated to the main controller container.
@@ -24,6 +24,7 @@ The procedure for configuring these settings using the user interface is present
 .Procedure
 
 * Change a parameter's value in  the `spec` portion of the `ForkliftController` CR by adding the label and value as follows:
++
 [source, YAML]
 ----
 spec:
@@ -37,7 +38,19 @@ spec:
 |Label |Description |Default value
 
 |`controller_max_vm_inflight`
-|The maximum number of VMs per plan that can be migrated simultaneously.
+a|Varies with provider as follows:
+
+* For all migrations except OVA or VMware migrations: The maximum number of disks that {project-short} can transfer simultaneously.
+* For OVA migrations: The maximum number of VMs that {project-short} can migrate simultaneously.
+*  For VMware migrations, the label has the following meanings:
+** Cold migration:
+
+*** To local {virt}: VMs for each ESXi host that can migrate simultaneously.
+*** To remote {virt}: Disks for each ESXi host that can migrate simultaneously.
+
+** Warm migration: Disks for each ESXi host that can migrate simultaneously.
++
+See xref:max-concurrent-vms_{context}[Configuring the controller_max_vm_inflight label] for a detailed explanation of this label.
 |`20`
 
 |`must_gather_api_cleanup_max_age`

--- a/documentation/modules/max-concurrent-vms.adoc
+++ b/documentation/modules/max-concurrent-vms.adoc
@@ -1,0 +1,27 @@
+
+// Module included in the following assemblies:
+//
+// * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+
+:_content-type: PROCEDURE
+[id="max-concurrent-vms_{context}"]
+= Configuring the controller_max_vm_inflight label
+
+The meaning of the `controller_max_vm_inflight` label, which is shown in the UI as *Max concurrent virtual machine migrations*, varies by the source provider of the migration
+
+* For all migrations except OVA or VMware migrations, the label specifies the maximum number of _disks_ that {project-first} can transfer simultaneously. In these migrations, {project-short} migrates the disks in parallel. This means that if the combined number of disks that you want to migrate is greater than the value of the setting, additional disks must wait until the queue is free, without regard for whether a VM has finished migrating.
++
+For example, if the value of the label is 15, and VM A has 5 disks, VM B has 5 disks, and VM C has 6 disks; all the disks except for the 16th disk start migrating at the same time. Once any of them has migrated, the 16th disk can be migrated, even though not all the disks on VM A and the disks on VM B have finished migrating.
+
+* For OVA migrations, the label specifies the maximum number of _VMs_ that {project-short} can migrate simultaneously, meaning that all additional disks must wait until at least one VM has been completely migrated.
++
+For example, if the value of the label is 2, and VM A has 5 disks, VM B has 5 disks, and VM C has 6 disks. All the disks on VM C must wait to migrate until either all the disks on VM A or on VM B finish migrating.
+
+* For VMware migrations, the label has the following meanings:
+
+** Cold migration:
+
+*** To local {virt}: VMs for each ESXi host that can migrate simultaneously.
+*** To remote {virt}: Disks for each ESXi host that can migrate simultaneously.
+
+** Warm migration: Disks for each ESXi host that can migrate simultaneously.

--- a/documentation/modules/mtv-settings.adoc
+++ b/documentation/modules/mtv-settings.adoc
@@ -14,27 +14,39 @@ If you have Administrator privileges, you can access the *Overview* page and cha
 |Setting |Description |Default value
 
 |Max concurrent virtual machine migrations
-|The maximum number of VMs per plan that can be migrated simultaneously
+a|Varies with provider as follows:
+
+* For all migrations except OVA or VMware migrations: The maximum number of disks that {project-short} can transfer simultaneously.
+* For OVA migrations: The maximum number of VMs that {project-short} can migrate simultaneously.
+*  For VMware migrations, the setting has the following meanings::
+** Cold migration:
+
+*** To local {virt}: VMs for each ESXi host that can migrate simultaneously.
+*** To remote {virt}: Disks for each ESXi host that can migrate simultaneously.
+
+** Warm migration: Disks for each ESXi host that can migrate simultaneously.
++
+See xref:max-concurrent-vms_{context}[Configuring the controller_max_vm_inflight label] for a detailed explanation of this setting.
 |20
 
 |Must gather cleanup after (hours)
-|The duration for retaining `must gather` reports before they are automatically deleted
+|The duration for retaining `must gather` reports before they are automatically deleted.
 |Disabled
 
 |Controller main container CPU limit
-|The CPU limit allocated to the main controller container
+|The CPU limit allocated to the main controller container.
 |500 m
 
 |Controller main container Memory limit
-|The memory limit allocated to the main controller container
+|The memory limit allocated to the main controller container.
 |800 Mi
 
 |Precopy internal (minutes)
-|The interval at which a new snapshot is requested before initiating a warm migration
+|The interval at which a new snapshot is requested before initiating a warm migration.
 |60
 
 |Snapshot polling interval (seconds)
-|The frequency with which the system checks the status of snapshot creation or removal during a warm migration
+|The frequency with which the system checks the status of snapshot creation or removal during a warm migration.
 |10
 |===
 
@@ -44,3 +56,4 @@ If you have Administrator privileges, you can access the *Overview* page and cha
 . In the *Settings* list, click the Edit icon of the setting you want to change.
 . Choose a setting from the list.
 . Click *Save*.
+


### PR DESCRIPTION
MTV 2.7

Resolves https://issues.redhat.com/browse/MTV-1211 by adding information about `controller_max_vm_inflight` (shown in the UI as *Max concurrent virtual machine migrations*).

Previews:

- https://file.corp.redhat.com/rhoch/max_concur_vm/html-single/#configuring-mtv-operator_mtv  [first bullet in list and first item in Table 3.1]
- https://file.corp.redhat.com/rhoch/max_concur_vm/html-single/#max-concurrent-vms_mtv [new section]
- https://file.corp.redhat.com/rhoch/max_concur_vm/html-single/#mtv-settings_mtv [first item in Table 4.1]