### PR TITLE
HOLD FOR MTV 2.8.4: MTV 2.8.4 Attributes

### DIFF
--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -19,7 +19,7 @@
 :project-short: MTV
 :project-first: {project-full} ({project-short})
 :project-version: 2.8
-:project-z-version: 2.8.3
+:project-z-version: 2.8.4
 :the: The
 :the-lc: the
 :virt: OpenShift Virtualization


### PR DESCRIPTION
MTV 2.8.4

Resolves https://issues.redhat.com/browse/MTV-2505 by updating the attribute file for MTV 2.8.4.

Previews:

https://file.corp.redhat.com/rhoch/MTV-2505-284-attributes/html-single/#installing-mtv-operator_cli [step 3]
https://file.corp.redhat.com/rhoch/MTV-2505-284-attributes/html-single/#using-must-gather_mtv [steps 2 and 3]
https://file.corp.redhat.com/rhoch/MTV-2505-284-attributes/html-single/#accessing-logs-cli_mtv [steps 2 and 3]