### PR TITLE
TO BE MERGED FOR MTV 2.8.1: Add a name for a target VM

### DIFF
--- a/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+++ b/documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
@@ -88,6 +88,7 @@ include::modules/ostack-app-cred-auth.adoc[leveloffset=+4]
 :mtv:
 
 include::modules/vmware-prerequisites.adoc[leveloffset=+2]
+include::modules/creating-vmware-role-mtv-permissions.adoc[leveloffset=+3]
 include::modules/creating-vddk-image.adoc[leveloffset=+3]
 include::modules/increasing-nfc-memory-vmware-host.adoc[leveloffset=+3]
 include::modules/vddk-validator-containers.adoc[leveloffset=+3]

--- a/documentation/modules/creating-vmware-role-mtv-permissions.adoc
+++ b/documentation/modules/creating-vmware-role-mtv-permissions.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Migration_Toolkit_for_Virtualization/master.adoc
+
+:_content-type: PROCEDURE
+[id="creating-vmware-role-mtv-permissions_{context}"]
+= Creating a VMware role to grant MTV privileges
+
+You can create a role in VMware to grant privileges for {project-first} and then grant those privileges to users with that role.  
+
+The procedure that follows explains how to do this in general. For detailed instructions, see VMware documentation.
+
+.Procedure
+
+. In the vCenter Server UI, create a role that includes the set of privileges described in the table in xref:vmware-prerequisites_mtv[VMware prerequisites].
+. In the vSphere inventory UI, grant privileges for users with this role to the appropriate vSphere logical objects at one of the following levels:
+
+.. At the user or group level: Assign privileges to the appropriate logical objects in the data center and use the *Propagate to child objects* option. 
+.. At the object level: Apply the same role individually to all the relevant vSphere logical objects involved in the migration, for example, hosts, vSphere clusters, data centers, or networks. 

--- a/documentation/modules/new-migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/new-migrating-virtual-machines-cli.adoc
@@ -808,13 +808,14 @@ spec:
     - id: <source_vm1> <13>
     - name: <source_vm2>
       networkNameTemplate: <network_interface_template_for_this_vm> <14>
-      pvcNameTemplate:   <pvc_name_template_for_this_vm> <15> 
-      volumeNameTemplate:   <volume_name_template_for_this_vm> <16>
-      hooks: <17>
+      pvcNameTemplate: <pvc_name_template_for_this_vm> <15> 
+      volumeNameTemplate: <volume_name_template_for_this_vm> <16>
+      targetName: <target_name> <17>
+      hooks: <18>
         - hook:
             namespace: <namespace>
-            name: <hook> <18>
-          step: <step> <19>
+            name: <hook> <19>
+          step: <step> <20>
 
 EOF
 ----
@@ -863,9 +864,10 @@ The template follows the Go template syntax and has access to the following vari
 <14> Optional. Specify a network interface name for the specific VM. Overrides the value set in `spec:networkNameTemplate`. Variables and examples as in xref:callout9[callout 9].
 <15> Optional. Specify a PVC name for the specific VM. Overrides the value set in `spec:pvcNameTemplate`. Variables and examples as in xref:callout10[callout 10]. 
 <16> Optional. Specify a volume name for the specific VM. Overrides the value set in `spec:volumeNameTemplate`. Variables and examples as in xref:callout11[callout 11].
-<17> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
-<18> Specify the name of the `Hook` CR.
-<19> Allowed values are `PreHook`, before the migration plan starts, or `PostHook`, after the migration is complete.
+<17> Optional: {project-short} automatically generates a name for the target VM. You can override this name by using this parameter and entering a new name. The name you enter must be unique and it must be a valid Kubernetes subdomain. Otherwise, the migration fails automatically.
+<18> Optional: Specify up to two hooks for a VM. Each hook must run during a separate migration step.
+<19> Specify the name of the `Hook` CR.
+<20> Allowed values are `PreHook`, before the migration plan starts, or `PostHook`, after the migration is complete.
 +
 include::snip_vmware-name-change.adoc[]
 endif::[]
@@ -938,7 +940,7 @@ EOF
 <8> Specify the name of the `StorageMap` CR.
 <9> You can use either the `id` or the `name` parameter to specify the source VMs.
 <10> Specify the {rhv-short} VM UUID.
-<11> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
+<11> Optional: Specify up to two hooks for a VM. Each hook must run during a separate migration step.
 <12> Specify the name of the `Hook` CR.
 <13> Allowed values are `PreHook`, before the migration plan starts, or `PostHook`, after the migration is complete.
 +
@@ -1086,7 +1088,7 @@ EOF
 <6> Specify the name of the `StorageMap` CR.
 <7> You can use either the `id` or the `name` parameter to specify the source VMs.
 <8> Specify the {osp} VM UUID.
-<9> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
+<9> Optional: Specify up to two hooks for a VM. Each hook must run during a separate migration step.
 <10> Specify the name of the `Hook` CR.
 <11> Allowed values are `PreHook`, before the migration plan starts, or `PostHook`, after the migration is complete.
 endif::[]
@@ -1153,7 +1155,7 @@ EOF
 <4> Specify the name of the `NetworkMap` CR.
 <5> Specify a storage mapping, even if the VMs to be migrated are not assigned with disk images. The mapping can be empty in this case.
 <6> Specify the name of the `StorageMap` CR.
-<7> Optional: You can specify up to two hooks for a VM. Each hook must run during a separate migration step.
+<7> Optional: Specify up to two hooks for a VM. Each hook must run during a separate migration step.
 <8> Specify the name of the `Hook` CR.
 <9> Allowed values are `PreHook`, before the migration plan starts, or `PostHook`, after the migration is complete.
 endif::[]

--- a/documentation/modules/vmware-prerequisites.adoc
+++ b/documentation/modules/vmware-prerequisites.adoc
@@ -22,7 +22,7 @@ The following prerequisites apply to VMware migrations:
 
 [IMPORTANT]
 ====
-In the event of a power outage, data might be lost for a VM with disabled hibernation. However, if hibernation is not disabled, migration will fail
+In case of a power outage, data might be lost for a VM with disabled hibernation. However, if hibernation is not disabled, migration will fail.
 ====
 
 [NOTE]
@@ -90,3 +90,8 @@ All `Virtual machine.Provisioning` privileges are required.
 |`Cryptographic.Decrypt` |Allows decryption of an encrypted virtual machine.
 |`Cryptographic.Direct access` |Allows access to encrypted resources.
 |===
+
+[TIP]
+==== 
+Create a role in VMware with the permissions described in the preceding table and then apply this role to the *Inventory* section, as described in xref:creating-vmware-role-mtv-permissions_mtv[Creating a VMware role to apply MTV permissions]
+====


### PR DESCRIPTION
MTV 2.8.1

Resolves https://issues.redhat.com/browse/MTV-2095 by adding a new parameter, `targetName` to the `vms` section of the `Plan` CR for VMware.

Previews:

- https://file.corp.redhat.com/rhoch/non_conform_vm_name/html-single/#new-migrating-virtual-machines-cli_vmware [step 8, callout 17]


Note: This item will also be included in the MTV 2.8.1 release notes. 
