### PR TITLE
MTV-1696: How MTV uses virt-v2v

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -350,6 +350,7 @@ This section describes {project-short} custom resources, services, and workflows
 include::modules/mtv-resources-and-services.adoc[leveloffset=+3]
 include::modules/mtv-workflow.adoc[leveloffset=+3]
 include::modules/virt-migration-workflow.adoc[leveloffset=+3]
+include::modules/virt-v2v-mtv.adoc[leveloffset=+3]
 
 [id="logs-and-crs_{context}"]
 === Logs and custom resources

--- a/documentation/modules/virt-v2v-mtv.adoc
+++ b/documentation/modules/virt-v2v-mtv.adoc
@@ -21,7 +21,7 @@ During migration, {project-short} uses `virt-v2v` to collect metadata about VMs,
 
 ** Injection of VirtIO drivers, for example, network or disk drivers.
 ** Preparation of hypervisor-specific tools or agents, for example, a QEMU guest agent installation.
-** Modification boot configuration, for example, updated bootloader or boot entries.
+** Modification of boot configuration, for example, updated bootloader or boot entries.
 
 * Removals:
 

--- a/documentation/modules/virt-v2v-mtv.adoc
+++ b/documentation/modules/virt-v2v-mtv.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+
+:_content-type: CONCEPT
+[id="virt-v2v-mtv_{context}"]
+= How MTV uses the virt-v2v tool
+
+The {project-first} uses the `virt-v2v` tool to convert the disk image of a VM into a format compatible with {virt}. The tool makes migrations easier because it automatically performs the tasks needed to make your VMs work with {virt}, such as enabling paravirtualized VirtIO drivers in the converted virtual machine, if possible, and installing the QEMU guest agent.
+
+`virt-v2v` is included in Red Hat Enterprise Linux (RHEL) versions 7 and later.
+
+[id="main-functions-virt-v2v-mtv_{context}"]
+== Main functions of virt-v2v in MTV migrations
+
+During migration, {project-short} uses `virt-v2v` to collect metadata about VMs, make necessary changes to VM disks, and copy the disks containing the VMs to {virt}.
+
+`virt-v2v` makes the following changes to VM disks to prepare them for migration:
+
+* Additions:
+
+** Injection of VirtIO drivers, for example, network or disk drivers.
+** Preparation of hypervisor-specific tools or agents, for example, a QEMU guest agent installation.
+** Modification boot configuration, for example, updated bootloader or boot entries.
+
+* Removals:
+
+** Unnecessary or former hypervisor-specific files, for example, VMware tools or VirtualBox additions.
+** Old network driver configurations, for example, removing VMware-specific NIC drivers.
+** Configuration settings that are incompatible with the target system, for example, old boot settings.
+
+If you are migrating from VMware or from OVA files, `virt-v2v` also sets their IP addresses either during the migration or during the first reboot of the VMs after migration.
+
+[NOTE]
+====
+You can also run pre-defined Ansible hooks before or after a migration using {project-short}. For more information, see xref:../master.adoc#adding-hooks-migration-plan-using-api[Adding hooks to a migration plan].
+
+These hooks do not necessarily use `virt-v2v`.
+====
+
+[id="customizing-removing-installing-virt-v2v_{context}"]
+== Customizing, removing, and installing files
+
+{project-short} uses `virt-v2v` to perform additional guest customizations during the conversion, such as the following actions:
+
+* Customization to preserve IP addresses
+* Customization to preserve drive letters
+
+[NOTE]
+====
+For RHEL-based guests, `virt-v2v` attempts to install the guest agent from the Red Hat registry. If the migration is run in a detached environment, the installer will fail, and you must use hooks, or other automation, to install the guest agent.
+====
+
+For more information, see the man reference pages:
+
+* link:https://libguestfs.org/virt-v2v.1.html[`virt-v2v` - Convert a guest to use KVM]
+* link:https://libguestfs.org/virt-customize.1.html[`virt-customize` - Customize a virtual machine]
+
+[id="permissions-virt-v2v_{context}"]
+== Permissions and virt-v2v
+
+`virt-v2v` does not require permissions or access credentials for the guest operating system itself because `virt-v2v` is not run against a running VM, but only against the disks of a VM.


### PR DESCRIPTION
MTV 2.8

Partly resolves https://issues.redhat.com/browse/MTV-1696 by adding a section discussing how MTV uses virt-v2v in migrations. 

Preview: https://file.corp.redhat.com/rhoch/virt_v2v_mtv/html-single/#virt-v2v-mtv_mtv