### PR TITLE
MTV-1608: Tip on applying VMware permissions

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -88,6 +88,7 @@ include::modules/ostack-app-cred-auth.adoc[leveloffset=+4]
 :mtv:
 
 include::modules/vmware-prerequisites.adoc[leveloffset=+2]
+include::modules/creating-vmware-role-mtv-permissions.adoc[leveloffset=+3]
 include::modules/creating-vddk-image.adoc[leveloffset=+3]
 include::modules/increasing-nfc-memory-vmware-host.adoc[leveloffset=+3]
 include::modules/vddk-validator-containers.adoc[leveloffset=+3]

--- a/documentation/modules/creating-vmware-role-mtv-permissions.adoc
+++ b/documentation/modules/creating-vmware-role-mtv-permissions.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+
+:_content-type: PROCEDURE
+[id="creating-vmware-role-mtv-permissions_{context}"]
+= Creating a VMware role to grant MTV privileges
+
+You can create a role in VMware to grant privileges for {project-first} and then grant those privileges to users with that role.  
+
+The procedure that follows explains how to do this in general. For detailed instructions, see VMware documentation.
+
+.Procedure
+
+. In the vCenter Server UI, create a role that includes the set of privileges described in the table in xref:vmware-prerequisites_mtv[VMware prerequisites].
+. In the vSphere inventory UI, grant privileges for users with this role to the appropriate vSphere logical objects at one of the following levels:
+
+.. At the user or group level: Assign privileges to the appropriate logical objects in the data center and use the *Propagate to child objects* option. 
+.. At the object level: Apply the same role individually to all the relevant vSphere logical objects involved in the migration, for example, hosts, vSphere clusters, data centers, or networks. 

--- a/documentation/modules/vmware-prerequisites.adoc
+++ b/documentation/modules/vmware-prerequisites.adoc
@@ -22,7 +22,7 @@ The following prerequisites apply to VMware migrations:
 
 [IMPORTANT]
 ====
-In the event of a power outage, data might be lost for a VM with disabled hibernation. However, if hibernation is not disabled, migration will fail.
+In case of a power outage, data might be lost for a VM with disabled hibernation. However, if hibernation is not disabled, migration will fail.
 ====
 
 [NOTE]

--- a/documentation/modules/vmware-prerequisites.adoc
+++ b/documentation/modules/vmware-prerequisites.adoc
@@ -22,7 +22,7 @@ The following prerequisites apply to VMware migrations:
 
 [IMPORTANT]
 ====
-In the event of a power outage, data might be lost for a VM with disabled hibernation. However, if hibernation is not disabled, migration will fail
+In the event of a power outage, data might be lost for a VM with disabled hibernation. However, if hibernation is not disabled, migration will fail.
 ====
 
 [NOTE]
@@ -90,3 +90,8 @@ All `Virtual machine.Provisioning` privileges are required.
 |`Cryptographic.Decrypt` |Allows decryption of an encrypted virtual machine.
 |`Cryptographic.Direct access` |Allows access to encrypted resources.
 |===
+
+[TIP]
+==== 
+Create a role in VMware with the permissions described in the preceding table and then apply this role to the *Inventory* section, as described in xref:creating-vmware-role-mtv-permissions_mtv[Creating a VMware role to apply MTV permissions]
+====


### PR DESCRIPTION
MTV 2.7

Resolves https://issues.redhat.com/browse/MTV-1608 by adding a tip on how to apply VMware permissions. The tip is aimed at making the migration process easier for users of VMware. 

Previews:

- https://file.corp.redhat.com/rhoch/vm_role/html-single/#vmware-prerequisites_mtv [Tip following table 3.4]
- https://file.corp.redhat.com/rhoch/vm_role/html-single/#creating-vmware-role-mtv-permissions_mtv
