### PR TITLE
MTV-2167: Release notes for MTV 2.7.11

### DIFF
--- a/documentation/modules/known-issues-2-7.adoc
+++ b/documentation/modules/known-issues-2-7.adoc
@@ -35,3 +35,17 @@ Migration fails if the module configuration file is available in the guest and t
 .Harden grub2-mkconfig to avoid overwriting `/boot/efi/EFI/redhat/grub.cfg`
 
 In Red Hat Enterprise Linux (RHEL) 9, there has been a significant change in how GRUB is handled on UEFI systems. Previously, the GRUB configuration file, `/boot/efi/EFI/redhat/grub.cfg`, was used on UEFI systems. However, in RHEL 9, this file now serves as a stub that dynamically redirects to the GRUB configuration, located at `/boot/grub2/grub.cfg`. This behavior is expected in RHEL 9.4, but has been resolved in RHEL 9.5. link:https://issues.redhat.com/browse/RHEL-32099[(RHEL-32099)]
+
+.Migration fails for VMs backed by vSAN without VDDK
+
+Migrations for virtual machines (VMs) that are backed by VMware vSAN must use a Virtual Disk Development Kit (VDDK) image. Without a VDDK image, these migrations fail. link:https://issues.redhat.com/browse/MTV-2203[(MTV-2203)]
+
+.Migrated VMs that use the diskBus:scsi option fail to boot
+
+VMs that are migrated in migration plans by using the `plan.spec.diskBus:scsi` option fail to boot after migration as follows:
+
+* All Windows VMs fail to boot.
+* Some Linux VMs fail to boot.
+
+VMs that use the `plan.spec.diskBus:sata` and `plan.spec.diskBus:virtio` options successfully boot after migration. link:https://issues.redhat.com/browse/MTV-2199[(MTV-2199)]
+

--- a/documentation/modules/new-features-and-enhancements-2-7.adoc
+++ b/documentation/modules/new-features-and-enhancements-2-7.adoc
@@ -6,10 +6,35 @@
 
 * In {project-short} 2.7.0, warm migration is now based on RHEL 9 inheriting features and bug fixes.
 
-// https://issues.redhat.com/browse/MTV-2039
+// https://issues.redhat.com/browse/MTV-2039 and https://issues.redhat.com/browse/MTV-2199
 * In {project-short} 2.7.10, you can specify the `plan.spec.diskBus` which will be on all disks during the creation.
 +
 Possible options are:
 * SCSI
 * SATA
 * VirtIO
+
+[NOTE]
+====
+Virtual machines (VMs) that are migrated in migration plans by using the `diskBus:scsi` option fail to boot after migration as follows:
+
+* All Windows VMs fail to boot.
+* Some Linux VMs fail to boot.
+
+VMs that use the `plan.spec.diskBus:sata` and `plan.spec.diskBus:virtio` options successfully boot after migration.
+====
+
+
+// https://issues.redhat.com/browse/MTV-2029
+* In {project-short} 2.7.11, you can now migrate shared disks from VMware vSphere by using a new parameter named `migrateSharedDisks` in `Plan` CRs.
++
+The parameter can be set to `true` or `false`:
+
+** When set to `true,` {project-short} migrates all shared disks in the CR. 
+** When set to `false`, {project-short} does not migrate the shared disks. 
+
+[NOTE]
+====
+`migrateSharedDisks` applies only to cold migrations. Warm migration of shared disks is not supported. 
+====
+

--- a/documentation/modules/rn-27-resolved-issues.adoc
+++ b/documentation/modules/rn-27-resolved-issues.adoc
@@ -7,6 +7,13 @@
 
 {project-first} 2.7 has the following resolved issues:
 
+[id="resolved-issues-2-7-11_{context}"]
+== Resolved issues 2.7.11
+
+.Main controller container of forklift controller crashes during VMware migrations
+
+In earlier releases of {project-short}, the main controller container of `forklift-container` crashed during VMware migrations because users created snapshots of the virtual machines (VMs) during migrations. As a result, some VMs migrated, but others failed to migrate. This issue has been resolved in {project-short} 2.7.11, but users are cautioned not to create snapshots of VMs during migrations. link:https://issues.redhat.com/browse/MTV-2164[(MTV-2164)]
+
 [id="resolved-issues-2-7-10_{context}"]
 == Resolved issues 2.7.10
 
@@ -15,7 +22,6 @@
 In earlier releases of {project-short}, the OVN secondary network was not working with Multus default network override. This issue caused the importer pod to become stuck, as the importer pod was created when there were multiple networks and the wrong default network override annotation was configured. This issue has been resolved in {project-short} 2.7.10. link:https://issues.redhat.com/browse/MTV-1645[(MTV-1645)]
 
 .Retain IP field description misleading to customers
-
 
 In earlier releases of {project-short}, it was difficult to understand the user interface relating to the *Preserve IPs* VM setting in the chosen setting mode. This issue has been resolved in {project-short} 2.7.10. link:https://issues.redhat.com/browse/MTV-1743[(MTV-1743)]
 


### PR DESCRIPTION
MTV 2.7.11

Resolves https://issues.redhat.com/browse/MTV-2167 by creating release notes for MTV 2.7.11.

**New feature**:

[MTV-2029](https://issues.redhat.com/browse/MTV-2029): Shared disk

**Resolved issue**:

[MTV-2164](https://issues.redhat.com/browse/MTV-2164): Main controller container of forklift controller crashes during VMware migrations

**Known issue**: 
[MTV-2203](https://issues.redhat.com/browse/MTV-2203) fails for VMs backed by vSAN without VDDK
[MTV-2199](https://issues.redhat.com/browse/MTV-2199) diskBus:scsi issue

Previews: 

- https://file.corp.redhat.com/rhoch/MTV-2167-release-notes-2.7.11/html-single/#new-features-and-enhancements-2-7_release-notes [last item and the note above it]
- https://file.corp.redhat.com/rhoch/MTV-2167-release-notes-2.7.11/html-single/#resolved-issues-2-7-11_release-notes
- https://file.corp.redhat.com/rhoch/MTV-2167-release-notes-2.7.11/html-single/#known-issues-2-7_release-notes [last 2 items]

