### PR TITLE
TO BE MERGED FOR MTV 2.8.1: Migrating shared boot disks is not supported

### DIFF
--- a/documentation/modules/mtv-shared-disks.adoc
+++ b/documentation/modules/mtv-shared-disks.adoc
@@ -6,7 +6,7 @@
 [id="mtv-shared-disks_{context}"]
 = Migrating virtual machines with shared disks
 
-You can migrate VMware virtual machines (VMs) with shared disks by using the {project-first}. This functionality is available for cold migrations only. 
+You can migrate VMware virtual machines (VMs) with shared disks by using the {project-first}. This functionality is available only for cold migrations and is not available for shared boot disks. 
 
 Shared disks are disks that are attached to more than one VM and that use the multi-writer option. As a result of these characteristics, shared disks are difficult to migrate. 
  


### PR DESCRIPTION
MTV 2.8.1

Resolves https://issues.redhat.com/browse/MTV-2201 by adding a few words to the description of migrating shared disks.

Preview:

https://file.corp.redhat.com/rhoch/no_shared_boot_disks/html-single/#mtv-shared-disks_vmware [2nd sentence]. 
