### PR TITLE
MTV-1936 Fix link in MTV user guide 3.3

### DIFF
--- a/documentation/modules/configuring-mtv-operator.adoc
+++ b/documentation/modules/configuring-mtv-operator.adoc
@@ -19,7 +19,7 @@ You can configure all of the following settings of the {operator-name} by modify
 * Configuration map of operating systems to preferences for vSphere source providers (`ForkliftController` CR only).
 * Configuration map of operating systems to preferences for {rhv-full} ({rhv-short}) source providers (`ForkliftController` CR only).
 
-The procedure for configuring these settings using the user interface is presented in xref:mtv-overview-page_{context}[Configuring MTV settings]. The procedure for configuring these settings by modifying the `ForkliftController` CR is presented following.
+The procedure for configuring these settings using the user interface is presented in xref:mtv-settings_{context}[Configuring MTV settings]. The procedure for configuring these settings by modifying the `ForkliftController` CR is presented following.
 
 .Procedure
 


### PR DESCRIPTION
MTV 2.7.8

Resolves https://issues.redhat.com/browse/MTV-1936 by fixing the incorrect link. 

Preview: https://file.corp.redhat.com/rhoch/fix_link_section_33/html-single/#configuring-mtv-operator_mtv [First paragraph after the bulleted list, click the link with text "Configuring MTV settings"] 