### PR TITLE
MTV-3046 Add ability to upload  a VDDK init image archive to UI

### DIFF
--- a/documentation/modules/adding-source-provider.adoc
+++ b/documentation/modules/adding-source-provider.adoc
@@ -88,7 +88,7 @@ ifdef::vmware[]
 
 .. In the {ocp} web console, click *Migration for Virtualization > Providers*.
 ... Click *Create Provider*.
-... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}.
 +
 If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
 +
@@ -100,7 +100,7 @@ If you have Administrator privileges, you can see all projects, otherwise, you c
 ... In the *Welcome* pane, click *{vmw}*.
 + 
 If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page, and click *{vmw}* when the *Welcome* pane opens.
-... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}.
 +
 If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
 +
@@ -108,14 +108,28 @@ If you have Administrator privileges, you can see all projects, otherwise, you c
 
 . Specify the following fields:
 +
-*Provider details*
+.. *Provider details*
 
 * *Provider resource name*: Name of the source provider.
 * *Endpoint type*: Select the vSphere provider endpoint type. Options: *vCenter* or *ESXi*. You can migrate virtual machines from vCenter, an ESX/ESXi server that is not managed by vCenter, or from an ESX/ESXi server that is managed by vCenter but does not go through vCenter.
 * *URL*: URL of the SDK endpoint of the vCenter on which the source VM is mounted. Ensure that the URL includes the `sdk` path, usually `/sdk`. For example, `https://vCenter-host-example.com/sdk`. If a certificate for FQDN is specified, the value of this field needs to match the FQDN in the certificate.
 * *VDDK init image*: `VDDKInitImage` path. It is strongly recommended to create a VDDK init image to accelerate migrations. For more information, see xref:creating-vddk-image_mtv[Creating a VDDK image].
 +
-*Provider credentials*
+Do one of the following:
+
+** Select the *Skip VMWare Virtual Disk Development Kit (VDDK) SDK acceleration (not recommended)*.
+
+** Enter the path in the *VDDK init image* text box. Format: `<registry_route_or_server_path>/vddk:<tag>`.
+
+** Upload a VDDK archive and build a VDDK init image from the archive by doing the following:
+
+*** Click *Browse* next to the *VDDK init image archive* text box, select the desired file, and click *Select*.
+
+*** Click *Upload*.
++
+The URL of the uploaded archive is displayed in the *VDDK init image archive* text box.
+
+.. *Provider credentials*
 
 * *Username*: vCenter user or ESXi user. For example, `user@vsphere.local`.
 * *Password*: vCenter user password or ESXi user password.
@@ -130,7 +144,7 @@ ifdef::rhv[]
 
 .. In the {ocp} web console, click *Migration for Virtualization > Providers*.
 ... Click *Create Provider*.
-... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}.
 +
 If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
 +
@@ -142,7 +156,7 @@ If you have Administrator privileges, you can see all projects, otherwise, you c
 ... In the *Welcome* pane, click *{rhv-full}*.
 +
 If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page, and click *{rhv-full}* when the *Welcome* pane opens.
-... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}.
 +
 If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
 +
@@ -162,7 +176,7 @@ ifdef::ova[]
 
 .. In the {ocp} web console, click *Migration for Virtualization > Providers*.
 ... Click *Create Provider*.
-... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}.
 +
 If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
 +
@@ -173,7 +187,7 @@ If you have Administrator privileges, you can see all projects, otherwise, you c
 ... In the *Welcome* pane, click *Open Virtual Appliance*.
 +
 If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page, and click *Open Virtual Appliance* when the *Welcome* pane opens.
-... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}.
 +
 If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
 +
@@ -189,7 +203,7 @@ ifdef::ostack[]
 
 .. In the {ocp} web console, click *Migration for Virtualization > Providers*.
 ... Click *Create Provider*.
-... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}.
 +
 If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
 +
@@ -200,7 +214,7 @@ If you have Administrator privileges, you can see all projects, otherwise, you c
 ... In the *Welcome* pane, click *{osp}*.
 +
 If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page, and click *{osp}* when the *Welcome* pane opens.
-... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}.
 +
 If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
 +
@@ -247,7 +261,7 @@ ifdef::cnv[]
 
 .. In the {ocp} web console, click *Migration for Virtualization > Providers*.
 ... Click *Create Provider*.
-... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}.
 +
 If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
 +
@@ -258,7 +272,7 @@ If you have Administrator privileges, you can see all projects, otherwise, you c
 ... In the *Welcome* pane, click *{virt}*.
 +
 If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page, and click *{virt}* when the *Welcome* pane opens.
-... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}.
 +
 If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
 +
@@ -279,7 +293,7 @@ ifdef::dest_vmware,dest_rhv,dest_ostack,dest_ova,dest_cnv[]
 
 .. In the {ocp} web console, click *Migration for Virtualization > Providers*.
 ... Click *Create Provider*.
-... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}.
 +
 If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
 +
@@ -290,7 +304,7 @@ If you have Administrator privileges, you can see all projects, otherwise, you c
 ... In the *Welcome* pane, click *{virt}*.
 +
 If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page, and click *{virt}* when the *Welcome* pane opens.
-... Select a *Project* from the list. The default project shown depends on the active project of {project-short}. 
+... Select a *Project* from the list. The default project shown depends on the active project of {project-short}.
 +
 If the active project is *All projects*, then the default project is `openshift-mtv`. Otherwise, the default project is the same as the active project.
 +

--- a/documentation/modules/creating-plan-wizard-290-vmware.adoc
+++ b/documentation/modules/creating-plan-wizard-290-vmware.adoc
@@ -142,7 +142,7 @@ To learn more about the different types of networks {ocp-short} supports, see li
 
 * *Root device*: Applies to multi-boot VM migrations only. By default, {project-short} uses the first bootable device detected as the root device.
 
-** To specify a different root device, enter it in the textbox.
+** To specify a different root device, enter it in the text box.
 +
 {project-short} uses the following format for disk location: `/dev/sd<disk_identifier><disk_partition>`. For example, if the second disk is the root device and the operating system is on the disk's second partition, the format would be: `/dev/sdb2`. After you enter the boot device, click *Save*.
 +


### PR DESCRIPTION
MTV 2.9.4

Resolves https://issues.redhat.com/browse/MTV-3046 by adding a description of how to upload  a VDDK init image archive to to the Create VMware provider page in the UI.

Preview: https://file.corp.redhat.com/rhoch/MTV-3046_VDDK_UI/html-single/#adding-source-provider_vmware [step 2a, 3rd bullet]