### PR TITLE
Snippet fix

### DIFF
--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -13,6 +13,8 @@ You can migrate VMware vSphere VMs from VMware vCenter or from a VMWare ESX/ESXi
 EMS enforcement is disabled for migrations with VMware vSphere source providers in order to enable migrations from versions of vSphere that are supported by {project-full} but do not comply with the 2023 FIPS requirements. Therefore, users should consider whether migrations from vSphere source providers risk their compliance with FIPS. Supported versions of vSphere are specified in xref:../master.adoc#compatibility-guidelines_mtv[Software compatibility guidelines].
 ====
 
+include::snip-mtu-value.adoc[]
+
 .Prerequisites
 
 * It is strongly recommended to create a VMware Virtual Disk Development Kit (VDDK) image in a secure registry that is accessible to all clusters. A VDDK image accelerates migration and reduces the risk of a plan failing. If you are not using VDDK and a plan fails, then please retry with VDDK installed. For more information, see xref:../master.adoc#creating-vddk-image_mtv[Creating a VDDK image].

--- a/documentation/modules/snip-mtu-value.adoc
+++ b/documentation/modules/snip-mtu-value.adoc
@@ -1,6 +1,46 @@
 :_content-type: SNIPPET
 
+ifdef::vmware,dest_vwmware[]
+
 [NOTE]
 ====
-If you input any value of maximum transmission unit (MTU) besides the default value in your migration network, you must also input the same value in the {ocp-short} transfer network that you use. For more information about the {ocp-short} transfer network, see xref:creating-migration-plan-2-8_{context}[Creating a migration plan].
+If you input any value of maximum transmission unit (MTU) besides the default value in your migration network, you must also input the same value in the {ocp-short} transfer network that you use. For more information about the {ocp-short} transfer network, see xref:creating-migration-plan-2-8_vmware[Creating a migration plan].
 ====
+
+endif::[]
+
+ifdef::dest_rhv[]
+
+[NOTE]
+====
+If you input any value of maximum transmission unit (MTU) besides the default value in your migration network, you must also input the same value in the {ocp-short} transfer network that you use. For more information about the {ocp-short} transfer network, see xref:creating-migration-plan-2-8_rhv[Creating a migration plan].
+====
+
+endif::[]
+
+ifdef::dest_ostack[]
+
+[NOTE]
+====
+If you input any value of maximum transmission unit (MTU) besides the default value in your migration network, you must also input the same value in the {ocp-short} transfer network that you use. For more information about the {ocp-short} transfer network, see xref:creating-migration-plan-2-8_ostack[Creating a migration plan].
+====
+
+endif::[]
+
+ifdef::dest_ova[]
+
+[NOTE]
+====
+If you input any value of maximum transmission unit (MTU) besides the default value in your migration network, you must also input the same value in the {ocp-short} transfer network that you use. For more information about the {ocp-short} transfer network, see xref:creating-migration-plan-2-8_ostack[Creating a migration plan].
+====
+
+endif::[]
+
+ifdef::dest_cnv[]
+
+[NOTE]
+====
+If you input any value of maximum transmission unit (MTU) besides the default value in your migration network, you must also input the same value in the {ocp-short} transfer network that you use. For more information about the {ocp-short} transfer network, see xref:creating-migration-plan-2-8_cnv[Creating a migration plan].
+====
+
+endif::[]


### PR DESCRIPTION
@RichardHoch  - here is the snippet fix.

Basically, you would need to do create an xref with the `{context}` already defined

```
ifdef::vmware,dest_vwmware[]

[NOTE]
====
If you input any value of maximum transmission unit (MTU) besides the default value in your migration network, you must also input the same value in the {ocp-short} transfer network that you use. For more information about the {ocp-short} transfer network, see xref:creating-migration-plan-2-8_vmware[Creating a migration plan].
====

endif::[]

ifdef::dest_rhv[]

[NOTE]
====
If you input any value of maximum transmission unit (MTU) besides the default value in your migration network, you must also input the same value in the {ocp-short} transfer network that you use. For more information about the {ocp-short} transfer network, see xref:creating-migration-plan-2-8_rhv[Creating a migration plan].
====
```

### PREVIEW

* [6.1. Adding a VMware vSphere source provider](https://anarnold97.github.io/MTA-Preview/MTV/snippet-fix.html#adding-source-provider_vmware)