### PR TITLE
Warn against taking snapshots after migration starts

### DIFF
--- a/documentation/modules/creating-migration-plan-2-8.adoc
+++ b/documentation/modules/creating-migration-plan-2-8.adoc
@@ -55,11 +55,11 @@ ifdef::vmware[]
 *** Select a different transfer network from the list.
 *** Click *Save*.
 
-** (Optional): To configure an {ocp-short} network in the {ocp-short} web console, click *Networking > NetworkAttachmentDefinitions*.
+** Optional: To configure an {ocp-short} network in the {ocp-short} web console, click *Networking > NetworkAttachmentDefinitions*.
 +
 To learn more about the different types of networks {ocp-short} supports, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html-single/networking/index#additional-networks-provided_understanding-multiple-networks[Additional Networks in OpenShift Container Platform].
 
-** (Optional): To adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network. For more information, see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
+** Optional: To adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network. For more information, see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
 
 * *Target namespace*: Destination namespace for all the migrated VMs. By default, the destination namespace is the current or active namespace.
 
@@ -114,7 +114,7 @@ Migrating shared disks might slow down the migration process.
 *** Toggle the *Migrate shared disks* switch.
 *** Click *Save*.
 
-* (Optional): *PVC name template*: Specifies a template for the name of the persistent volume claim (PVC) for the VMs in your plan. 
+* Optional: *PVC name template*: Specifies a template for the name of the persistent volume claim (PVC) for the VMs in your plan. 
 +
 The template follows the Go template syntax and has access to the following variables:
 
@@ -151,7 +151,7 @@ Variable names cannot exceed 63 characters.
 Changes you make in the  *Virtual Machines* tab override any changes in the *Plan details* page.
 ====
 
-* (Optional): *Volume name template*: Specifies a template for the volume interface name for the VMs in your plan.
+* Optional: *Volume name template*: Specifies a template for the volume interface name for the VMs in your plan.
 +
 The template follows the Go template syntax and has access to the following variables:
 
@@ -186,7 +186,7 @@ Variable names cannot exceed 63 characters
 Changes you make in the *Virtual Machines* tab override any changes in the *Plan details* page.
 ====
 
-* (Optional): *Network name template*: Specifies a template for the network interface name for the VMs in your plan.
+* Optional: *Network name template*: Specifies a template for the network interface name for the VMs in your plan.
 +
 The template follows the Go template syntax and has access to the following variables:
 
@@ -241,11 +241,11 @@ ifdef::rhv[]
 *** Select a different transfer network from the list.
 *** Click *Save*.
 
-** (Optional): To configure an {ocp-short} network in the {ocp-short} web console, click *Networking > NetworkAttachmentDefinitions*.
+** Optional: To configure an {ocp-short} network in the {ocp-short} web console, click *Networking > NetworkAttachmentDefinitions*.
 +
 To learn more about the different types of networks {ocp-short} supports, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html-single/networking/index#additional-networks-provided_understanding-multiple-networks[Additional Networks in OpenShift Container Platform].
 
-** (Optional): To adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network. For more information, see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
+** Optional: To adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network. For more information, see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
 
 * *Target namespace*: Destination namespace for all the migrated VMs. By default, the destination namespace is the current or active namespace.
 
@@ -277,11 +277,11 @@ ifdef::ostack,ova,cnv[]
 *** Select a different transfer network from the list.
 *** Click *Save*.
 
-** (Optional): To configure an {ocp-short} network in the {ocp-short} web console, click *Networking > NetworkAttachmentDefinitions*.
+** Optional: To configure an {ocp-short} network in the {ocp-short} web console, click *Networking > NetworkAttachmentDefinitions*.
 +
 To learn more about the different types of networks {ocp-short} supports, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html-single/networking/index#additional-networks-provided_understanding-multiple-networks[Additional Networks in OpenShift Container Platform].
 
-** (Optional): To adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network. For more information, see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
+** Optional: To adjust the maximum transmission unit (MTU) of the {ocp-short} transfer network, you must also change the MTU of the VMware migration network. For more information, see xref:selecting-migration-network-for-vmware-source-provider_vmware[Selecting a migration network for a VMware source provider].
 
 * *Target namespace*: Destination namespace for all the migrated VMs. By default, the destination namespace is the current or active namespace.
 
@@ -295,6 +295,11 @@ endif::ostack,ova,cnv[]
 . If your plan is valid, you can do one of the following:
 .. Run the plan now by clicking *Start migration*.
 .. Run the plan later by selecting it on the *Plans for virtualization* page and following the procedure in xref:running-migration-plan_{context}[Running a migration plan].
+
+[WARNING]
+====
+Do not take a snapshot of a VM after you start a migration. Taking a snaphot after a migration starts might cause the migration to fail. 
+====
 
 ifdef::vmware[]
 include::snip_vmware-name-change.adoc[]

--- a/documentation/modules/running-migration-plan.adoc
+++ b/documentation/modules/running-migration-plan.adoc
@@ -14,7 +14,7 @@ You can run a migration plan and view its progress in the {ocp} web console.
 
 .Procedure
 
-. In the {ocp} web console, click *Migration* -> *Plans for virtualization*.
+. In the {ocp} web console, click *Migration* > *Plans for virtualization*.
 +
 The *Plans* list displays the source and target providers, the number of virtual machines (VMs) being migrated, the status, the date that the migration started, and the description of each plan.
 
@@ -23,10 +23,17 @@ The *Plans* list displays the source and target providers, the number of virtual
 +
 The plan's *Status* changes to *Running*, and the migration's progress is displayed.
 +
+ifdef::vmware,rhv[]
 Warm migration only:
 
 * The precopy stage starts.
 * Click *Cutover* to complete the migration.
+endif::vmware,rhv[]
++
+[WARNING]
+====
+Do not take a snapshot of a VM after you start a migration. Taking a snaphot after a migration starts might cause the migration to fail. 
+====
 
 . Optional: Click the links in the migration's *Status* to see its overall status and the status of each VM:
 


### PR DESCRIPTION
MTV 2.8.2

Resolves https://issues.redhat.com/browse/MTV-2223 by adding a warning against taking snapshots of VMs to the procedure for creating a migration plan and the procedure for running a migration plan:

Previews:
- https://file.corp.redhat.com/rhoch/no_snapshots_during_migs/html-single/#creating-migration-plan-2-8_vmware [Warning after step 9]
- https://file.corp.redhat.com/rhoch/no_snapshots_during_migs/html-single/#running-migration-plan_vmware [warning after step 3, procedure include "warm migration only" section, as expected] 
- https://file.corp.redhat.com/rhoch/no_snapshots_during_migs/html-single/#running-migration-plan_rhv [same, RHV] 

The PR also corrects some small formatting errors and ensures that a reference to warm migration in "Running a migration plan" is only visible for VMware and RHV procedures.

Previews of OpenStack, OVA, and CNV versions of "Running a migration plan" to show they do not refer to warm migration:

- https://file.corp.redhat.com/rhoch/no_snapshots_during_migs/html-single/#running-migration-plan_ostack [OpenStack, as expected, no "warm migration only" after step 3] 
- https://file.corp.redhat.com/rhoch/no_snapshots_during_migs/html-single/#running-migration-plan_ova [OVA, smae]
- https://file.corp.redhat.com/rhoch/no_snapshots_during_migs/html-single/#running-migration-plan_cnv [CNV, same]

