### PR TITLE
MTV-2585: Accessing Providers in MTV 2.9.0

### DIFF
--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -6,11 +6,11 @@
 ifdef::vmware[]
 = Adding a VMware vSphere source provider
 
-You can migrate VMware vSphere VMs from VMware vCenter or from a VMWare ESX/ESXi server. In {project-short} versions 2.6 and later, you can migrate directly from an ESX/ESXi server, without going through vCenter, by specifying the SDK endpoint to that of an ESX/ESXi server.
+You can migrate {vmw} vSphere VMs from {vmw} vCenter or from a {vmw} ESX/ESXi server, without going through vCenter.
 
 [IMPORTANT]
 ====
-EMS enforcement is disabled for migrations with VMware vSphere source providers in order to enable migrations from versions of vSphere that are supported by {project-full} but do not comply with the 2023 FIPS requirements. Therefore, users should consider whether migrations from vSphere source providers risk their compliance with FIPS. Supported versions of vSphere are specified in xref:../master.adoc#compatibility-guidelines_mtv[Software compatibility guidelines].
+EMS enforcement is disabled for migrations with {vmw} vSphere source providers in order to enable migrations from versions of vSphere that are supported by {project-full} but do not comply with the 2023 FIPS requirements. Therefore, users should consider whether migrations from vSphere source providers risk their compliance with FIPS. Supported versions of vSphere are specified in xref:../master.adoc#compatibility-guidelines_mtv[Software compatibility guidelines].
 ====
 
 include::snip_anti-virus-warning.adoc[]
@@ -21,7 +21,7 @@ include::snip-mtu-value.adoc[]
 
 .Prerequisites
 
-* It is strongly recommended to create a VMware Virtual Disk Development Kit (VDDK) image in a secure registry that is accessible to all clusters. A VDDK image accelerates migration and reduces the risk of a plan failing. If you are not using VDDK and a plan fails, then please retry with VDDK installed. For more information, see xref:../master.adoc#creating-vddk-image_mtv[Creating a VDDK image].
+* It is strongly recommended to create a {vmw} Virtual Disk Development Kit (VDDK) image in a secure registry that is accessible to all clusters. A VDDK image accelerates migration and reduces the risk of a plan failing. If you are not using VDDK and a plan fails, then please retry with VDDK installed. For more information, see xref:../master.adoc#creating-vddk-image_mtv[Creating a VDDK image].
 
 include::snip-vsan.adoc[]
 
@@ -38,7 +38,7 @@ endif::[]
 ifdef::ova[]
 = Adding an Open Virtual Appliance (OVA) source provider
 
-You can add Open Virtual Appliance (OVA) files that were created by VMware vSphere as a source provider by using the {ocp} web console.
+You can add Open Virtual Appliance (OVA) files that were created by {vmw} vSphere as a source provider by using the {ocp} web console.
 
 endif::[]
 ifdef::ostack[]
@@ -83,12 +83,30 @@ endif::[]
 
 .Procedure
 
-. In the {ocp} web console, click *Migration* -> *Providers for virtualization*.
-. Click *Create Provider*.
 ifdef::vmware[]
-. Click *vSphere*.
-. Specify the following fields:
+. Access the *Create provider* page for {vmw} by doing one of the following:
 
+.. In the {ocp} web console, click *Migration for Virtualization > Providers*.
+... Click *Create Provider*.
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
++
+If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
++
+If you have Administrator privileges, you can see all projects, otherwise, you can see only the projects you are authorized to work with.
+
+... Click *{vmw}*.
+
+.. If you have Administrator privileges, in the {ocp} web console, click *Migration for Virtualization > Overview*.
+... In the *Welcome* pane, click *{vmw}*.
++ 
+If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page, and click *{vmw}* when the *Welcome* pane opens.
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
++
+If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
++
+If you have Administrator privileges, you can see all projects, otherwise, you can see only the projects you are authorized to work with.
+
+. Specify the following fields:
 +
 *Provider details*
 
@@ -96,21 +114,40 @@ ifdef::vmware[]
 * *Endpoint type*: Select the vSphere provider endpoint type. Options: *vCenter* or *ESXi*. You can migrate virtual machines from vCenter, an ESX/ESXi server that is not managed by vCenter, or from an ESX/ESXi server that is managed by vCenter but does not go through vCenter.
 * *URL*: URL of the SDK endpoint of the vCenter on which the source VM is mounted. Ensure that the URL includes the `sdk` path, usually `/sdk`. For example, `https://vCenter-host-example.com/sdk`. If a certificate for FQDN is specified, the value of this field needs to match the FQDN in the certificate.
 * *VDDK init image*: `VDDKInitImage` path. It is strongly recommended to create a VDDK init image to accelerate migrations. For more information, see xref:../master.adoc#creating-vddk-image_mtv[Creating a VDDK image].
-
-
 +
 *Provider credentials*
 
 * *Username*: vCenter user or ESXi user. For example, `user@vsphere.local`.
 * *Password*: vCenter user password or ESXi user password.
 
-[start=5]
+[start=3]
 include::snip-certificate-options.adoc[]
 
 endif::[]
 
 ifdef::rhv[]
-. Click *Red Hat Virtualization*
+. Access the *Create provider* page for {rhv-full} by doing one of the following:
+
+.. In the {ocp} web console, click *Migration for Virtualization > Providers*.
+... Click *Create Provider*.
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
++
+If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
++
+If you have Administrator privileges, you can see all projects, otherwise, you can see only the projects you are authorized to work with.
++
+... Click *{rhv-full}*.
+
+.. If you have Administrator privileges, in the {ocp} web console, click  *Migration for Virtualization > Overview*.
+... In the *Welcome* pane, click *{rhv-full}*.
++
+If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page, and click *{rhv-full}* when the *Welcome* pane opens.
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
++
+If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
++
+If you have Administrator privileges, you can see all projects, otherwise, you can see only the projects you are authorized to work with.
+
 . Specify the following fields:
 
 * *Provider resource name*: Name of the source provider.
@@ -121,14 +158,54 @@ ifdef::rhv[]
 include::snip-certificate-options.adoc[]
 endif::[]
 ifdef::ova[]
-. Click *Open Virtual Appliance (OVA)*.
+. Access the *Create provider* page for Open Virtual Appliance by doing one of the following:
+
+.. In the {ocp} web console, click *Migration for Virtualization > Providers*.
+... Click *Create Provider*.
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
++
+If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
++
+If you have Administrator privileges, you can see all projects, otherwise, you can see only the projects you are authorized to work with.
+... Click *Open Virtual Appliance*.
+
+.. If you have Administrator privileges, in the {ocp} web console, click *Migration for Virtualization > Overview*.
+... In the *Welcome* pane, click *Open Virtual Appliance*.
++
+If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page, and click *Open Virtual Appliance* when the *Welcome* pane opens.
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
++
+If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
++
+If you have Administrator privileges, you can see all projects, otherwise, you can see only the projects you are authorized to work with.
+
 . Specify the following fields:
 
 * *Provider resource name*: Name of the source provider
 * *URL*: URL of the NFS file share that serves the OVA
 endif::[]
 ifdef::ostack[]
-. Click *OpenStack*.
+. Access the *Create provider* page for {osp} by doing one of the following:
+
+.. In the {ocp} web console, click *Migration for Virtualization > Providers*.
+... Click *Create Provider*.
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
++
+If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
++
+If you have Administrator privileges, you can see all projects, otherwise, you can see only the projects you are authorized to work with.
+... Click *{osp}*.
+
+.. If you have Administrator privileges, in the {ocp} web console, click *Migration for Virtualization > Overview*.
+... In the *Welcome* pane, click *{osp}*.
++
+If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page, and click *{osp}* when the *Welcome* pane opens.
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
++
+If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
++
+If you have Administrator privileges, you can see all projects, otherwise, you can see only the projects you are authorized to work with.
+
 . Specify the following fields:
 
 * *Provider resource name*: Name of the source provider.
@@ -164,8 +241,28 @@ ifdef::ostack[]
 +
 include::snip-certificate-options.adoc[]
 endif::[]
+
 ifdef::cnv[]
-. Click *{virt}*.
+. Access the *Create provider* interface {virt} by doing one of the following:
+
+.. In the {ocp} web console, click *Migration for Virtualization > Providers*.
+... Click *Create Provider*.
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
++
+If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
++
+If you have Administrator privileges, you can see all projects, otherwise, you can see only the projects you are authorized to work with.
+... Click *{virt}*.
+
+.. If you have Administrator privileges, in the {ocp} web console, click *Migration for Virtualization > Overview*.
+... In the *Welcome* pane, click *{virt}*.
++
+If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page, and click *{virt}* when the *Welcome* pane opens.
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
++
+If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
++
+If you have Administrator privileges, you can see all projects, otherwise, you can see only the projects you are authorized to work with.
 . Specify the following fields:
 
 * *Provider resource name*: Name of the source provider
@@ -176,8 +273,29 @@ If both *URL* and *Service account bearer token* are left blank, the local {ocp-
 +
 include::snip-certificate-options.adoc[]
 endif::[]
+
 ifdef::dest_vmware,dest_rhv,dest_ostack,dest_ova,dest_cnv[]
-. Click *{virt}*.
+. Access the *Create {virt} provider* interface by doing one of the following:
+
+.. In the {ocp} web console, click *Migration for Virtualization > Providers*.
+... Click *Create Provider*.
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
++
+If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
++
+If you have Administrator privileges, you can see all projects, otherwise, you can see only the projects you are authorized to work with.
+... Click *{virt}*.
+
+.. If you have Administrator privileges, in the {ocp} web console, click *Migration for Virtualization > Overview*.
+... In the *Welcome* pane, click *{virt}*.
++
+If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page, and click *{virt}* when the *Welcome* pane opens.
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
++
+If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
++
+If you have Administrator privileges, you can see all projects, otherwise, you can see only the projects you are authorized to work with.
+
 . Specify the following fields:
 
 * *Provider resource name*: Name of the source provider


### PR DESCRIPTION
MTV 2.9.0 

Resolves https://issues.redhat.com/browse/MTV-2585 by adjusting the first step of the "Create Providers" procedure to also allow access from the Overview page.

Previews:

- https://file.corp.redhat.com/rhoch/MTV-2585-accessing-providers/html-single/#adding-source-provider_vmware [step 1]
- https://file.corp.redhat.com/rhoch/MTV-2585-accessing-providers/html-single/#adding-source-provider_rhv [step 1]
- https://file.corp.redhat.com/rhoch/MTV-2585-accessing-providers/html-single/#adding-source-provider_ostack [step 1]
- https://file.corp.redhat.com/rhoch/MTV-2585-accessing-providers/html-single/#adding-source-provider_ova [step 1]
- https://file.corp.redhat.com/rhoch/MTV-2585-accessing-providers/html-single/#adding-source-provider_cnv [step 1]
- https://file.corp.redhat.com/rhoch/MTV-2585-accessing-providers/html-single/#adding-source-provider_dest_cnv [step 1]
