### PR TITLE
To be merged for 2.8.0 - MTV-1780 Allow users to keep importer pods

### DIFF
--- a/documentation/modules/configuring-mtv-operator.adoc
+++ b/documentation/modules/configuring-mtv-operator.adoc
@@ -18,31 +18,32 @@ You can configure all of the following settings of the {operator-name} by modify
 * Fixed amount of additional space allocated in persistent block volumes. This setting is applicable for any `storageclass` that is block-based (`ForkliftController` CR only).
 * Configuration map of operating systems to preferences for vSphere source providers (`ForkliftController` CR only).
 * Configuration map of operating systems to preferences for {rhv-full} ({rhv-short}) source providers (`ForkliftController` CR only).
+* Whether to retain importer pods so that the Containerized Data Importer (CDI) does not delete them during migration (`ForkliftController` CR only).
 
 The procedure for configuring these settings using the user interface is presented in xref:mtv-settings_{context}[Configuring MTV settings]. The procedure for configuring these settings by modifying the `ForkliftController` CR is presented following.
 
 .Procedure
 
-* Change a parameter's value in  the `spec` portion of the `ForkliftController` CR by adding the label and value as follows:
+* Change a parameter's value in  the `spec` section of the `ForkliftController` CR by adding the parameter and value as follows:
 +
 [source, YAML]
 ----
 spec:
-  label: value <1>
+  parameter: value # <1>
 ----
-<1> Labels you can configure using the CLI are shown in the table that follows, along with a description of each label and its default value.
+<1> Parameters that you can configure using the CLI are shown in the table that follows, along with a description of each parameter and its default value.
 
-.{operator-name} labels
+.{operator-name} parameters
 [cols="1,1,1",options="header"]
 |===
-|Label |Description |Default value
+|Parameter |Description |Default value
 
 |`controller_max_vm_inflight`
 a|Varies with provider as follows:
 
 * For all migrations except OVA or VMware migrations: The maximum number of disks that {project-short} can transfer simultaneously.
 * For OVA migrations: The maximum number of VMs that {project-short} can migrate simultaneously.
-*  For VMware migrations, the label has the following meanings:
+*  For VMware migrations, the parameter has the following meanings:
 ** Cold migration:
 
 *** To local {virt}: VMs for each ESXi host that can migrate simultaneously.
@@ -50,7 +51,7 @@ a|Varies with provider as follows:
 
 ** Warm migration: Disks for each ESXi host that can migrate simultaneously.
 +
-See xref:max-concurrent-vms_{context}[Configuring the controller_max_vm_inflight label] for a detailed explanation of this label.
+See xref:max-concurrent-vms_{context}[Configuring the controller_max_vm_inflight parameter] for a detailed explanation of this parameter.
 |`20`
 
 |`must_gather_api_cleanup_max_age`
@@ -88,9 +89,9 @@ See xref:max-concurrent-vms_{context}[Configuring the controller_max_vm_inflight
 |`vsphere_osmap_configmap_name`
 |Configuration map for vSphere source providers. This configuration map maps the operating system of the incoming VM to a {virt} preference name. This configuration map needs to be in the namespace where the {project-short} Operator is deployed.
 
-To see the list of preferences in your {virt} environment, open the {ocp-name} web console and click *Virtualization* -> *Preferences*.
+To see the list of preferences in your {virt} environment, open the {ocp-name} web console and click *Virtualization* > *Preferences*.
 
-You can add values to the configuration map when this label has the default value, `forklift-vsphere-osmap.` In order to override or delete values, specify a configuration map that is different from `forklift-vsphere-osmap`.
+Add values to the configuration map when this parameter has the default value, `forklift-vsphere-osmap.` To override or delete values, specify a configuration map that is different from `forklift-vsphere-osmap`.
 
 `ForkliftController` CR only.
 |`forklift-vsphere-osmap`
@@ -100,10 +101,17 @@ You can add values to the configuration map when this label has the default valu
 
 To see the list of preferences in your {virt} environment, open the {ocp-name} web console and click *Virtualization* -> *Preferences*.
 
-You can add values to the configuration map when this label has the default value, `forklift-ovirt-osmap.` In order to override or delete values, specify a configuration map that is different from `forklift-ovirt-osmap`.
+You can add values to the configuration map when this parameter has the default value, `forklift-ovirt-osmap.` In order to override or delete values, specify a configuration map that is different from `forklift-ovirt-osmap`.
 
 `ForkliftController` CR only.
 |`forklift-ovirt-osmap`
+
+|`controller_retain_precopy_importer_pods`
+|Whether to retain importer pods so that the Containerized Data Importer (CDI) does not delete them during migration.
+
+`ForkliftController` CR only.
+
+|`false`
 |===
 
 

--- a/documentation/modules/max-concurrent-vms.adoc
+++ b/documentation/modules/max-concurrent-vms.adoc
@@ -5,19 +5,19 @@
 
 :_content-type: PROCEDURE
 [id="max-concurrent-vms_{context}"]
-= Configuring the controller_max_vm_inflight label
+= Configuring the controller_max_vm_inflight parameter
 
-The meaning of the `controller_max_vm_inflight` label, which is shown in the UI as *Max concurrent virtual machine migrations*, varies by the source provider of the migration
+The value of `controller_max_vm_inflight` parameter, which is shown in the UI as *Max concurrent virtual machine migrations*, varies by the source provider of the migration
 
-* For all migrations except OVA or VMware migrations, the label specifies the maximum number of _disks_ that {project-first} can transfer simultaneously. In these migrations, {project-short} migrates the disks in parallel. This means that if the combined number of disks that you want to migrate is greater than the value of the setting, additional disks must wait until the queue is free, without regard for whether a VM has finished migrating.
+* For all migrations except OVA or VMware migrations, the parameter specifies the maximum number of _disks_ that {project-first} can transfer simultaneously. In these migrations, {project-short} migrates the disks in parallel. This means that if the combined number of disks that you want to migrate is greater than the value of the setting, additional disks must wait until the queue is free, without regard for whether a VM has finished migrating.
 +
-For example, if the value of the label is 15, and VM A has 5 disks, VM B has 5 disks, and VM C has 6 disks; all the disks except for the 16th disk start migrating at the same time. Once any of them has migrated, the 16th disk can be migrated, even though not all the disks on VM A and the disks on VM B have finished migrating.
+For example, if the value of the parameter is 15, and VM A has 5 disks, VM B has 5 disks, and VM C has 6 disks, all the disks except for the 16th disk start migrating at the same time. Once any of them has migrated, the 16th disk can be migrated, even though not all the disks on VM A and the disks on VM B have finished migrating.
 
-* For OVA migrations, the label specifies the maximum number of _VMs_ that {project-short} can migrate simultaneously, meaning that all additional disks must wait until at least one VM has been completely migrated.
+* For OVA migrations, the parameter specifies the maximum number of _VMs_ that {project-short} can migrate simultaneously, meaning that all additional disks must wait until at least one VM has been completely migrated.
 +
-For example, if the value of the label is 2, and VM A has 5 disks, VM B has 5 disks, and VM C has 6 disks. All the disks on VM C must wait to migrate until either all the disks on VM A or on VM B finish migrating.
+For example, if the value of the parameter is 2, and VM A has 5 disks, VM B has 5 disks, and VM C has 6 disks, all the disks on VM C must wait to migrate until either all the disks on VM A or on VM B finish migrating.
 
-* For VMware migrations, the label has the following meanings:
+* For VMware migrations, the parameter has the following meanings:
 
 ** Cold migration:
 

--- a/documentation/modules/mtv-settings.adoc
+++ b/documentation/modules/mtv-settings.adoc
@@ -26,7 +26,7 @@ a|Varies with provider as follows:
 
 ** Warm migration: Disks for each ESXi host that can migrate simultaneously.
 +
-See xref:max-concurrent-vms_{context}[Configuring the controller_max_vm_inflight label] for a detailed explanation of this setting.
+See xref:max-concurrent-vms_{context}[Configuring the controller_max_vm_inflight parameter] for a detailed explanation of this setting.
 |20
 
 |Must gather cleanup after (hours)
@@ -52,7 +52,7 @@ See xref:max-concurrent-vms_{context}[Configuring the controller_max_vm_inflight
 
 .Procedure
 
-. In the {ocp} web console, click *Migration* -> *Overview*. The *Settings* list is on the right-hand side of the page.
+. In the {ocp} web console, click *Migration* > *Overview*. The *Settings* list is on the right side of the page.
 . In the *Settings* list, click the Edit icon of the setting you want to change.
 . Choose a setting from the list.
 . Click *Save*.


### PR DESCRIPTION
MTV 2.8

Resolves https://issues.redhat.com/browse/MTV-1780 by adding by adding `controller_retain_precopy_importer_pods` to the table in https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#configuring-mtv-operator_mtv .

Martin pointed out elsewhere that we should be be referring to "parameters," not "labels", so I made that change here and in two related modules. 

Previews: 

- https://file.corp.redhat.com/rhoch/keep_importer_pods/html-single/#configuring-mtv-operator_mtv
- https://file.corp.redhat.com/rhoch/keep_importer_pods/html-single/#max-concurrent-vms_mtv
- https://file.corp.redhat.com/rhoch/keep_importer_pods/html-single/#mtv-settings_mtv
