### PR TITLE
MTV main partially fixed

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -129,17 +129,6 @@ include::modules/mtv-ui.adoc[leveloffset=+2]
 include::modules/mtv-overview-page.adoc[leveloffset=+3]
 include::modules/mtv-settings.adoc[leveloffset=+3]
 
-
-[id="migrating-vms-ocp-web-console_{context}"]
-== Migrating virtual machines by using the {ocp} web console
-
-Use the {project-short} user interface to migrate virtual machines (VMs). It is located in the *Virtualization* section of the {ocp} web console.
-
-include::modules/mtv-ui.adoc[leveloffset=+2]
-
-include::modules/mtv-overview-page.adoc[leveloffset=+3]
-include::modules/mtv-settings.adoc[leveloffset=+3]
-
 [id="migrating-vms-mtv-ui_{context}"]
 === Migrating virtual machines using the MTV user interface
 
@@ -167,8 +156,11 @@ VMware only: Creating a xref:creating-vddk-image_{context}[VMware Virtual Disk D
 :context: vmware
 :vmware:
 
-[id="migrating-vmware-ui"]
+[id="migrating-vmware"]
 ==== Migrating virtual machines from VMware vSphere
+
+include::modules/adding-source-provider.adoc[leveloffset=+4]
+include::modules/selecting-migration-network-for-vmware-source-provider.adoc[leveloffset=+4]
 
 :!vmware:
 :context: dest_vwmware
@@ -176,9 +168,10 @@ VMware only: Creating a xref:creating-vddk-image_{context}[VMware Virtual Disk D
 
 include::modules/adding-source-provider.adoc[leveloffset=+4]
 include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+4]
-:!dest_vmware:
 
-==== Migrating virtual machines from {rhv-full}
+:!dest_vmware:
+:context: vmware
+:vmware:
 
 include::modules/creating-migration-plan-2-8.adoc[leveloffset=+4]
 
@@ -189,12 +182,24 @@ include::modules/migration-plan-options-ui.adoc[leveloffset=+4]
 include::modules/canceling-migration-ui.adoc[leveloffset=+4]
 
 :!vmware:
-
-
-==== Migrating virtual machines from RHV
-
 :context: rhv
 :rhv:
+
+[id="migrating-rhv_{context}"]
+==== Migrating virtual machines from {rhv-full}
+include::modules/adding-source-provider.adoc[leveloffset=+4]
+
+:!rhv:
+:context: dest_rhv
+:dest_rhv:
+
+include::modules/adding-source-provider.adoc[leveloffset=+4]
+include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+4]
+
+:!dest_rhv:
+:context: rhv
+:rhv:
+
 include::modules/creating-migration-plan-2-8.adoc[leveloffset=+4]
 
 include::modules/running-migration-plan.adoc[leveloffset=+4]
@@ -204,18 +209,25 @@ include::modules/migration-plan-options-ui.adoc[leveloffset=+4]
 include::modules/canceling-migration-ui.adoc[leveloffset=+4]
 
 :!rhv:
-
-
-:context: dest_rhv
-:dest_rhv:
-include::modules/adding-source-provider.adoc[leveloffset=+4]
-include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+4]
-:!dest_rhv:
-
-==== Migrating virtual machines from {osp}
-
 :context: ostack
 :ostack:
+
+[id="migrating-osp_{context}"]
+==== Migrating virtual machines from {osp}
+
+include::modules/adding-source-provider.adoc[leveloffset=+4]
+
+:!ostack:
+:context: dest_ostack
+:dest_ostack:
+
+include::modules/adding-source-provider.adoc[leveloffset=+4]
+include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+4]
+
+:!dest_ostack:
+:context: ostack
+:ostack:
+
 include::modules/creating-migration-plan-2-8.adoc[leveloffset=+4]
 
 include::modules/running-migration-plan.adoc[leveloffset=+4]
@@ -225,18 +237,24 @@ include::modules/migration-plan-options-ui.adoc[leveloffset=+4]
 include::modules/canceling-migration-ui.adoc[leveloffset=+4]
 
 :!ostack:
-
-:context: dest_ostack
-:dest_ostack:
-include::modules/adding-source-provider.adoc[leveloffset=+4]
-include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+4]
-:!dest_ostack:
-
-
-==== Migrating virtual machines from OVA
-
 :context: ova
 :ova:
+
+[id="migrating-ova_{context}"]
+==== Migrating virtual machines from OVA
+
+include::modules/adding-source-provider.adoc[leveloffset=+4]
+
+:!ova:
+:context: dest_ova
+:dest_ova:
+include::modules/adding-source-provider.adoc[leveloffset=+4]
+include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+4]
+
+:!dest_ova:
+:context: ova
+:ova:
+
 include::modules/creating-migration-plan-2-8.adoc[leveloffset=+4]
 
 include::modules/running-migration-plan.adoc[leveloffset=+4]
@@ -246,20 +264,14 @@ include::modules/migration-plan-options-ui.adoc[leveloffset=+4]
 include::modules/canceling-migration-ui.adoc[leveloffset=+4]
 
 :!ova:
-:context: dest_ova
-
-:dest_ova:
-include::modules/adding-source-provider.adoc[leveloffset=+4]
-include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+4]
-:!dest_ova:
-
-
-==== Migrating virtual machines from {virt}
-
 :context: cnv
 :cnv:
 
+[id="migrating-virt_{context}"]
+==== Migrating virtual machines from {virt}
+
 include::modules/adding-source-provider.adoc[leveloffset=+4]
+
 :!cnv:
 :context: dest_cnv
 :dest_cnv:
@@ -268,15 +280,9 @@ include::modules/adding-source-provider.adoc[leveloffset=+4]
 include::modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+4]
 
 :!dest_cnv:
-:context: mtv
-:mtv:
-
-
-==== Migrating virtual machines from CNV
-
-
 :context: cnv
 :cnv:
+
 include::modules/creating-migration-plan-2-8.adoc[leveloffset=+4]
 
 include::modules/running-migration-plan.adoc[leveloffset=+4]
@@ -286,43 +292,6 @@ include::modules/migration-plan-options-ui.adoc[leveloffset=+4]
 include::modules/canceling-migration-ui.adoc[leveloffset=+4]
 
 :!cnv:
-
-
-[id="creating-migration-plans-ui_{context}"]
-=== Creating migration plans
-
-You can create a migration plan by using the {ocp} web console to specify a source provider, the virtual machines (VMs) you want to migrate, and other plan details.
-
-For your convenience, there are two procedures to create migration plans, starting with either a source provider or with specific VMs:
-
-* To start with a source provider, see xref:creating-migration-plan-2-8_provider[Creating a migration plan starting with a source provider].
-* To start with specific VMs, see xref:creating-migration-plan-2-8_vms[Creating a migration plan starting with specific VMs].
-
-
-[WARNING]
-====
-Virtual machines with guest initiated storage connections, such as Internet Small Computer Systems Interface (iSCSI) connections or Network File System (NFS) mounts, are not handled by {project-short} and could require additional planning before or reconfiguration after the migration.
-
-This is to ensure that no issues arise due to the addition or newly migrated VM accessing this storage.
-====
-
-include::modules/snip_plan-limits.adoc[]
-
-:mtv!:
-:context: provider
-:provider:
-
-include::modules/creating-migration-plan-2-8.adoc[leveloffset=+3]
-
-:provider!:
-:context: vms
-:vms:
-include::modules/creating-migration-plan-2-8.adoc[leveloffset=+3]
-
-:vms!:
-
-=======
->>>>>>> f8b824c (Cleanup master.adoc)
 :context: mtv
 :mtv:
 
@@ -338,10 +307,12 @@ You must ensure that all xref:prerequisites_{context}[prerequisites] are met.
 
 :mtv!:
 :context: cli
+:cli:
+
 include::modules/non-admin-permissions-for-ui.adoc[leveloffset=+2]
 :cli!:
 :context: mtv
-
+:mtv:
 
 
 [id="migrating-virtual-machines_{context}"]
@@ -364,28 +335,35 @@ To migrate to or from an {ocp-short} cluster that is different from the one the 
 :vmware:
 
 include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
-// Do we want this snippet here?
 include::modules/snip_vmware-permissions.adoc[]
 include::modules/retrieving-vmware-moref.adoc[leveloffset=+4]
 include::modules/canceling-migration-cli.adoc[leveloffset=+4]
+
 :vmware!:
 :context: rhv
 :rhv:
+
 include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
 include::modules/canceling-migration-cli.adoc[leveloffset=+4]
+
 :rhv!:
 :context: ostack
 :ostack:
+
 include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
 include::modules/canceling-migration-cli.adoc[leveloffset=+4]
+
 :ostack!:
 :context: ova
 :ova:
+
 include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
 include::modules/canceling-migration-cli.adoc[leveloffset=+4]
+
 :ova!:
 :context: cnv
 :cnv:
+
 include::modules/new-migrating-virtual-machines-cli.adoc[leveloffset=+3]
 include::modules/canceling-migration-cli.adoc[leveloffset=+4]
 :cnv!:

--- a/documentation/modules/creating-migration-plan-2-8.adoc
+++ b/documentation/modules/creating-migration-plan-2-8.adoc
@@ -3,10 +3,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="creating-migration-plan-2-8_{context}"]
 
-ifdef::provider[]
-= Creating a migration plan starting with a source provider
-
-
 Use the {ocp} web console to create a migration plan. Specify the source provider, the virtual machines (VMs) you want to migrate, and other plan details.
 
 [WARNING]
@@ -44,7 +40,7 @@ ifdef::vmware[]
 
 * *Warm migration*: By default, all migrations are cold migrations. For a warm migration, click the *Edit* icon and select *Warm migration*.
 * *Transfer Network*: The network used to transfer the VMs to {virt}, by default, this is the default transfer network of the provider. Verify that the transfer network is in the selected target namespace.To edit the transfer network, click the *Edit* icon, choose a different transfer network from the list in the window that opens, and click *Save*. 
-* *Target namespace*: Ddestination namespace to be used by all the migrated VMs, by default, this is the current or active namespace. To edit the namespace, click the *Edit* icon, choose a different target namespace from the list in the window that opens, and click *Save*.  
+* *Target namespace*: Destination namespace to be used by all the migrated VMs, by default, this is the current or active namespace. To edit the namespace, click the *Edit* icon, choose a different target namespace from the list in the window that opens, and click *Save*.  
 * *Preserving static IPs of VMs*: By default, virtual network interface controllers (vNICs) change during the migration process. As a result, vNICs that are configured with a static IP linked to the interface name in the guest VM lose their IP. To avoid this, click the *Edit* icon next to *Preserve static IPs* and toggle the *Whether to preserve the static IPs* switch in the window that opens. Then cl ick *Save*.
 +
 {project-short} then issues a warning message about any VMs for which vNIC properties are missing. To retrieve any missing vNIC properties, run those VMs in vSphere in order for the vNIC properties to be reported to {project-short}.
@@ -64,7 +60,7 @@ ifdef::rhv[]
 
 * *Warm migration* By default, all migrations are cold migrations. For a warm migration, click the *Edit* icon, and select *Warm migration*.
 * *Transfer Network*: The network used to transfer the VMs to {virt}, by default, this is the default transfer network of the provider. Verify that the transfer network is in the selected target namespace.To edit the transfer network, click the *Edit* icon, choose a different transfer network from the list in the window that opens, and click *Save*. 
-* *Target namespace*: Ddestination namespace to be used by all the migrated VMs, by default, this is the current or active namespace. To edit the namespace, click the *Edit* icon, choose a different target namespace from the list in the window that opens, and click *Save*.  
+* *Target namespace*: Destination namespace to be used by all the migrated VMs, by default, this is the current or active namespace. To edit the namespace, click the *Edit* icon, choose a different target namespace from the list in the window that opens, and click *Save*.  
 * *Preserving the CPU model of VMs that are migrated from {rhv-short}*: Generally, the CPU model (type) for {rhv-short} VMs is set at the cluster level, but it can be set at the VM level, which is called a custom CPU model.
 By default, {project-short} sets the CPU model on the destination cluster as follows:
 ** {project-short} preserves custom CPU settings for VMs that have them.
@@ -75,7 +71,7 @@ endif::[]
 
 ifdef::ostack,ova,cnv[]
 * *Transfer Network*: The network used to transfer the VMs to {virt}, by default, this is the default transfer network of the provider. Verify that the transfer network is in the selected target namespace.To edit the transfer network, click the *Edit* icon, choose a different transfer network from the list in the window that opens, and click *Save*. 
-* *Target namespace*: Ddestination namespace to be used by all the migrated VMs, by default, this is the current or active namespace. To edit the namespace, click the *Edit* icon, choose a different target namespace from the list in the window that opens, and click *Save*.  
+* *Target namespace*: Destination namespace to be used by all the migrated VMs, by default, this is the current or active namespace. To edit the namespace, click the *Edit* icon, choose a different target namespace from the list in the window that opens, and click *Save*.  
 endif::[]
 
 . If your plan is valid, you can do one of the following:

--- a/documentation/modules/new-migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/new-migrating-virtual-machines-cli.adoc
@@ -735,7 +735,7 @@ metadata:
   namespace: <namespace>
 spec:
   image: quay.io/konveyor/hook-runner
-  serviceAccount:<ervice account> <1>
+  serviceAccount:<service account> <1>
   playbook: |
     LS0tCi0gbm... <2>
 EOF

--- a/documentation/modules/ostack-app-cred-auth.adoc
+++ b/documentation/modules/ostack-app-cred-auth.adoc
@@ -92,4 +92,4 @@ stringData:
   url: <OS_AUTH_URL_from_openstack_rc_file>
 EOF
 ----
-. Continue migrating your virtual machine according to the procedure in xref:new-migrating-virtual-machines-cli_ostack[Migrating virtual machines], starting with step 2, "Create a `Provider` manifest for the source provider."
+// . Continue migrating your virtual machine according to the procedure in xref:new-migrating-virtual-machines-cli_ostack[Migrating virtual machines], starting with step 2, "Create a `Provider` manifest for the source provider."

--- a/documentation/modules/ostack-token-auth.adoc
+++ b/documentation/modules/ostack-token-auth.adoc
@@ -92,4 +92,4 @@ stringData:
 EOF
 ----
 
-. Continue migrating your virtual machine according to the procedure in xref:new-migrating-virtual-machines-cli_ostack[Migrating virtual machines], starting with step 2, "Create a `Provider` manifest for the source provider."
+// . Continue migrating your virtual machine according to the procedure in xref:new-migrating-virtual-machines-cli_ostack[Migrating virtual machines], starting with step 2, "Create a `Provider` manifest for the source provider."

--- a/documentation/modules/snip-mtu-value.adoc
+++ b/documentation/modules/snip-mtu-value.adoc
@@ -2,5 +2,5 @@
 
 [NOTE]
 ====
-If you input any value of maximum transmission unit (MTU) besides the default value in your migration network, you must also input the same value in the {ocp-short} transfer network that you use. For more information about the {ocp-short} transfer network, see xref:creating-migration-plan-2-8_provider[Creating a migration plan starting with a source provider] or xref:creating-migration-plan-2-8_vms[Creating a migration plan starting with specific VMs].
+If you input any value of maximum transmission unit (MTU) besides the default value in your migration network, you must also input the same value in the {ocp-short} transfer network that you use. For more information about the {ocp-short} transfer network, see xref:creating-migration-plan-2-8_{context}[Creating a migration plan].
 ====


### PR DESCRIPTION
@anarnold97 Please help! 

From the xml, it appears that master.adoc is trying run "creating-migration-plan-2.8" for dest_vmware, dest-rhv, etc.

There is a single file for creating all providers, source and destination, so I created contexts for each of them (vmware, dest_vmware, rhv, dest_rhv, etc.). but after tracing all the changes in context in master.adoc, I don't see why master is looking for creating-migration-plan-2.8_dest_vmware and the rest. I'm sure I'm missing something. 

Fixing this PR will give us a user guide with this structure:
Intro
Warm and Cold
Prerequisites
Installing and configuring the Operator
Migrating with UI (by provider)
Migrating with CLI (by provider)
All the rest 

I will need to work with master.doc again to get what we want:
Intro
Warm and Cold
Prerequisites
Installing and configuring the Operator
Migrating with UI and CLI (by provider)  
All the rest

but not this PR -- it will take some rewriting of master.doc. We should meet before I work on that. 

Thanks. 