### PR TITLE
HOLD FOR MTV 2.8.3: Warning about anti-virus software

### DIFF
--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -13,6 +13,7 @@ You can migrate VMware vSphere VMs from VMware vCenter or from a VMWare ESX/ESXi
 EMS enforcement is disabled for migrations with VMware vSphere source providers in order to enable migrations from versions of vSphere that are supported by {project-full} but do not comply with the 2023 FIPS requirements. Therefore, users should consider whether migrations from vSphere source providers risk their compliance with FIPS. Supported versions of vSphere are specified in xref:../master.adoc#compatibility-guidelines_mtv[Software compatibility guidelines].
 ====
 
+include::snip_anti-virus-warning.adoc[]
 include::snip-mtu-value.adoc[]
 
 .Prerequisites

--- a/documentation/modules/new-migrating-virtual-machines-cli.adoc
+++ b/documentation/modules/new-migrating-virtual-machines-cli.adoc
@@ -10,6 +10,8 @@ ifdef::vmware[]
 
 You can migrate from a VMware vSphere source provider by using the command-line interface (CLI).
 
+include::snip_anti-virus-warning.adoc[]
+
 [NOTE]
 ====
 To migrate virtual machines (VMs) that have shared disks, see xref:mtv-shared-disks_{context}[Migrating virtual machines with shared disks]. 

--- a/documentation/modules/snip_anti-virus-warning.adoc
+++ b/documentation/modules/snip_anti-virus-warning.adoc
@@ -1,0 +1,6 @@
+:_content-type: SNIPPET
+
+[IMPORTANT]
+====
+Anti-virus software can cause migrations to fail. It is strongly recommended to remove such software from source VMs before you start a migration. 
+====


### PR DESCRIPTION
MTV 2.8.3

Resolves https://issues.redhat.com/browse/MTV-2452 by adding an admonition that anti-virus software on a source VM might cause a migration to fail.

Previews:

https://file.corp.redhat.com/rhoch/anti_virus_warning/html-single/#adding-source-provider_vmware [2nd admonition]
https://file.corp.redhat.com/rhoch/anti_virus_warning/html-single/#new-migrating-virtual-machines-cli_vmware [1st admonition]