### PR TITLE
MTV-1719: Selecting a migration network for a CNV destination provider

### DIFF
--- a/documentation/modules/selecting-migration-network-for-virt-provider.adoc
+++ b/documentation/modules/selecting-migration-network-for-virt-provider.adoc
@@ -17,7 +17,11 @@ You can override the default migration network of the provider by selecting a di
 
 .Procedure
 
-. In the {ocp} web console, click *Migration* -> *Providers for virtualization*.
-. On the right side of the provider, select *Select migration network* from the {kebab}.
-. Select a network from the list of available networks and click *Select*.
-//. Click the network number in the *Networks* column beside the provider to verify that the selected network is the default migration network.
+. In the {ocp} web console, click *Migration* > *Providers for virtualization*.
+. Click the {virt} provider whose migration network you want to change.
++
+The *Providers detail* page opens.
+. Click the *Networks* tab.
+. Click *Set default transfer network*.
+. Select a default transfer network from the list and click *Save*.
+


### PR DESCRIPTION
MTV 2.7

Resolves https://issues.redhat.com/browse/MTV-1719 by correcting the procedure in https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html/installing_and_using_the_migration_toolkit_for_virtualization/migrating-vms-web-console_mtv#selecting-migration-network-for-virt-provider_mtv

 