### PR TITLE
MTV-1648: MTV 2.7.4 attributes

### DIFF
--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -17,7 +17,7 @@
 :project-short: MTV
 :project-first: {project-full} ({project-short})
 :project-version: 2.7
-:project-z-version: 2.7.3
+:project-z-version: 2.7.4
 :the: The
 :the-lc: the
 :virt: OpenShift Virtualization


### PR DESCRIPTION
### JIRA

* [MTV-1648](https://issues.redhat.com/browse/MTV-1648)

    MTV z-attribute updated from `2.7.3` to `2.7.4`:
    
    `:project-z-version: 2.7.4`

### PREVIEW

* [Software compatibility guidelines](https://anarnold97.github.io/MTA-Preview/MTV/mtv-2-7-4-attributes.html#compatibility-guidelines_mtv)

![image](https://github.com/user-attachments/assets/01a3a262-47f7-4375-8eac-6b014edfd840)
