### PR TITLE
MTV-2899: Updating MTV 2.8 Prerequisites

### DIFF
--- a/documentation/modules/installing-mtv-operator.adoc
+++ b/documentation/modules/installing-mtv-operator.adoc
@@ -17,7 +17,7 @@ endif::[]
 
 .Prerequisites
 
-* {ocp} {ocp-version} or later installed.
+* {ocp} {ocp-y-version} or later installed.
 * {virt} Operator installed on an OpenShift migration target cluster.
 * You must be logged in as a user with `cluster-admin` permissions.
 


### PR DESCRIPTION
### JIRA

* [MTV-2899](https://issues.redhat.com/browse/MTV-2899)

Updating the attribute used in prerequisites from:
```
ocp-version: 4.18
```
to 
```
ocp-y-version: 4.18, 4.17, 4.16
```

this will update with each release to ensure we keep to OCP `n -2`

![image](https://github.com/user-attachments/assets/9ed631a3-e13b-422e-a186-d0d428eacc1f)
