### PR TITLE
HOLD FOR MTV 2.8.3: Add shared parameter to PVC name template

### DIFF
--- a/documentation/modules/new-migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/new-migrating-virtual-machines-cli.adoc
@@ -745,7 +745,7 @@ spec:
     LS0tCi0gbm... <2>
 EOF
 ----
-<1> (Optional) {ocp} service account. The `serviceAccount` must be provided if you want to manipulate any resources of the cluster.
+<1> Optional: {ocp} service account. Use the `serviceAccount` parameter to modify any cluster resources.
 <2> Base64-encoded Ansible Playbook. If you specify a playbook, the `image` must include an `ansible-runner`.
 +
 [NOTE]
@@ -847,10 +847,12 @@ The template follows the Go template syntax and has access to the following vari
 * `.PlanName`: Name of the migration plan.
 * `.DiskIndex`: Initial volume index of the disk.
 * `.RootDiskIndex`: Index of the root disk.
+* `.Shared`: Options: `true`, for a shared volume, `false`, for a non-shared volume. 
 +
 *Examples*
 * `"{{.VmName}}-disk-{{.DiskIndex}}"`
 * `"{{if eq .DiskIndex .RootDiskIndex}}root{{else}}data{{end}}-{{.DiskIndex}}"`
+* `"{{if .Shared}}shared-{{end}}{{.VmName}}-{{.DiskIndex}}"`
 +
 <11> Optional:
 * When set to `true`, {project-short} adds one or more randonly generated alphanumeric characters to the name of the PVC in order to ensure all PVCs have unique names. 


### PR DESCRIPTION
MTV 2.8.3

Resolves https://issues.redhat.com/browse/MTV-2339 by adding the `shared` parameter to the PVC name template.

Preview: https://file.corp.redhat.com/rhoch/pvc_shared/html-single/#new-migrating-virtual-machines-cli_vmware [step 8, callout 10. Note that callout 16 refers to callout 10, so callout 16 does not need to be changed.]