### PR TITLE
Option to not map network during creation of CLI migration plan

### DIFF
--- a/documentation/modules/new-migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/new-migrating-virtual-machines-cli.adoc
@@ -396,7 +396,7 @@ spec:
       namespace: <namespace>
 EOF
 ----
-<1> Allowed values are `pod` and `multus`.
+<1> Allowed values are `pod`, `multus`, and `ignored`. Use `ignored` to avoid attaching VMs to this network for this migration. 
 <2> You can use either the `id` or the `name` parameter to specify the source network. For `id`, specify the VMware vSphere network Managed Object Reference (moRef). To retrieve the moRef, see xref:retrieving-vmware-moref_vmware[Retrieving a VMware vSphere moRef].
 <3> Specify a network attachment definition for each additional {virt} network.
 <4> Required only when `type` is `multus`. Specify the namespace of the {virt} network attachment definition.


### PR DESCRIPTION
MTV 2.8.1

Resolves https://issues.redhat.com/browse/MTV-2357 by adding a new valid value, `ignored`, to `spec:map:destination:type` in the `NetworkMap` CR. 

Preview: https://file.corp.redhat.com/rhoch/no_map_network_cli/html-single/#new-migrating-virtual-machines-cli_vmware [step 4, callout 1] 