### PR TITLE
MTV-3506: Fixes bulleted list in user guide section 2.4

### DIFF
--- a/documentation/modules/about-cold-warm-migration.adoc
+++ b/documentation/modules/about-cold-warm-migration.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 {project-first} supports cold and warm migration as follows:
 
-{project-short} supports cold migration from these source providers:
+{project-short} supports cold migration from the following source providers:
 
 * {vmw} vSphere
 * {rhv-full} ({rhv-short})
@@ -17,7 +17,8 @@
 * Open Virtual Appliances (OVAs) that were created by {vmw} vSphere
 * Remote {virt} clusters
 
-{project-short} supports warm migration from these source providers:
+{project-short} supports warm migration from the following source providers:
+
 * {vmw} vSphere
 * {rhv-full}
 


### PR DESCRIPTION
MTV 2.9.3

Resolves https://issues.redhat.com/browse/MTV-3506 by fixing the second bulleted list in https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.9/html/installing_and_using_the_migration_toolkit_for_virtualization/mtv-cold-warm-migration_mtv#about-cold-warm-migration_mtv

Preview:  https://file.corp.redhat.com/rhoch/MTV-3506_formatting/html-single/#about-cold-warm-migration_mtv [2nd bulleted list]