### PR TITLE
CLI implementation of configuring NAD

### DIFF
--- a/documentation/modules/new-migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/new-migrating-virtual-machines-cli.adoc
@@ -750,6 +750,24 @@ You can use the default `hook-runner` image or specify a custom image. If you sp
 
 ifdef::vmware[]
 [start=7]
+. Enter the following command to create the network attachment definition (NAD) of the transfer network used for {project-short} migrations. 
++
+You use this definition to configure an IP address for the interface, either from the Dynamic Host Configuration Protocol (DHCP) or statically. 
++
+Configuring the IP address enables the interface to reach the configured gateway. 
++
+[source,yaml,subs="attributes+"]
+----
+$ oc edit NetworkAttachmentDefinitions <name_of_the_NAD_to_edit>
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: <name_of_transfer_network>
+  namespace: <namespace>
+  annotations:
+    forklift.konveyor.io/route: <IP_address> 
+----
+
 . Create a `Plan` manifest for the migration:
 +
 [source,yaml,subs="attributes+"]
@@ -808,6 +826,24 @@ endif::[]
 
 ifdef::rhv[]
 [start=6]
+. Enter the following command to create the network attachment definition (NAD) of the transfer network used for {project-short} migrations. 
++
+You use this definition to configure an IP address for the interface, either from the Dynamic Host Configuration Protocol (DHCP) or statically. 
++
+Configuring the IP address enables the interface to reach the configured gateway. 
++
+[source,yaml,subs="attributes+"]
+----
+$ oc edit NetworkAttachmentDefinitions <name_of_the_NAD_to_edit>
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: <name_of_transfer_network>
+  namespace: <namespace>
+  annotations:
+    forklift.konveyor.io/route: <IP_address> 
+----
+
 . Create a `Plan` manifest for the migration:
 +
 [source,yaml,subs="attributes+"]
@@ -873,6 +909,24 @@ endif::[]
 
 ifdef::ova[]
 [start=6]
+. Enter the following command to create the network attachment definition (NAD) of the transfer network used for {project-short} migrations. 
++
+You use this definition to configure an IP address for the interface, either from the Dynamic Host Configuration Protocol (DHCP) or statically. 
++
+Configuring the IP address enables the interface to reach the configured gateway. 
++
+[source,yaml,subs="attributes+"]
+----
+$ oc edit NetworkAttachmentDefinitions <name_of_the_NAD_to_edit>
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: <name_of_transfer_network>
+  namespace: <namespace>
+  annotations:
+    forklift.konveyor.io/route: <IP_address> 
+----
+
 . Create a `Plan` manifest for the migration:
 +
 [source,yaml,subs="attributes+"]
@@ -924,6 +978,24 @@ endif::[]
 
 ifdef::ostack[]
 [start=6]
+. Enter the following command to create the network attachment definition (NAD) of the transfer network used for {project-short} migrations. 
++
+You use this definition to configure an IP address for the interface, either from the Dynamic Host Configuration Protocol (DHCP) or statically. 
++
+Configuring the IP address enables the interface to reach the configured gateway. 
++
+[source,yaml,subs="attributes+"]
+----
+$ oc edit NetworkAttachmentDefinitions <name_of_the_NAD_to_edit>
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: <name_of_transfer_network>
+  namespace: <namespace>
+  annotations:
+    forklift.konveyor.io/route: <IP_address> 
+----
+
 . Create a `Plan` manifest for the migration:
 +
 [source,yaml,subs="attributes+"]
@@ -975,6 +1047,24 @@ endif::[]
 
 ifdef::cnv[]
 [start=6]
+. Enter the following command to create the network attachment definition (NAD) of the transfer network used for {project-short} migrations. 
++
+You use this definition to configure an IP address for the interface, either from the Dynamic Host Configuration Protocol (DHCP) or statically. 
++
+Configuring the IP address enables the interface to reach the configured gateway. 
++
+[source,yaml,subs="attributes+"]
+----
+$ oc edit NetworkAttachmentDefinitions <name_of_the_NAD_to_edit>
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: <name_of_transfer_network>
+  namespace: <namespace>
+  annotations:
+    forklift.konveyor.io/route: <IP_address> 
+----
+
 . Create a `Plan` manifest for the migration:
 +
 [source,yaml,subs="attributes+"]


### PR DESCRIPTION
MTV 2.8.0

Resolves https://issues.redhat.com/browse/MTV-2238 for the CLI instructions by inserting a step before creating the Plan CR. 

Preview: 

- https://file.corp.redhat.com/rhoch/cli_nad/html-single/#new-migrating-virtual-machines-cli_vmware [step 7]
- https://file.corp.redhat.com/rhoch/cli_nad/html-single/#new-migrating-virtual-machines-cli_rhv [step 6]
- https://file.corp.redhat.com/rhoch/cli_nad/html-single/#new-migrating-virtual-machines-cli_ostack [step 6]
- https://file.corp.redhat.com/rhoch/cli_nad/html-single/#new-migrating-virtual-machines-cli_ova [step 6]
- https://file.corp.redhat.com/rhoch/cli_nad/html-single/#new-migrating-virtual-machines-cli_cnv [step 6]

