### PR TITLE
MTV-2712 | use build-specific variables for hook-runner and must-gather images

### DIFF
--- a/documentation/modules/about-hooks-for-migration-plans.adoc
+++ b/documentation/modules/about-hooks-for-migration-plans.adoc
@@ -18,7 +18,7 @@ Hook types::
 
 Hook configuration::
 
-* Default hook image: The default hook image for an {project-short} hook is `quay.io/kubev2v/hook-runner`. The image is based on the Ansible Runner image with the addition of `python-openshift` to provide Ansible Kubernetes resources and a recent `oc` binary.
+* Default hook image: The default hook image for an {project-short} hook is `{hook-runner-image}`. The image is based on the Ansible Runner image with the addition of `python-openshift` to provide Ansible Kubernetes resources and a recent `{oc}` binary.
 * Hook execution: An Ansible Playbook that is provided as part of a migration hook is mounted into the hook container as a `ConfigMap`. The hook container is run as a job on the relevant cluster in the `openshift-mtv` namespace. When you add a hook, you must specify the name of the hook and whether it is a pre-migration hook or a post-migration hook.
 * Service account: You can optionally specify a service account when adding a hook. When you add a hook by using the {ocp} web console, you can specify the service account name in the *Service account* field when creating or editing the migration plan. When you add a hook by using the CLI, you can specify the service account in the `Hook` CR. If you specify a service account, it must have the appropriate RBAC permissions to manage cluster resources and at least write access for the `openshift-mtv` namespace where hooks execute.
 

--- a/documentation/modules/accessing-logs-cli.adoc
+++ b/documentation/modules/accessing-logs-cli.adoc
@@ -28,7 +28,7 @@ If you specify a non-existent resource in the filtered `must-gather` command, no
 +
 [source,terminal,subs="attributes+"]
 ----
-$ {oc} adm must-gather --image={must-gather}
+$ {oc} adm must-gather --image={must-gather-image}
 ----
 +
 The data is saved as `/must-gather/must-gather.tar.gz`. You can upload this file to a support case on the link:https://access.redhat.com/[Red Hat Customer Portal].
@@ -39,7 +39,7 @@ The data is saved as `/must-gather/must-gather.tar.gz`. You can upload this file
 +
 [source,terminal,subs="attributes+"]
 ----
-$ {oc} adm must-gather --image={must-gather} \
+$ {oc} adm must-gather --image={must-gather-image} \
   -- NS=<namespace> /usr/bin/targeted
 ----
 
@@ -47,7 +47,7 @@ $ {oc} adm must-gather --image={must-gather} \
 +
 [source,terminal,subs="attributes+"]
 ----
-$ {oc} adm must-gather --image={must-gather} \
+$ {oc} adm must-gather --image={must-gather-image} \
   -- PLAN=<migration_plan> /usr/bin/targeted
 ----
 
@@ -55,7 +55,7 @@ $ {oc} adm must-gather --image={must-gather} \
 +
 [source,terminal,subs="attributes+"]
 ----
-$ {oc} adm must-gather --image={must-gather} \
+$ {oc} adm must-gather --image={must-gather-image} \
   -- VM=<vm_name> NS=<namespace> /usr/bin/targeted
 ----
 +

--- a/documentation/modules/adding-hook-using-cli.adoc
+++ b/documentation/modules/adding-hook-using-cli.adoc
@@ -55,7 +55,7 @@ metadata:
   name: <hook>
   namespace: <namespace>
 spec:
-  image: quay.io/kubev2v/hook-runner
+  image: {hook-runner-image}
   serviceAccount: <service_account>
   playbook: |
     <playbook>

--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -25,7 +25,8 @@
 :project-z-version: 2.11.1
 :rhel-first: Red Hat Enterprise Linux (RHEL)
 :virt: OpenShift Virtualization
-:must-gather: registry.redhat.io/migration-toolkit-virtualization/mtv-must-gather-rhel8:{project-z-version}
+:must-gather-image: registry.redhat.io/migration-toolkit-virtualization/mtv-must-gather-rhel8:{project-z-version}
+:hook-runner-image: registry.redhat.io/migration-toolkit-virtualization/mtv-hook-runner-rhel8:{project-z-version}
 :rhv-full: Red Hat Virtualization
 :rhv-short: RHV
 :a-rhv: a {rhv-full}

--- a/documentation/modules/migrating-live-cnv-cnv-vms-cli.adoc
+++ b/documentation/modules/migrating-live-cnv-cnv-vms-cli.adoc
@@ -180,7 +180,7 @@ metadata:
   name: <hook>
   namespace: <namespace>
 spec:
-  image: quay.io/kubev2v/hook-runner
+  image: {hook-runner-image}
   serviceAccount: <service_account>
   playbook: |
     LS0tCi0gbm...

--- a/documentation/modules/proc_migrating-vms-cli-cnv.adoc
+++ b/documentation/modules/proc_migrating-vms-cli-cnv.adoc
@@ -182,7 +182,7 @@ metadata:
   name: <hook>
   namespace: <namespace>
 spec:
-  image: quay.io/kubev2v/hook-runner
+  image: {hook-runner-image}
   serviceAccount:<service account>
   playbook: |
     LS0tCi0gbm...

--- a/documentation/modules/proc_migrating-vms-cli-ostack.adoc
+++ b/documentation/modules/proc_migrating-vms-cli-ostack.adoc
@@ -192,7 +192,7 @@ metadata:
   name: <hook>
   namespace: <namespace>
 spec:
-  image: quay.io/kubev2v/hook-runner
+  image: {hook-runner-image}
   serviceAccount:<service account>
   playbook: |
     LS0tCi0gbm...

--- a/documentation/modules/proc_migrating-vms-cli-ova.adoc
+++ b/documentation/modules/proc_migrating-vms-cli-ova.adoc
@@ -170,7 +170,7 @@ metadata:
   name: <hook>
   namespace: <namespace>
 spec:
-  image: quay.io/kubev2v/hook-runner
+  image: {hook-runner-image}
   serviceAccount:<service account>
   playbook: |
     LS0tCi0gbm...

--- a/documentation/modules/proc_migrating-vms-cli-rhv.adoc
+++ b/documentation/modules/proc_migrating-vms-cli-rhv.adoc
@@ -198,7 +198,7 @@ metadata:
   name: <hook>
   namespace: <namespace>
 spec:
-  image: quay.io/kubev2v/hook-runner
+  image: {hook-runner-image}
   serviceAccount:<service account>
   playbook: |
     LS0tCi0gbm...

--- a/documentation/modules/proc_migrating-vms-cli-vmware.adoc
+++ b/documentation/modules/proc_migrating-vms-cli-vmware.adoc
@@ -287,7 +287,7 @@ metadata:
   name: <hook>
   namespace: <namespace>
 spec:
-  image: quay.io/kubev2v/hook-runner
+  image: {hook-runner-image}
   serviceAccount:<service account>
   playbook: |
     LS0tCi0gbm...

--- a/documentation/modules/using-must-gather.adoc
+++ b/documentation/modules/using-must-gather.adoc
@@ -28,7 +28,7 @@ If you specify a non-existent resource in the filtered `must-gather` command, no
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather --image={must-gather}
+$ oc adm must-gather --image={must-gather-image}
 ----
 +
 The data is saved as `/must-gather/must-gather.tar.gz`. You can upload this file to a support case on the link:https://access.redhat.com/[Red Hat Customer Portal].
@@ -39,7 +39,7 @@ The data is saved as `/must-gather/must-gather.tar.gz`. You can upload this file
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather --image={must-gather} \
+$ oc adm must-gather --image={must-gather-image} \
   -- NS=<namespace> /usr/bin/targeted
 ----
 
@@ -47,7 +47,7 @@ $ oc adm must-gather --image={must-gather} \
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather --image={must-gather} \
+$ oc adm must-gather --image={must-gather-image} \
   -- PLAN=<migration_plan> /usr/bin/targeted
 ----
 
@@ -55,7 +55,7 @@ $ oc adm must-gather --image={must-gather} \
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather --image={must-gather} \
+$ oc adm must-gather --image={must-gather-image} \
   -- VM=<vm_id> NS=<namespace> /usr/bin/targeted
 ----
 +

--- a/documentation/upstream-attributes.adoc
+++ b/documentation/upstream-attributes.adoc
@@ -24,7 +24,8 @@
 :namespace: konveyor-forklift
 :operator: forklift-operator
 :operator-name: Forklift Operator
-:must-gather: quay.io/kubev2v/forklift-must-gather:latest
+:must-gather-image: quay.io/kubev2v/forklift-must-gather:latest
+:hook-runner-image: quay.io/kubev2v/hook-runner:latest
 
 // Guide titles
 :planning-guide-title: Planning your migration


### PR DESCRIPTION
Issue:
Hardcoded hook-runner image.

Fix:
Replace hardcoded quay.io/kubev2v/hook-runner with a new {hook-runner-image} variable so downstream renders the correct registry.redhat.io image. Also rename {must-gather} to {must-gather-image} for consistent naming.

Resolves: MTV-2712
Ref: https://issues.redhat.com/browse/MTV-2712