### PR TITLE
Changing references to RHEL 9 to RHEL 10

### DIFF
--- a/documentation/modules/proc_enabling-nbde-with-clevis.adoc
+++ b/documentation/modules/proc_enabling-nbde-with-clevis.adoc
@@ -55,6 +55,4 @@ vms:
 ----
 
 .Troubleshooting
-* For information about LUKS or Clevis configuration on the source VM, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html-single/security_hardening/index#configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption_security-hardening[Configuring automated unlocking of encrypted volumes by using policy-based decryption] in the RHEL _Security hardening_ guide.
-
-
+* For information about LUKS or Clevis configuration on the source VM, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-by-using-policy-based-decryption[Configuring automated unlocking of encrypted volumes by using policy-based decryption] in the RHEL _Security hardening_ guide.

--- a/documentation/modules/ref_source-vm-prerequisites.adoc
+++ b/documentation/modules/ref_source-vm-prerequisites.adoc
@@ -17,7 +17,7 @@ Prerequisites::
 +
 [NOTE]
 ====
-You can check that the OS is supported by referring to the table in link:https://access.redhat.com/articles/1351473[Converting virtual machines from other hypervisors to KVM with virt-v2v]. See the columns of the table that refer to RHEL 8 hosts and RHEL 9 hosts.
+You can check that the OS is supported by referring to the table in link:https://access.redhat.com/articles/1351473[Converting virtual machines from other hypervisors to KVM with virt-v2v in RHEL 7, RHEL 8, RHEL 9, and RHEL 10]. See the column of the table that refers to RHEL 10 hosts.
 ====
 
 


### PR DESCRIPTION
MTV 2.11.1

Resolves https://issues.redhat.com/browse/MTV-3857 by changing references to RHEL 9 to RHEL 10. 

Preview: Note in https://forklift-documentation-git-fork-ri-2496fb-yaacov-8047s-projects.vercel.app/documentation/doc-Planning_your_migration/master.html#ref_source-vm-prerequisites_mtv
