### PR TITLE
MTV-1145: Remote providers web UI link

### DIFF
--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -199,3 +199,20 @@ ifdef::ova[]
 An error message might appear that states that an error has occurred. You can ignore this message.
 ====
 endif::[]
+
+ifdef::vmware,rhv,ostack,cnv,cnv2[]
+. Optional: Add access to the UI of the provider:
+.. On the *Providers* page, click the provider.
++
+The *Provider details* page opens.
+.. Click the *Edit* icon under *External UI web link*.
+.. Enter the link and click *Save*.
++
+[NOTE]
+====
+If you do not enter a link, {project-short} attempts to calculate the correct link.
+
+* If {project-short} succeeds, the hyperlink of the field points to the calculated link.
+* If {project-short} does not succeed, the field remains empty.
+====
+endif::[]


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/MTV-1145 by adding instructions about how to connect to a remote provider's UI, for all providers except OVA..

Preview: https://file.corp.redhat.com/rhoch/external_ui_link/html-single/#adding-source-providers [section 4.4.1.1., step 8; appears for all providers except OVA]
 