### PR TITLE
MTV 2.8.4: Update RHV port requirements

### DIFF
--- a/documentation/modules/network-prerequisites.adoc
+++ b/documentation/modules/network-prerequisites.adoc
@@ -60,12 +60,6 @@ Disk transfer authentication
 
 Disk transfer authentication
 
-|443
-|TCP
-|OpenShift nodes
-|{rhv-short} hosts
-|Disk transfer authentication
-
 |54322
 |TCP
 |OpenShift nodes


### PR DESCRIPTION
MTV 2.8.4

Resolves https://issues.redhat.com/browse/MTV-2411 by removing an incorrect RHV port destination.

Preview: https://file.corp.redhat.com/rhoch/MTV-2411-rhv-port-req/html-single/#ports_mtv [Table 3.3]  

Replaces https://github.com/kubev2v/forklift-documentation/pull/694 [Closed].