### PR TITLE
HOLD FOR MTV 2.8.5: MTV-2593-MTV-2_8_5-attributes: MTV 2.8.5 attributes

### DIFF
--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -19,7 +19,7 @@
 :project-short: MTV
 :project-first: {project-full} ({project-short})
 :project-version: 2.8
-:project-z-version: 2.8.4
+:project-z-version: 2.8.5
 :the: The
 :the-lc: the
 :virt: OpenShift Virtualization


### PR DESCRIPTION
MTV 2.8.5

Resolves https://issues.redhat.com/browse/MTV-2593 by updating common-attributes.adoc

Previews: 

- https://file.corp.redhat.com/rhoch/MTV-2593-MTV-2_8_5-attributes/html-single/#installing-mtv-operator_cli [step 3]
- https://file.corp.redhat.com/rhoch/MTV-2593-MTV-2_8_5-attributes/html-single/#using-must-gather_mtv [steps 2 and 3]
- https://file.corp.redhat.com/rhoch/MTV-2593-MTV-2_8_5-attributes/html-single/#accessing-logs-cli_mtv [steps 2 and 3]