### PR TITLE
MTV-1433: Minor changes to migration from CLI section

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -66,7 +66,7 @@ include::modules/openstack-prerequisites.adoc[leveloffset=+2]
 * Token authentication
 * Application credential authentication
 
-You can use these methods to migrate virtual machines with {osp} source providers using the CLI the same way you migrate other virtual machines, except for how you prepare the `Secret` manifest.
+You can use these methods to migrate virtual machines with {osp} source providers using the command-line interface (CLI) the same way you migrate other virtual machines, except for how you prepare the `Secret` manifest.
 
 :!mtv:
 :context: ostack
@@ -91,7 +91,7 @@ include::modules/compatibility-guidelines.adoc[leveloffset=+2]
 [id="installing-the-operator_{context}"]
 == Installing and configuring the {operator-name}
 
-You can install the {operator-name} by using the {ocp} web console or the command line interface (CLI).
+You can install the {operator-name} by using the {ocp} web console or the command-line interface (CLI).
 
 In {project-first} version 2.4 and later, the {operator-name} includes the {project-short} plugin for the {ocp} web console.
 
@@ -243,21 +243,18 @@ You can migrate virtual machines to {virt} from the command line.
 You must ensure that all xref:prerequisites_{context}[prerequisites] are met.
 ====
 
-include::modules/snip_plan-limits.adoc[]
-
 :mtv!:
 :context: cli
 include::modules/non-admin-permissions-for-ui.adoc[leveloffset=+2]
-include::modules/snip_vmware-permissions.adoc[]
 :cli!:
 :context: mtv
 
-include::modules/retrieving-vmware-moref.adoc[leveloffset=+2]
+
 
 [id="migrating-virtual-machines_{context}"]
 === Migrating virtual machines
 
-You migrate virtual machines (VMs) from the command line (CLI) by creating {project-short} custom resources (CRs). The CRs and the migration procedure vary by source provider.
+You migrate virtual machines (VMs) using the command-line interface (CLI) by creating {project-short} custom resources (CRs). The CRs and the migration procedure vary by source provider.
 
 [IMPORTANT]
 ====
@@ -272,33 +269,35 @@ To migrate to or from an {ocp-short} cluster that is different from the one the 
 :mtv!:
 :context: vmware
 :vmware:
+
 include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
+// Do we want this snippet here?
 include::modules/snip_vmware-permissions.adoc[]
+include::modules/retrieving-vmware-moref.adoc[leveloffset=+4]
+include::modules/canceling-migration-cli.adoc[leveloffset=+4]
 :vmware!:
 :context: rhv
 :rhv:
 include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
+include::modules/canceling-migration-cli.adoc[leveloffset=+4]
 :rhv!:
 :context: ostack
 :ostack:
 include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
+include::modules/canceling-migration-cli.adoc[leveloffset=+4]
 :ostack!:
 :context: ova
 :ova:
-//include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
-//:ova!:
-//:context: ostack
-//:ostack:
 include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
+include::modules/canceling-migration-cli.adoc[leveloffset=+4]
 :ova!:
 :context: cnv
 :cnv:
 include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
+include::modules/canceling-migration-cli.adoc[leveloffset=+4]
 :cnv!:
 :context: mtv
 :mtv:
-
-include::modules/canceling-migration-cli.adoc[leveloffset=+2]
 
 [id="advanced-migration-options_{context}"]
 == Advanced migration options
@@ -331,7 +330,7 @@ include::modules/upgrading-mtv-ui.adoc[leveloffset=+1]
 [id="uninstalling-mtv_{context}"]
 == Uninstalling {the-lc} {project-full}
 
-You can uninstall {the-lc} {project-first} by using the {ocp} web console or the command line interface (CLI).
+You can uninstall {the-lc} {project-first} by using the {ocp} web console or the command-line interface (CLI).
 
 include::modules/uninstalling-mtv-ui.adoc[leveloffset=+2]
 include::modules/uninstalling-mtv-cli.adoc[leveloffset=+2]

--- a/documentation/modules/accessing-logs-cli.adoc
+++ b/documentation/modules/accessing-logs-cli.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="accessing-logs-cli_{context}"]
-= Accessing logs and custom resource information from the command line interface
+= Accessing logs and custom resource information from the command line
 
-You can access logs and information about custom resources (CRs) from the command line interface by using the `must-gather` tool. You must attach a `must-gather` data file to all customer cases.
+You can access logs and information about custom resources (CRs) from the command line by using the `must-gather` tool. You must attach a `must-gather` data file to all customer cases.
 
 You can gather data for a specific namespace, a completed, failed, or canceled migration plan, or a migrated virtual machine (VM) by using the filtering options.
 

--- a/documentation/modules/accessing-logs-ui.adoc
+++ b/documentation/modules/accessing-logs-ui.adoc
@@ -6,7 +6,7 @@
 [id="accessing-logs-ui_{context}"]
 = Downloading logs and custom resource information from the web console
 
-You can download logs and information about custom resources (CRs) for a completed, failed, or canceled migration plan or for migrated virtual machines (VMs) by using the {ocp} web console.
+You can download logs and information about custom resources (CRs) for a completed, failed, or canceled migration plan or for migrated virtual machines (VMs) from the {ocp} web console.
 
 .Procedure
 

--- a/documentation/modules/canceling-migration-cli.adoc
+++ b/documentation/modules/canceling-migration-cli.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="canceling-migration-cli_{context}"]
-= Canceling a migration
+= Canceling a migration from the command-line interface
 
-You can cancel an entire migration or individual virtual machines (VMs) while a migration is in progress from the command line interface (CLI).
+You can use the command-line interface (CLI) to cancel either an entire migration or the migration of specific virtual machines (VMs) while a migration is in progress.
 
 .Canceling an entire migration
 
@@ -18,10 +18,11 @@ $ {oc} delete migration <migration> -n <namespace> <1>
 ----
 <1> Specify the name of the `Migration` CR.
 
-.Canceling the migration of individual VMs
+.Canceling the migration of specific VMs
 
-. Add the individual VMs to the `spec.cancel` block of the `Migration` manifest:
+. Add the specific VMs to the `spec.cancel` block of the `Migration` manifest:
 +
+.Example YAML for canceling the migrations of two VMs
 [source,yaml,subs="attributes+"]
 ----
 $ cat << EOF | {oc} apply -f -

--- a/documentation/modules/collected-logs-cr-info.adoc
+++ b/documentation/modules/collected-logs-cr-info.adoc
@@ -6,7 +6,7 @@
 [id="collected-logs-cr-info_{context}"]
 = Collected logs and custom resource information
 
-You can download logs and custom resource (CR) `yaml` files for the following targets by using the {ocp} web console or the command line interface (CLI):
+You can download logs and custom resource (CR) `yaml` files for the following targets by using the {ocp} web console or the command-line interface (CLI):
 
 * Migration plan: Web console or CLI.
 * Virtual machine: Web console or CLI.

--- a/documentation/modules/installing-mtv-operator.adoc
+++ b/documentation/modules/installing-mtv-operator.adoc
@@ -10,9 +10,9 @@ ifdef::web[]
 You can install the {operator-name} by using the {ocp} web console.
 endif::[]
 ifdef::cli[]
-= Installing the {operator-name} from the command line interface
+= Installing the {operator-name} by using the command-line interface
 
-You can install the {operator-name} from the command line interface (CLI).
+You can install the {operator-name} by using the command-line interface (CLI).
 endif::[]
 
 .Prerequisites

--- a/documentation/modules/new-migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/new-migrating-virtual-machines-cli.adoc
@@ -8,13 +8,13 @@
 ifdef::vmware[]
 = Migrating from a VMware vSphere source provider
 
-You can migrate from a VMware vSphere source provider by using the CLI.
+You can migrate from a VMware vSphere source provider by using the command-line interface (CLI).
 
 endif::[]
 ifdef::rhv[]
 = Migrating from a {rhv-full} source provider
 
-You can migrate from a {rhv-full} ({rhv-short}) source provider by using the CLI.
+You can migrate from a {rhv-full} ({rhv-short}) source provider by using the command-line interface (CLI).
 
 .Prerequisites
 
@@ -26,18 +26,18 @@ endif::[]
 ifdef::ova[]
 = Migrating from an Open Virtual Appliance (OVA) source provider
 
-You can migrate from Open Virtual Appliance (OVA) files that were created by VMware vSphere as a source provider by using the CLI.
+You can migrate from Open Virtual Appliance (OVA) files that were created by VMware vSphere as a source provider by using the command-line interface (CLI).
 
 endif::[]
 ifdef::ostack[]
 = Migrating from an {osp} source provider
 
-You can migrate from an {osp} source provider by using the CLI.
+You can migrate from an {osp} source provider by using the command-line interface (CLI).
 endif::[]
 ifdef::cnv[]
 = Migrating from a Red Hat {virt} source provider
 
-You can use a Red Hat {virt} provider as either a source provider or as a destination provider.
+You can use a Red Hat {virt} provider as either a source provider or as a destination provider. You can migrate from an {virt} source provider by using the command-line interface (CLI).
 endif::[]
 
 .Procedure
@@ -74,9 +74,9 @@ EOF
 <1> The `ownerReferences` section is optional.
 <2> Specify the vCenter user or the ESX/ESXi user.
 <3> Specify the password of the vCenter user or the ESX/ESXi user.
-<4> Specify `"true"` to skip certificate verification, specify `"false"` to verify the certificate. Defaults to `"false"` if not specified. Skipping certificate verification proceeds with an insecure migration and then the certificate is not required. Insecure migration means that the transferred data is sent over an insecure connection and potentially sensitive data could be exposed.
+<4> Specify `"true"` to skip certificate verification, and specify `"false"` to verify the certificate. Defaults to `"false"` if not specified. Skipping certificate verification proceeds with an insecure migration and then the certificate is not required. Insecure migration means that the transferred data is sent over an insecure connection and potentially sensitive data could be exposed.
 <5> When this field is not set and 'skip certificate verification' is disabled, {project-short} attempts to use the system CA.
-<6>  Specify the API endpoint URL of the vCenter or the ESX/ESXi, for example, `https://<vCenter_host>/sdk`.
+<6> Specify the API endpoint URL of the vCenter or the ESX/ESXi, for example, `https://<vCenter_host>/sdk`.
 endif::[]
 ifdef::rhv[]
 +
@@ -109,8 +109,8 @@ EOF
 <1> The `ownerReferences` section is optional.
 <2> Specify the {rhv-short} {manager} user.
 <3> Specify the user password.
-<4> Specify `"true"` to skip certificate verification, specify `"false"` to verify the certificate. Defaults to `"false"` if not specified. Skipping certificate verification proceeds with an insecure migration and then the certificate is not required. Insecure migration means that the transferred data is sent over an insecure connection and potentially sensitive data could be exposed.
-<5>  Enter the {manager} CA certificate, unless it was replaced by a third-party certificate, in which case, enter the {manager} Apache CA certificate. You can retrieve the {manager} CA certificate at https://<engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA.
+<4> Specify `"true"` to skip certificate verification, and specify `"false"` to verify the certificate. Defaults to `"false"` if not specified. Skipping certificate verification proceeds with an insecure migration and then the certificate is not required. Insecure migration means that the transferred data is sent over an insecure connection and potentially sensitive data could be exposed.
+<5> Enter the {manager} CA certificate, unless it was replaced by a third-party certificate, in which case, enter the {manager} Apache CA certificate. You can retrieve the {manager} CA certificate at https://<engine_host>/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA.
 <6> Specify the API endpoint URL, for example, `https://<engine_host>/ovirt-engine/api`.
 endif::[]
 ifdef::ova[]
@@ -173,7 +173,7 @@ EOF
 <1> The `ownerReferences` section is optional.
 <2> Specify the {osp} user.
 <3> Specify the user {osp} password.
-<4> Specify `"true"` to skip certificate verification, specify `"false"` to verify the certificate. Defaults to `"false"` if not specified. Skipping certificate verification proceeds with an insecure migration and then the certificate is not required. Insecure migration means that the transferred data is sent over an insecure connection and potentially sensitive data could be exposed.
+<4> Specify `"true"` to skip certificate verification, and specify `"false"` to verify the certificate. Defaults to `"false"` if not specified. Skipping certificate verification proceeds with an insecure migration and then the certificate is not required. Insecure migration means that the transferred data is sent over an insecure connection and potentially sensitive data could be exposed.
 <5> When this field is not set and 'skip certificate verification' is disabled, {project-short} attempts to use the system CA.
 <6> Specify the API endpoint URL, for example, `https://<identity_service>/v3`.
 endif::[]
@@ -209,7 +209,7 @@ EOF
 <1> The `ownerReferences` section is optional.
 <2> Specify a token for a service account with `cluster-admin` privileges. If both `token` and `url` are left blank, the local {ocp-short} cluster is used.
 <3> Specify the user password.
-<4> Specify `"true"` to skip certificate verification, specify `"false"` to verify the certificate. Defaults to `"false"` if not specified. Skipping certificate verification proceeds with an insecure migration and then the certificate is not required. Insecure migration means that the transferred data is sent over an insecure connection and potentially sensitive data could be exposed.
+<4> Specify `"true"` to skip certificate verification, and specify `"false"` to verify the certificate. Defaults to `"false"` if not specified. Skipping certificate verification proceeds with an insecure migration and then the certificate is not required. Insecure migration means that the transferred data is sent over an insecure connection and potentially sensitive data could be exposed.
 <5> When this field is not set and 'skip certificate verification' is disabled, {project-short} attempts to use the system CA.
 <6> Specify the URL of the endpoint of the API server.
 endif::[]
@@ -353,7 +353,7 @@ spec:
 EOF
 ----
 <1> Specify the name of the VMware vSphere `Provider` CR.
-<2> Specify the Managed Object Reference (moRef) of the VMware vSphere host. To retrieve the moRef, see xref:retrieving-vmware-moref_mtv[Retrieving a VMware vSphere moRef].
+<2> Specify the Managed Object Reference (moRef) of the VMware vSphere host. To retrieve the moRef, see xref:retrieving-vmware-moref_vmware[Retrieving a VMware vSphere moRef].
 <3> Specify the IP address of the VMware vSphere migration network.
 
 [start=4]
@@ -392,7 +392,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `pod` and `multus`.
-<2> You can use either the `id` _or_ the `name` parameter to specify the source network. For `id`, specify the VMware vSphere network Managed Object Reference (moRef). To retrieve the moRef, see xref:retrieving-vmware-moref_mtv[Retrieving a VMware vSphere moRef].
+<2> You can use either the `id` or the `name` parameter to specify the source network. For `id`, specify the VMware vSphere network Managed Object Reference (moRef). To retrieve the moRef, see xref:retrieving-vmware-moref_vmware[Retrieving a VMware vSphere moRef].
 <3> Specify a network attachment definition for each additional {virt} network.
 <4> Required only when `type` is `multus`. Specify the namespace of the {virt} network attachment definition.
 endif::[]
@@ -434,7 +434,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `pod` and `multus`.
-<2> You can use either the `id` _or_ the `name` parameter to specify the source network. For `id`, specify the {rhv-short} network Universal Unique ID (UUID).
+<2> You can use either the `id` or the `name` parameter to specify the source network. For `id`, specify the {rhv-short} network Universal Unique ID (UUID).
 <3> Specify a network attachment definition for each additional {virt} network.
 <4> Required only when `type` is `multus`. Specify the namespace of the {virt} network attachment definition.
 endif::[]
@@ -516,7 +516,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `pod` and `multus`.
-<2> You can use either the `id` _or_ the `name` parameter to specify the source network. For `id`, specify the {osp} network UUID.
+<2> You can use either the `id` or the `name` parameter to specify the source network. For `id`, specify the {osp} network UUID.
 <3> Specify a network attachment definition for each additional {virt} network.
 <4> Required only when `type` is `multus`. Specify the namespace of the {virt} network attachment definition.
 endif::[]
@@ -593,7 +593,7 @@ spec:
 EOF
 ----
 <1> Allowed values are `ReadWriteOnce` and `ReadWriteMany`.
-<2> Specify the VMware vSphere datastore moRef. For example, `f2737930-b567-451a-9ceb-2887f6207009`. To retrieve the moRef, see xref:retrieving-vmware-moref_mtv[Retrieving a VMware vSphere moRef].
+<2> Specify the VMware vSphere datastore moRef. For example, `f2737930-b567-451a-9ceb-2887f6207009`. To retrieve the moRef, see xref:retrieving-vmware-moref_vmware[Retrieving a VMware vSphere moRef].
 endif::[]
 
 ifdef::rhv[]
@@ -802,8 +802,8 @@ EOF
 <7> Specify the name of the `StorageMap` CR.
 <8> By default, virtual network interface controllers (vNICs) change during the migration process. As a result, vNICs that are configured with a static IP linked to the interface name in the guest VM lose their IP.
 To avoid this, set `preserveStaticIPs` to `true`. {project-short} issues a warning message about any VMs for which vNIC properties are missing. To retrieve any missing vNIC properties, run those VMs in vSphere in order for the vNIC properties to be reported to {project-short}.
-<9> You can use either the `id` _or_ the `name` parameter to specify the source VMs.
-<10> Specify the VMware vSphere VM moRef. To retrieve the moRef, see xref:retrieving-vmware-moref_mtv[Retrieving a VMware vSphere moRef].
+<9> You can use either the `id` or the `name` parameter to specify the source VMs.
+<10> Specify the VMware vSphere VM moRef. To retrieve the moRef, see xref:retrieving-vmware-moref_vmware[Retrieving a VMware vSphere moRef].
 <11> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
 <12> Specify the name of the `Hook` CR.
 <13> Allowed values are `PreHook`, before the migration plan starts, or `PostHook`, after the migration is complete.
@@ -859,7 +859,7 @@ EOF
 <6> Specify the name of the `NetworkMap` CR.
 <7> Specify a storage mapping even if the VMs to be migrated are not assigned with disk images. The mapping can be empty in this case.
 <8> Specify the name of the `StorageMap` CR.
-<9> You can use either the `id` _or_ the `name` parameter to specify the source VMs.
+<9> You can use either the `id` or the `name` parameter to specify the source VMs.
 <10> Specify the {rhv-short} VM UUID.
 <11> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
 <12> Specify the name of the `Hook` CR.
@@ -867,7 +867,7 @@ EOF
 +
 [NOTE]
 ====
-* If the migrated machines is set with a custom CPU model, it will be set with that CPU model in the destination cluster, regardless of the setting of `preserveClusterCpuModel`.
+* If the migrated machine is set with a custom CPU model, it will be set with that CPU model in the destination cluster, regardless of the setting of `preserveClusterCpuModel`.
 
 * If the migrated machine is _not_ set with a custom CPU model:
 
@@ -920,7 +920,7 @@ EOF
 <4> Specify the name of the `NetworkMap` CR.
 <5> Specify a storage mapping even if the VMs to be migrated are not assigned with disk images. The mapping can be empty in this case.
 <6> Specify the name of the `StorageMap` CR.
-<7> You can use either the `id` _or_ the `name` parameter to specify the source VMs.
+<7> You can use either the `id` or the `name` parameter to specify the source VMs.
 <8> Specify the OVA VM UUID.
 <9> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
 <10> Specify the name of the `Hook` CR.
@@ -971,7 +971,7 @@ EOF
 <4> Specify the name of the `NetworkMap` CR.
 <5> Specify a storage mapping, even if the VMs to be migrated are not assigned with disk images. The mapping can be empty in this case.
 <6> Specify the name of the `StorageMap` CR.
-<7> You can use either the `id` _or_ the `name` parameter to specify the source VMs.
+<7> You can use either the `id` or the `name` parameter to specify the source VMs.
 <8> Specify the {osp} VM UUID.
 <9> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
 <10> Specify the name of the `Hook` CR.

--- a/documentation/modules/retrieving-vmware-moref.adoc
+++ b/documentation/modules/retrieving-vmware-moref.adoc
@@ -6,7 +6,7 @@
 [id="retrieving-vmware-moref_{context}"]
 = Retrieving a VMware vSphere moRef
 
-When you migrate VMs with a VMware vSphere source provider using {project-first} from the CLI, you need to know the managed object reference (moRef) of certain entities in vSphere, such as datastores, networks, and VMs.
+When you migrate VMs with a VMware vSphere source provider using {project-first} from the command line, you need to know the managed object reference (moRef) of certain entities in vSphere, such as datastores, networks, and VMs.
 
 You can retrieve the moRef of one or more vSphere entities from the Inventory service. You can then use each moRef as a reference for retrieving the moRef of another entity.
 

--- a/documentation/modules/snip_vmware-permissions.adoc
+++ b/documentation/modules/snip_vmware-permissions.adoc
@@ -1,9 +1,9 @@
 :_content-type: SNIPPET
 
 [IMPORTANT]
-.`forklift-controller` consistently failing to reconcile a plan, and returning an HTTP 500 error
+.`forklift-controller` consistently fails to reconcile plans, and returns an HTTP 500 error.
 ====
-There is an issue with the `forklift-controller` consistently failing to reconcile a Migration Plan, and subsequently returning an HTTP 500 error. This issue is caused when you specify the user permissions only on the virtual machine (VM).
+There is an issue with the `forklift-controller` consistently failing to reconcile a migration plan, and subsequently returning an HTTP 500 error. This issue is caused when you specify the user permissions only on the virtual machine (VM).
 
 In {project-short}, you need to add permissions at the datacenter level, which includes storage, networks, switches, and so on, which are used by the VM. You must then propagate the permissions to the child elements.
 

--- a/documentation/modules/uninstalling-mtv-cli.adoc
+++ b/documentation/modules/uninstalling-mtv-cli.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="uninstalling-mtv-cli_{context}"]
-= Uninstalling {project-short} from the command line interface
+= Uninstalling {project-short} by from the command line
 
-You can uninstall {project-first} from the command line interface (CLI).
+You can uninstall {project-first} from the command line.
 
 [NOTE]
 ====


### PR DESCRIPTION
MTV 2.8 

Partially resolves https://issues.redhat.com/browse/MTV-1433 by making the following changes to the per-provider procedures for migrating VMs:

- Moves the section "Retrieving a VMware vSphere moRef" to the section of the guide related specifically to migrating VMware VMs.
- Adds the section "Cancelling a migration from the CLI" to each of the provider-based procedures,  

Previews:
https://file.corp.redhat.com/rhoch/cli_migrations_providers/html-single/#new-migrating-virtual-machines-cli_vmware [VMware section]
https://file.corp.redhat.com/rhoch/cli_migrations_providers/html-single/#new-migrating-virtual-machines-cli_rhv [RHV section]
https://file.corp.redhat.com/rhoch/cli_migrations_providers/html-single/#new-migrating-virtual-machines-cli_ostack [OpenStack]
https://file.corp.redhat.com/rhoch/cli_migrations_providers/html-single/#new-migrating-virtual-machines-cli_ova [OVA]
https://file.corp.redhat.com/rhoch/cli_migrations_providers/html-single/#new-migrating-virtual-machines-cli_cnv [CNV]