### PR TITLE
To be merged for 2.8.0 - MTV-2056 Warm migration -> Migration type

### DIFF
--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -9,8 +9,8 @@
 :ocp-name: OpenShift
 :ocp-short: OpenShift
 // when updating the ocp-version, update the ocp-y-version
-:ocp-version: 4.17
-:ocp-y-version: 4.17, 4.16, 4.15
+:ocp-version: 4.18
+:ocp-y-version: 4.18, 4.17, 4.16
 :operator: mtv-operator
 :operator-name-ui: Migration Toolkit for Virtualization Operator
 :operator-name: MTV Operator
@@ -18,8 +18,8 @@
 :project-full: Migration Toolkit for Virtualization
 :project-short: MTV
 :project-first: {project-full} ({project-short})
-:project-version: 2.7
-:project-z-version: 2.7.11
+:project-version: 2.8
+:project-z-version: 2.8.0
 :the: The
 :the-lc: the
 :virt: OpenShift Virtualization

--- a/documentation/modules/creating-migration-plan-2-8.adoc
+++ b/documentation/modules/creating-migration-plan-2-8.adoc
@@ -28,7 +28,7 @@ The *Select virtual machines* interface opens.
 The *Create migration plan* pane opens. It displays the source provider's name and suggestions for a target provider and namespace, a network map, and a storage map.
 . Enter the *Plan name*.
 . To change the *Target provider*, the *Target namespace*, or elements of the *Network map* or the *Storage map*, select an item from the relevant list.
-. To add either a *Network map* or a *Storage map*, click the *+* sign anf add a mapping.
+. To add either a *Network map* or a *Storage map*, click the *+* sign and add a mapping.
 . Click *Create migration plan*.
 +
 {project-short} validates the migration plan, and the *Plan details* page opens, indicating whether the plan is ready for use or contains an error.
@@ -39,30 +39,37 @@ The details of the plan are listed, and you can edit the items you filled in on 
 
 ifdef::vmware[]
 
-* *Warm migration*: By default, all migrations are cold migrations. For a warm migration, click the *Edit* icon and select *Warm migration*.
-* *Transfer Network*: The network used to transfer the VMs to {virt}, by default, this is the default transfer network of the provider. Verify that the transfer network is in the selected target namespace.To edit the transfer network, click the *Edit* icon, choose a different transfer network from the list in the window that opens, and click *Save*.
+* *Migration type*: Type of migration. By default, {project-short} sets the migration type to `cold`. 
+
+** For a warm migration, click the *Edit* icon and select *warm*.
+
+* *Transfer Network*: The network used to transfer the VMs to {virt}. This is the default transfer network of the provider. Verify that the transfer network is in the selected target namespace. 
+
+** To edit the transfer network, click the *Edit* icon, select a different transfer network from the list, and click *Save*.
+
+** (Optional): To configure an {ocp-short} network in the {ocp-short} web console by clicking *Networking > NetworkAttachmentDefinitions*.
 +
-You can configure an {ocp-short} network in the {ocp-short} web console by clicking *Networking > NetworkAttachmentDefinitions*.
-+
-ifeval::[{ocp-version} == 4.17]
-To learn more about the different types of networks {ocp-short} supports, see link:https://docs.openshift.com/container-platform/{ocp-version}/networking/multiple_networks/understanding-multiple-networks.html#additional-networks-provided_understanding-multiple-networks[Additional Networks in OpenShift Container Platform].
-endif::[]
-+
-ifeval::[{ocp-version} == 4.18]
 To learn more about the different types of networks {ocp-short} supports, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html-single/networking/index#additional-networks-provided_understanding-multiple-networks[Additional Networks in OpenShift Container Platform].
-endif::[]
-If you want to adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network. For more information see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
 
-* *Target namespace*: Destination namespace to be used by all the migrated VMs, by default, this is the current or active namespace. To edit the namespace, click the *Edit* icon, choose a different target namespace from the list in the window that opens, and click *Save*.
-* *Preserve static IPs*: By default, virtual network interface controllers (vNICs) change during the migration process. As a result, vNICs that are configured with a static IP linked to the interface name in the guest VM lose their IP. To avoid this, click the *Edit* icon next to *Preserve static IPs* and toggle the *Whether to preserve the static IPs* switch in the window that opens. Then click *Save*.
+** (Optional): To adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network For more information see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
+
+* *Target namespace*: Destination namespace for all the migrated VMs. By default, this is the current or active namespace. 
+
+** To edit the namespace, click the *Edit* icon, select a different target namespace from the list in the window that opens, and click *Save*.
+
+* *Preserve static IPs*: By default, virtual network interface controllers (vNICs) change during the migration process. As a result, vNICs that are configured with a static IP linked to the interface name in the guest VM lose their IP during migration.
+
+** To preserve static IPs, click the *Edit* icon next to *Preserve static IPs* and toggle the *Whether to preserve the static IPs* switch in the window that opens. Then click *Save*.
 +
-{project-short} then issues a warning message about any VMs for which vNIC properties are missing. To retrieve any missing vNIC properties, run those VMs in vSphere in order for the vNIC properties to be reported to {project-short}.
+{project-short} then issues a warning message about any VMs whose vNIC properties are missing. To retrieve any missing vNIC properties, run those VMs in vSphere. This causes the vNIC properties to be reported to {project-short}.
 
-* *Disk decryption passphrases*: For disks encrypted using Linux Unified Key Setup (LUKS). To enter a list of decryption passphrases for LUKS-encrypted devices, in the *Settings* section, click the *Edit* icon next to *Disk decryption passphrases*, enter the passphrases, and then click *Save*. You do not need to enter the passphrases in a specific order. For each LUKS-encrypted device, {project-short} tries each passphrase until one unlocks the device.
+* *Disk decryption passphrases*: For disks encrypted using Linux Unified Key Setup (LUKS). 
+
+** To enter a list of decryption passphrases for LUKS-encrypted devices, in the *Settings* section, click the *Edit* icon next to *Disk decryption passphrases*, enter the passphrases, and then click *Save*. You do not need to enter the passphrases in a specific order. For each LUKS-encrypted device, {project-short} tries each passphrase until one unlocks the device.
 
 * *Root device*: Applies to multi-boot VM migrations only. By default, {project-short} uses the first bootable device detected as the root device.
-+
-To specify a different root device, in the *Settings* section, click the *Edit icon* next to *Root device* and choose a device from the list of commonly-used options, or enter a device in the text box.
+
+** To specify a different root device, in the *Settings* section, click the *Edit* icon next to *Root device* and then either select a device from the list or enter a device in the text box.
 +
 {project-short} uses the following format for disk location: `/dev/sd<disk_identifier><disk_partition>`. For example, if the second disk is the root device and the operating system is on the disk's second partition, the format would be: `/dev/sdb2`. After you enter the boot device, click *Save*.
 +
@@ -71,49 +78,53 @@ If the conversion fails because the boot device provided is incorrect, it is pos
 endif::[]
 ifdef::rhv[]
 
-* *Warm migration* By default, all migrations are cold migrations. For a warm migration, click the *Edit* icon, and select *Warm migration*.
-* *Transfer Network*: The network used to transfer the VMs to {virt}, by default, this is the default transfer network of the provider. Verify that the transfer network is in the selected target namespace.To edit the transfer network, click the *Edit* icon, choose a different transfer network from the list in the window that opens, and click *Save*.
-+
-You can configure an {ocp-short} network in the {ocp-short} web console by clicking *Networking > NetworkAttachmentDefinitions*.
-+
-ifeval::[{ocp-version} == 4.17]
-To learn more about the different types of networks {ocp-short} supports, see link:https://docs.openshift.com/container-platform/{ocp-version}/networking/multiple_networks/understanding-multiple-networks.html#additional-networks-provided_understanding-multiple-networks[Additional Networks in OpenShift Container Platform].
-endif::[]
-+
-ifeval::[{ocp-version} == 4.18]
-To learn more about the different types of networks {ocp-short} supports, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html-single/networking/index#additional-networks-provided_understanding-multiple-networks[Additional Networks in OpenShift Container Platform].
-endif::[]
-If you want to adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network. For more information see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
+* *Migration type*: Type of migration. By default, {project-short} sets the migration type to `cold`. 
 
-* *Target namespace*: Destination namespace to be used by all the migrated VMs, by default, this is the current or active namespace. To edit the namespace, click the *Edit* icon, choose a different target namespace from the list in the window that opens, and click *Save*.
-* *Preserving the CPU model of VMs that are migrated from {rhv-short}*: Generally, the CPU model (type) for {rhv-short} VMs is set at the cluster level, but it can be set at the VM level, which is called a custom CPU model.
+** For a warm migration, click the *Edit* icon and select *warm*.
+
+* *Transfer Network*: The network used to transfer the VMs to {virt}. This is the default transfer network of the provider. Verify that the transfer network is in the selected target namespace. 
+
+** To edit the transfer network, click the *Edit* icon, select a different transfer network from the list, and click *Save*.
+
+** (Optional): To configure an {ocp-short} network in the {ocp-short} web console by clicking *Networking > NetworkAttachmentDefinitions*.
++
+To learn more about the different types of networks {ocp-short} supports, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html-single/networking/index#additional-networks-provided_understanding-multiple-networks[Additional Networks in OpenShift Container Platform].
+
+** (Optional): To adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network For more information see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
+
+* *Target namespace*: Destination namespace for all the migrated VMs. By default, this is the current or active namespace. 
+
+** To edit the namespace, click the *Edit* icon, select a different target namespace from the list in the window that opens, and click *Save*.
+
+* *Preserving the CPU model of VMs that are migrated from {rhv-short}*: Generally, the CPU model (type) for {rhv-short} VMs is set at the cluster level. However, the CPU model can be set at the VM level, which is called a custom CPU model.
++
 By default, {project-short} sets the CPU model on the destination cluster as follows:
 ** {project-short} preserves custom CPU settings for VMs that have them.
 ** For VMs without custom CPU settings, {project-short} does not set the CPU model. Instead, the CPU model is later set by {virt}.
-+
-To preserve the cluster-level CPU model of your {rhv-short} VMs, in the *Settings* section, click the *Edit* icon next to *Preserve CPU model*. Toggle the *Whether to preserve the CPU model* switch, and then click *Save*.
+
+** To preserve the cluster-level CPU model of your {rhv-short} VMs, in the *Settings* section, click the *Edit* icon next to *Preserve CPU model*. Toggle the *Whether to preserve the CPU model* switch, and then click *Save*.
 endif::[]
 
 ifdef::ostack,ova,cnv[]
-* *Transfer Network*: The network used to transfer the VMs to {virt}, by default, this is the default transfer network of the provider. Verify that the transfer network is in the selected target namespace.To edit the transfer network, click the *Edit* icon, choose a different transfer network from the list in the window that opens, and click *Save*.
-+
-You can configure an {ocp-short} network in the {ocp-short} web console by clicking *Networking > NetworkAttachmentDefinitions*.
-+
-ifeval::[{ocp-version} == 4.17]
-To learn more about the different types of networks {ocp-short} supports, see link:https://docs.openshift.com/container-platform/{ocp-version}/networking/multiple_networks/understanding-multiple-networks.html#additional-networks-provided_understanding-multiple-networks[Additional Networks in OpenShift Container Platform].
-endif::[]
-+
-ifeval::[{ocp-version} == 4.18]
-To learn more about the different types of networks {ocp-short} supports, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html-single/networking/index#additional-networks-provided_understanding-multiple-networks[Additional Networks in OpenShift Container Platform].
-endif::[]
-If you want to adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network. For more information see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
+* *Transfer Network*: The network used to transfer the VMs to {virt}. This is the default transfer network of the provider. Verify that the transfer network is in the selected target namespace. 
 
-* *Target namespace*: Destination namespace to be used by all the migrated VMs, by default, this is the current or active namespace. To edit the namespace, click the *Edit* icon, choose a different target namespace from the list in the window that opens, and click *Save*.
+** To edit the transfer network, click the *Edit* icon, select a different transfer network from the list, and click *Save*.
+
+** (Optional): To configure an {ocp-short} network in the {ocp-short} web console by clicking *Networking > NetworkAttachmentDefinitions*.
++
+To learn more about the different types of networks {ocp-short} supports, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html-single/networking/index#additional-networks-provided_understanding-multiple-networks[Additional Networks in OpenShift Container Platform].
+
+** (Optional): To adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network For more information see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
+
+* *Target namespace*: Destination namespace for all the migrated VMs. By default, this is the current or active namespace. 
+
+** To edit the namespace, click the *Edit* icon, select a different target namespace from the list in the window that opens, and click *Save*.
+endif::ostack,ova,cnv[]
 
 . If your plan is valid, you can do one of the following:
 .. Run the plan now by clicking *Start migration*.
 .. Run the plan later by selecting it on the *Plans for virtualization* page and following the procedure in xref:running-migration-plan_{context}[Running a migration plan].
-endif::ostack,ova,cnv[]
+
 ifdef::vmware[]
 include::snip_vmware-name-change.adoc[]
 endif::[]

--- a/documentation/modules/creating-migration-plan-2-8.adoc
+++ b/documentation/modules/creating-migration-plan-2-8.adoc
@@ -51,7 +51,7 @@ ifdef::vmware[]
 +
 To learn more about the different types of networks {ocp-short} supports, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html-single/networking/index#additional-networks-provided_understanding-multiple-networks[Additional Networks in OpenShift Container Platform].
 
-** (Optional): To adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network For more information see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
+** (Optional): To adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network. For more information, see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
 
 * *Target namespace*: Destination namespace for all the migrated VMs. By default, this is the current or active namespace. 
 

--- a/documentation/modules/creating-migration-plan-2-8.adoc
+++ b/documentation/modules/creating-migration-plan-2-8.adoc
@@ -90,7 +90,7 @@ ifdef::rhv[]
 +
 To learn more about the different types of networks {ocp-short} supports, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html-single/networking/index#additional-networks-provided_understanding-multiple-networks[Additional Networks in OpenShift Container Platform].
 
-** (Optional): To adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network For more information see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
+** (Optional): To adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network. For more information, see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
 
 * *Target namespace*: Destination namespace for all the migrated VMs. By default, this is the current or active namespace. 
 

--- a/documentation/modules/creating-migration-plan-2-8.adoc
+++ b/documentation/modules/creating-migration-plan-2-8.adoc
@@ -114,7 +114,7 @@ ifdef::ostack,ova,cnv[]
 +
 To learn more about the different types of networks {ocp-short} supports, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html-single/networking/index#additional-networks-provided_understanding-multiple-networks[Additional Networks in OpenShift Container Platform].
 
-** (Optional): To adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network For more information see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
+** (Optional): To adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network. For more information, see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
 
 * *Target namespace*: Destination namespace for all the migrated VMs. By default, this is the current or active namespace. 
 


### PR DESCRIPTION
MTV 2.8

Hold for MTV 2.8

- Resolves https://issues.redhat.com/browse/MTV-2056 by changing the name of the "Warm migration" label to "Migration type" in the MTV 2.8 documentation set. This is the first item of step 8 of "Creating a migration plan" for VMware and RHV.
- Rewrite of all of step 8 of "Creating a migration plan" for all providers. 

Previews:

- https://file.corp.redhat.com/rhoch/warm_mig_ui/html-single/#creating-migration-plan-2-8_vmware [Step 8]
- https://file.corp.redhat.com/rhoch/warm_mig_ui/html-single/#creating-migration-plan-2-8_rhv [Step 8]
- https://file.corp.redhat.com/rhoch/warm_mig_ui/html-single/#creating-migration-plan-2-8_ostack [step 8]