### PR TITLE
MTV-1945: Release Notes for MTV 2.7.10

### DIFF
--- a/documentation/modules/new-features-and-enhancements-2-7.adoc
+++ b/documentation/modules/new-features-and-enhancements-2-7.adoc
@@ -10,3 +10,10 @@
 
 * In {project-short} 2.7.0, warm migration is now based on RHEL 9 inheriting features and bug fixes.
 
+// https://issues.redhat.com/browse/MTV-2039
+* In {project-short} 2.7.10, you can specify the `plan.spec.diskBus` which will be on all disks during the creation.
++
+Possible options are:
+* SCSI
+* SATA
+* VirtIO

--- a/documentation/modules/new-features-and-enhancements-2-7.adoc
+++ b/documentation/modules/new-features-and-enhancements-2-7.adoc
@@ -4,10 +4,6 @@
 
 {project-first} 2.7 introduces the following features and enhancements:
 
-
-[id="new-features-and-enhancements-2-7-0_{context}"]
-== New features and enhancements 2.7.0
-
 * In {project-short} 2.7.0, warm migration is now based on RHEL 9 inheriting features and bug fixes.
 
 // https://issues.redhat.com/browse/MTV-2039

--- a/documentation/modules/rn-27-resolved-issues.adoc
+++ b/documentation/modules/rn-27-resolved-issues.adoc
@@ -7,6 +7,22 @@
 
 {project-first} 2.7 has the following resolved issues:
 
+[id="resolved-issues-2-7-10_{context}"]
+== Resolved issues 2.7.10
+
+.OVN secondary network not working with Multus default network override
+
+In earlier releases of {project-short}, the OVN secondary network was not working with Multus default network override. This issue caused the importer pod to become stuck, as the importer pod was created when there were multiple networks and the wrong default network override annotation was configured. This issue has been resolved in {project-short} 2.7.10. link:https://issues.redhat.com/browse/MTV-1645[(MTV-1645)]
+
+.Retain IP field description misleading to customers
+
+In earlier releases of project-short, it was difficult to understand the user interface relating to the *Preserve IPs* from VM setting in the chosen setting mode. This issue has been resolved in {project-short} 2.7.10. link:https://issues.redhat.com/browse/MTV-1743[(MTV-1743)]
+
+.Persistent TPM is always added to the Windows 2022 VM after conversion
+
+In earlier releases of project-short, when migrating a Windows Server 2022 VMware virtual machine (VM) to {virt}, the VMI had the Trusted Platform Module (TPM) module configured, even though the module was not configured in the original VM. This issue has been resolved in {project-short} 2.7.10. link:https://issues.redhat.com/browse/MTV-1939[(MTV-1939)]
+
+
 [id="resolved-issues-2-7-9_{context}"]
 == Resolved issues 2.7.9
 
@@ -17,13 +33,6 @@ In earlier releases of {project-short}, the `forklift-contoller` inventory conta
 .vCenter sessions keep on increasing during migration plan execution
 
 In earlier releases of {project-short}, when migrating virtual machines (VMs) from VMware vSphere 7 to {virt}, vCenter sessions kept increasing. This issue has been resolved in {project-short} 2.7.9. link:https://issues.redhat.com/browse/MTV-1929[(MTV-1929)]
-
-////
-.OVN secondary network not working with Multus default network override
-
-In earlier releases of {project-short}, the OVN secondary network was not working with Multus default network override. This issue caused the importer pod to become stuck, as the importer pod was created when there were multiple networks and the wrong default network override annotation was configured. This issue has been resolved in {project-short} 2.7.9. link:https://issues.redhat.com/browse/MTV-1645[(MTV-1645)]
-
-////
 
 
 [id="resolved-issues-2-7-8_{context}"]

--- a/documentation/modules/rn-27-resolved-issues.adoc
+++ b/documentation/modules/rn-27-resolved-issues.adoc
@@ -16,7 +16,8 @@ In earlier releases of {project-short}, the OVN secondary network was not worki
 
 .Retain IP field description misleading to customers
 
-In earlier releases of project-short, it was difficult to understand the user interface relating to the *Preserve IPs* from VM setting in the chosen setting mode. This issue has been resolved in {project-short} 2.7.10. link:https://issues.redhat.com/browse/MTV-1743[(MTV-1743)]
+
+In earlier releases of {project-short}, it was difficult to understand the user interface relating to the *Preserve IPs* VM setting in the chosen setting mode. This issue has been resolved in {project-short} 2.7.10. link:https://issues.redhat.com/browse/MTV-1743[(MTV-1743)]
 
 .Persistent TPM is always added to the Windows 2022 VM after conversion
 

--- a/documentation/modules/rn-27-resolved-issues.adoc
+++ b/documentation/modules/rn-27-resolved-issues.adoc
@@ -20,7 +20,7 @@ In earlier releases of project-short, it was difficult to understand the user in
 
 .Persistent TPM is always added to the Windows 2022 VM after conversion
 
-In earlier releases of project-short, when migrating a Windows Server 2022 VMware virtual machine (VM) to {virt}, the VMI had the Trusted Platform Module (TPM) module configured, even though the module was not configured in the original VM. This issue has been resolved in {project-short} 2.7.10. link:https://issues.redhat.com/browse/MTV-1939[(MTV-1939)]
+In earlier releases of {project-short}, when migrating a Windows Server 2022 VMware virtual machine (VM) to {virt}, the VMI had the Trusted Platform Module (TPM) module configured, even though the module was not configured in the original VM. This issue has been resolved in {project-short} 2.7.10. link:https://issues.redhat.com/browse/MTV-1939[(MTV-1939)]
 
 
 [id="resolved-issues-2-7-9_{context}"]


### PR DESCRIPTION
### JIRA

* [MTV-1945](https://issues.redhat.com/browse/MTV-1945)

### PREVIEW

* [1.2. New features and enhancements](https://anarnold97.github.io/MTA-Preview/MTV/2-7-10-rn.html#new-features-and-enhancements-2-7_release-notes)
* [1.3.1. Resolved issues 2.7.10](https://anarnold97.github.io/MTA-Preview/MTV/2-7-10-rn.html#resolved-issues-2-7-10_release-notes)

#### Resolved issues:

* MTV-1645 OVN secondary network is not working with multus default network override
* MTV-1743 Retain IP filed description missleading to customers
* MTV-1939 Persistent vTPM is always added to the Windows 2022 VM after conversion

#### New features
* MTV-2039 Allow to specify the diskBus on a plan