### PR TITLE
Bump upstream doc version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You must have Podman installed.
 
 1. Clone the repository:
   ```console
-  $ git clone -b source https://github.com/konveyor/forklift-documentation.git && cd forklift-documentation
+  $ git clone -b source https://github.com/kubev2v/forklift-documentation.git && cd forklift-documentation
   ```
 2. Create `.jekyll-cache` and `_site` directories:
   ```console

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ show_downloads: false
 title: "Forklift Documentation"
 description: "Migrating VMware virtual machines to KubeVirt"
 permalink: pretty
-repository: konveyor/forklift-documentation
+repository: kubev2v/forklift-documentation
 baseurl: /
 tags: "migration, VMware, OpenShift Virtualization, KubeVirt, migrating, virtual machines, OpenShift"
 
@@ -35,7 +35,6 @@ asciidoctor:
   - a-virt=a KubeVirt
   - oc=kubectl
   - ocp=OKD
-  - ocp-version=4.10
   - ocp-short=OKD
   - user-guide-title=Installing and using Forklift
   - rn-title=Release notes
@@ -52,15 +51,13 @@ asciidoctor:
   - build=upstream
   - keywords=migration, virtual machines, kubevirt
   - imagesdir=../modules/images
-  - must-gather=quay.io/konveyor/forklift-must-gather:latest
+  - must-gather=quay.io/kubev2v/forklift-must-gather:latest
   - namespace=konveyor-forklift
   - operator=forklift-operator
   - operator-name=Forklift Operator
   - project-short=Forklift
   - project-full=Forklift
   - project-first=Forklift
-  - project-version=2.3
-  - project-z-version=2.3.0
   - the-lc=
   - the=
   - experimental

--- a/assets/img/logo_location.txt
+++ b/assets/img/logo_location.txt
@@ -1,1 +1,1 @@
-https://github.com/konveyor/community/tree/main/brand/logo
+https://github.com/kubev2v/forklift-documentation/tree/main/assets/img

--- a/documentation/modules/about-hooks-for-migration-plans.adoc
+++ b/documentation/modules/about-hooks-for-migration-plans.adoc
@@ -13,7 +13,7 @@ You can add hooks to {project-first} migration plans using either the {project-s
 
 [id="default-hook-image_{context}"]
 == Default hook image
-The default hook image for an {project-short} hook is `quay.io/konveyor/hook-runner`. The image is based on the Ansible Runner image with the addition of `python-openshift` to provide Ansible Kubernetes resources and a recent `oc` binary.
+The default hook image for an {project-short} hook is `quay.io/kubev2v/hook-runner`. The image is based on the Ansible Runner image with the addition of `python-openshift` to provide Ansible Kubernetes resources and a recent `oc` binary.
 
 [id="hook-execution_{context}"]
 == Hook execution

--- a/documentation/modules/adding-hook-using-cli.adoc
+++ b/documentation/modules/adding-hook-using-cli.adoc
@@ -67,7 +67,7 @@ metadata:
   name: <hook>
   namespace: <namespace>
 spec:
-  image: quay.io/konveyor/hook-runner
+  image: quay.io/kubev2v/hook-runner
   serviceAccount:<service account> <1>
   playbook: |
     LS0tCi0gbm... <2>

--- a/documentation/modules/new-migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/new-migrating-virtual-machines-cli.adoc
@@ -739,7 +739,7 @@ metadata:
   name: <hook>
   namespace: <namespace>
 spec:
-  image: quay.io/konveyor/hook-runner
+  image: quay.io/kubev2v/hook-runner
   serviceAccount:<service account> <1>
   playbook: |
     LS0tCi0gbm... <2>

--- a/index.adoc
+++ b/index.adoc
@@ -4,7 +4,7 @@
 
 ## What is Forklift?
 
-Forklift is a tool in the link:https://konveyor.io/[Konveyor community] for migrating virtual machines from VMware or oVirt to KubeVirt.
+Forklift is a tool for migrating virtual machines from VMware, OpenStack, KubeVirt, OVA files or oVirt to KubeVirt.
 
 ## Documentation
 


### PR DESCRIPTION
Update configuration files:

  - [x] Remove upstream mtv version, mtv z version and ocp version, fallback on downstream versions.
  - [x] Remove user facing `konveyor` with `kubev2v` strings
  - [x] Remove link to https://konveyor.io 
  
 Upstream documentaion:
https://kubev2v.github.io/forklift-documentation/