### PR TITLE
MTV 2300 Page details tabs

### DIFF
--- a/documentation/modules/creating-plan-wizard-290-cnv.adoc
+++ b/documentation/modules/creating-plan-wizard-290-cnv.adoc
@@ -155,7 +155,7 @@ When your plan is validated, the *Plan details* page for your plan opens in the 
 +
 . When you have fixed all conditions listed, you can run your plan from the *Plans* page.
 +
-The *Plan details* page also includes five additional tabs, which are described on the table that follows:
+The *Plan details* page also includes five additional tabs, which are described in the table that follows:
 +
 [cols="1,1,1,1,1",options="header"]
 .Tabs of the Plan details page
@@ -166,7 +166,7 @@ The *Plan details* page also includes five additional tabs, which are described 
 |Mappings
 |Hooks
 
-|Editable YAML `Plan` manifest based on your plan's details including source provider, network and storage maps, VMs, and any issues with your VMs.
+|Editable YAML `Plan` manifest based on your plan's details including source provider, network and storage maps, VMs, and any issues with your VMs
 |The VMs the plan migrates
 |Calculated resources: VMs, CPUs, and total memory for both total VMs and running VMs
 |Editable specification of the network and storage maps used by your plan

--- a/documentation/modules/creating-plan-wizard-290-ostack.adoc
+++ b/documentation/modules/creating-plan-wizard-290-ostack.adoc
@@ -155,7 +155,7 @@ When your plan is validated, the *Plan details* page for your plan opens in the 
 
 . When you have fixed all conditions listed, you can run your plan from the *Plans* page.
 +
-The *Plan details* page also includes five additional tabs, which are described on the table that follows:
+The *Plan details* page also includes five additional tabs, which are described in the table that follows:
 +
 [cols="1,1,1,1,1",options="header"]
 .Tabs of the Plan details page
@@ -166,7 +166,7 @@ The *Plan details* page also includes five additional tabs, which are described 
 |Mappings
 |Hooks
 
-|Editable YAML `Plan` manifest based on your plan's details including source provider, network and storage maps, VMs, and any issues with your VMs.
+|Editable YAML `Plan` manifest based on your plan's details including source provider, network and storage maps, VMs, and any issues with your VMs
 |The VMs the plan migrates
 |Calculated resources: VMs, CPUs, and total memory for both total VMs and running VMs
 |Editable specification of the network and storage maps used by your plan

--- a/documentation/modules/creating-plan-wizard-290-ova.adoc
+++ b/documentation/modules/creating-plan-wizard-290-ova.adoc
@@ -155,7 +155,7 @@ When your plan is validated, the *Plan details* page for your plan opens in the 
 
 . When you have fixed all conditions listed, you can run your plan from the *Plans* page.
 +
-The *Plan details* page also includes five additional tabs, which are described on the table that follows:
+The *Plan details* page also includes five additional tabs, which are described in the table that follows:
 +
 [cols="1,1,1,1,1",options="header"]
 .Tabs of the Plan details page
@@ -166,7 +166,7 @@ The *Plan details* page also includes five additional tabs, which are described 
 |Mappings
 |Hooks
 
-|Editable YAML `Plan` manifest based on your plan's details including source provider, network and storage maps, VMs, and any issues with your VMs.
+|Editable YAML `Plan` manifest based on your plan's details including source provider, network and storage maps, VMs, and any issues with your VMs
 |The VMs the plan migrates
 |Calculated resources: VMs, CPUs, and total memory for both total VMs and running VMs
 |Editable specification of the network and storage maps used by your plan

--- a/documentation/modules/creating-plan-wizard-290-rhv.adoc
+++ b/documentation/modules/creating-plan-wizard-290-rhv.adoc
@@ -180,7 +180,7 @@ To preserve the cluster-level CPU model of your RHV VMs, do the following:
 +
 . When you have fixed all conditions listed, you can run your plan from the *Plans* page.
 +
-The *Plan details* page also includes five additional tabs, which are described on the table that follows:
+The *Plan details* page also includes five additional tabs, which are described in the table that follows:
 +
 [cols="1,1,1,1,1",options="header"]
 .Tabs of the Plan details page
@@ -191,7 +191,7 @@ The *Plan details* page also includes five additional tabs, which are described 
 |Mappings
 |Hooks
 
-|Editable YAML `Plan` manifest based on your plan's details including source provider, network and storage maps, VMs, and any issues with your VMs.
+|Editable YAML `Plan` manifest based on your plan's details including source provider, network and storage maps, VMs, and any issues with your VMs
 |The VMs the plan migrates
 |Calculated resources: VMs, CPUs, and total memory for both total VMs and running VMs
 |Editable specification of the network and storage maps used by your plan

--- a/documentation/modules/creating-plan-wizard-290-vmware.adoc
+++ b/documentation/modules/creating-plan-wizard-290-vmware.adoc
@@ -317,7 +317,7 @@ Changes you make on the *Virtual Machines* tab override any changes on the *Plan
 +
 . When you have fixed all conditions listed, you can run your plan from the *Plans* page.
 +
-The *Plan details* page also includes five additional tabs, which are described on the table that follows:
+The *Plan details* page also includes five additional tabs, which are described in the table that follows:
 +
 [cols="1,1,1,1,1",options="header"]
 .Tabs of the Plan details page
@@ -328,7 +328,7 @@ The *Plan details* page also includes five additional tabs, which are described 
 |Mappings
 |Hooks
 
-|Editable YAML `Plan` manifest based on your plan's details including source provider, network and storage maps, VMs, and any issues with your VMs.
+|Editable YAML `Plan` manifest based on your plan's details including source provider, network and storage maps, VMs, and any issues with your VMs
 |The VMs the plan migrates
 |Calculated resources: VMs, CPUs, and total memory for both total VMs and running VMs
 |Editable specification of the network and storage maps used by your plan


### PR DESCRIPTION
MTV 2.9.0

Resolves https://issues.redhat.com/browse/MTV-2300 and https://issues.redhat.com/browse/MTV-2301 by documenting the tabs on the Plan details page:

Previews:

- https://file.corp.redhat.com/rhoch/MTV-2300-page-details-tabs/html-single/#creating-plan-wizard-290-vmware_vmware [Steps 21, 23, and 24]
- https://file.corp.redhat.com/rhoch/MTV-2300-page-details-tabs/html-single/#creating-plan-wizard-290-rhv_rhv [Steps 21, 23, and 24]
- https://file.corp.redhat.com/rhoch/MTV-2300-page-details-tabs/html-single/#creating-plan-wizard-290-ostack_ostack [Steps 19-21]
- https://file.corp.redhat.com/rhoch/MTV-2300-page-details-tabs/html-single/#creating-plan-wizard-290-ova_ova [Steps 19-21]
- https://file.corp.redhat.com/rhoch/MTV-2300-page-details-tabs/html-single/#creating-plan-wizard-290-cnv_cnv [Steps 19-21]