### PR TITLE
Do not merge: Obsolete - Google Drive chapters

### DIFF
--- a/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-google-drive.adoc
+++ b/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-google-drive.adoc
@@ -1,0 +1,46 @@
+ifdef::context[:parent-context: {context}]
+
+:_mod-docs-content-type: ASSEMBLY
+
+[id="assembly_migrating-from-google-drive_{context}"]
+
+= Migrating from Google Drive
+
+//:context: migrating-google-drive
+
+[role="_abstract"]
+Run your Google Drive migration plan from the MTV UI or from the command-line.
+
+[NOTE]
+====
+Like OVA migrations, Google Drive migrations are file-based imports. The network mapping, storage mapping, and migration execution procedures are identical to OVA migrations. The key differences are in the prerequisites and provider configuration.
+====
+
+include::../modules/con_google-drive-scope-and-limitations.adoc[leveloffset=+1]
+
+== Prerequisites
+
+* You have planned your migration from Google Drive.
+
+:context: google-drive
+:google-drive:
+
+include::../modules/running-migration-plan.adoc[leveloffset=+1]
+
+include::../modules/migration-plan-options-ui.adoc[leveloffset=+2]
+
+include::../modules/canceling-migration-ui.adoc[leveloffset=+2]
+
+include::../modules/proc_migrating-vms-cli-google-drive.adoc[leveloffset=+1]
+
+include::../modules/canceling-migration-cli.adoc[leveloffset=+2]
+
+include::../modules/canceling-migration-cli-entire.adoc[leveloffset=+3]
+
+include::../modules/canceling-migration-cli-specific.adoc[leveloffset=+3]
+
+:google-drive!:
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]
+

--- a/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-google-drive.adoc
+++ b/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-google-drive.adoc
@@ -16,14 +16,11 @@ Run your Google Drive migration plan from the MTV UI or from the command-line.
 Like OVA migrations, Google Drive migrations are file-based imports. The network mapping, storage mapping, and migration execution procedures are identical to OVA migrations. The key differences are in the prerequisites and provider configuration.
 ====
 
-include::../modules/con_google-drive-scope-and-limitations.adoc[leveloffset=+1]
-
 == Prerequisites
 
 * You have planned your migration from Google Drive.
 
-:context: google-drive
-:google-drive:
+include::../modules/con_google-drive-scope-and-limitations.adoc[leveloffset=+1]
 
 include::../modules/running-migration-plan.adoc[leveloffset=+1]
 
@@ -38,8 +35,6 @@ include::../modules/canceling-migration-cli.adoc[leveloffset=+2]
 include::../modules/canceling-migration-cli-entire.adoc[leveloffset=+3]
 
 include::../modules/canceling-migration-cli-specific.adoc[leveloffset=+3]
-
-:google-drive!:
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-google-drive.adoc
+++ b/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-google-drive.adoc
@@ -18,7 +18,7 @@ Like OVA migrations, Google Drive migrations are file-based imports. The network
 
 == Prerequisites
 
-* You have planned your migration from Google Drive.
+* You have planned your migration from Google Drive. For more information, see link:{mtv-plan}assembly_planning-migration-google-drive_mtv[Planning a migration of virtual machines from Google Drive].
 
 include::../modules/con_google-drive-scope-and-limitations.adoc[leveloffset=+1]
 

--- a/documentation/doc-Migrating_your_virtual_machines/master.adoc
+++ b/documentation/doc-Migrating_your_virtual_machines/master.adoc
@@ -21,6 +21,8 @@ include::assemblies/assembly_migrating-from-osp.adoc[leveloffset=+1]
 
 include::assemblies/assembly_migrating-from-ova.adoc[leveloffset=+1]
 
+include::assemblies/assembly_migrating-from-google-drive.adoc[leveloffset=+1]
+
 include::assemblies/assembly_migrating-from-cnv.adoc[leveloffset=+1]
 
 include::assemblies/assembly_advanced-migration-options.adoc[leveloffset=+1]

--- a/documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-google-drive.adoc
+++ b/documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-google-drive.adoc
@@ -1,0 +1,54 @@
+
+ifdef::context[:parent-context: {context}]
+
+:_mod-docs-content-type: ASSEMBLY
+
+[id="assembly_planning-migration-google-drive_{context}"]
+
+= Planning a migration of virtual machines from Google Drive
+
+//:context: planning-google-drive
+
+[role="_abstract"]
+Create a Google Drive migration plan by setting up network maps, configuring source and destination providers with migration networks, and defining the migration plan in the {project-first} UI.
+
+[NOTE]
+====
+Like OVA migrations, Google Drive migrations are file-based imports. The network mapping, storage mapping, and migration execution procedures are identical to OVA migrations. The key differences are in the prerequisites and provider configuration.
+====
+
+:context: google-drive
+:google-drive:
+
+include::../modules/creating-form-based-network-maps-ui-google-drive.adoc[leveloffset=+1]
+
+include::../modules/creating-yaml-based-network-maps-ui-google-drive.adoc[leveloffset=+1]
+
+include::../modules/creating-form-based-storage-maps-ui-google-drive.adoc[leveloffset=+1]
+
+include::../modules/creating-yaml-based-storage-maps-ui-google-drive.adoc[leveloffset=+1]
+
+include::../modules/adding-google-drive-source-provider.adoc[leveloffset=+1]
+
+:!google-drive:
+:context: dest_google-drive
+:dest_google-drive:
+
+include::../modules/adding-source-provider.adoc[leveloffset=+1]
+
+include::../modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+1]
+
+:!dest_google-drive:
+:context: google-drive
+:google-drive:
+
+include::../modules/creating-plan-wizard-google-drive.adoc[leveloffset=+1]
+
+:!google-drive:
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]
+
+
+
+

--- a/documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-google-drive.adoc
+++ b/documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-google-drive.adoc
@@ -34,7 +34,7 @@ include::../modules/adding-google-drive-source-provider.adoc[leveloffset=+1]
 :context: dest_google-drive
 :dest_google-drive:
 
-include::../modules/adding-source-provider.adoc[leveloffset=+1]
+include::../modules/proc_adding-source-provider.adoc[leveloffset=+1]
 
 include::../modules/selecting-migration-network-for-virt-provider.adoc[leveloffset=+1]
 

--- a/documentation/doc-Planning_your_migration/assemblies/assembly_provider-specific-requirements-for-migration.adoc
+++ b/documentation/doc-Planning_your_migration/assemblies/assembly_provider-specific-requirements-for-migration.adoc
@@ -32,7 +32,9 @@ include::../modules/vddk-validator-containers.adoc[leveloffset=+2]
 
 include::../modules/ova-prerequisites.adoc[leveloffset=+1]
 
-include::../modules/proc_configuring-google-cloud-platform-google-drive.adoc[leveloffset=+1]
+include::../modules/ref_google-drive-prerequisites.adoc[leveloffset=+1]
+
+include::../modules/proc_configuring-google-cloud-platform-google-drive.adoc[leveloffset=+2]
 
 include::../modules/cnv-prerequisites.adoc[leveloffset=+1]
 

--- a/documentation/doc-Planning_your_migration/assemblies/assembly_provider-specific-requirements-for-migration.adoc
+++ b/documentation/doc-Planning_your_migration/assemblies/assembly_provider-specific-requirements-for-migration.adoc
@@ -32,7 +32,7 @@ include::../modules/vddk-validator-containers.adoc[leveloffset=+2]
 
 include::../modules/ova-prerequisites.adoc[leveloffset=+1]
 
-include::../modules/google-drive-prerequisites.adoc[leveloffset=+1]
+include::../modules/proc_configuring-google-cloud-platform-google-drive.adoc[leveloffset=+1]
 
 include::../modules/cnv-prerequisites.adoc[leveloffset=+1]
 

--- a/documentation/doc-Planning_your_migration/assemblies/assembly_provider-specific-requirements-for-migration.adoc
+++ b/documentation/doc-Planning_your_migration/assemblies/assembly_provider-specific-requirements-for-migration.adoc
@@ -32,6 +32,8 @@ include::../modules/vddk-validator-containers.adoc[leveloffset=+2]
 
 include::../modules/ova-prerequisites.adoc[leveloffset=+1]
 
+include::../modules/google-drive-prerequisites.adoc[leveloffset=+1]
+
 include::../modules/cnv-prerequisites.adoc[leveloffset=+1]
 
 include::../modules/cnv-cnv-live-prerequisites.adoc[leveloffset=+2]

--- a/documentation/doc-Planning_your_migration/master.adoc
+++ b/documentation/doc-Planning_your_migration/master.adoc
@@ -34,6 +34,8 @@ include::assemblies/assembly_planning-migration-osp.adoc[leveloffset=+1]
 
 include::assemblies/assembly_planning-migration-ova.adoc[leveloffset=+1]
 
+include::assemblies/assembly_planning-migration-google-drive.adoc[leveloffset=+1]
+
 include::assemblies/assembly_planning-migration-cnv.adoc[leveloffset=+1]
 
 

--- a/documentation/modules/adding-google-drive-source-provider.adoc
+++ b/documentation/modules/adding-google-drive-source-provider.adoc
@@ -30,13 +30,13 @@ You can add a Google Drive source provider in the {ocp} web console by creating 
 apiVersion: v1
 kind: Secret
 metadata:
-  name: <google_drive_secret> <1>
+  name: <google_drive_secret>
   namespace: openshift-mtv
   labels:
     createdForProviderType: google-drive
 type: Opaque
 stringData:
-  key.json: | <2>
+  key.json: |
     {
       "type": "service_account",
       "project_id": "<your-gcp-project-id>",
@@ -51,8 +51,14 @@ stringData:
       "universe_domain": "googleapis.com"
     }
 ----
-<1> Specify a name for the secret.
-<2> Paste the entire JSON content from the service account key file downloaded from Google Cloud Platform. Do not encode or modify the JSON content.
++
+where:
++
+`<google_drive_secret>`::
+Specifies the name of the secret.
++
+`key.json`::
+Specifies the entire JSON content from the service account key file downloaded from Google Cloud Platform. Do not encode or modify the JSON content.
 
 . Click *Create*.
 
@@ -67,19 +73,29 @@ stringData:
 apiVersion: forklift.konveyor.io/v1beta1
 kind: Provider
 metadata:
-  name: <google_drive_provider> <1>
+  name: <google_drive_provider>
   namespace: openshift-mtv
 spec:
-  type: google-drive <2>
-  url: "gdrive://<google-drive-folder-id>" <3>
+  type: google-drive
+  url: "gdrive://<google-drive-folder-id>"
   secret:
-    name: <google_drive_secret> <4>
+    name: <google_drive_secret>
     namespace: openshift-mtv
 ----
-<1> Specify a name for the provider.
-<2> The provider type must be `google-drive`.
-<3> Specify the Google Drive folder ID. You can find this in the Google Drive folder URL after `/folders/`. For example, if the URL is `https://drive.google.com/drive/folders/1a2b3c4d5e6f`, the folder ID is `1a2b3c4d5e6f`.
-<4> Specify the name of the secret created in the previous steps.
++
+where:
++
+`<google_drive_provider>`::
+Specifies the name of the provider.
++
+`type`::
+Specifies the provider type. Must be `google-drive`.
++
+`url`::
+Specifies the Google Drive folder ID. You can find this in the Google Drive folder URL after `/folders/`. For example, if the URL is `https://drive.google.com/drive/folders/1a2b3c4d5e6f`, the folder ID is `1a2b3c4d5e6f`.
++
+`secret.name`::
+Specifies the name of the secret created in the previous steps.
 
 . Click *Create*.
 

--- a/documentation/modules/adding-google-drive-source-provider.adoc
+++ b/documentation/modules/adding-google-drive-source-provider.adoc
@@ -1,0 +1,93 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-google-drive.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="adding-google-drive-source-provider_{context}"]
+= Adding a Google Drive source provider
+
+[role="_abstract"]
+You can add a Google Drive source provider in the {ocp} web console by creating a `Secret` manifest for the OAuth 2.0 service account credentials and a `Provider` manifest that references the secret and specifies the Google Drive folder location.
+
+.Prerequisites
+
+* Google Cloud Platform project configured with Google Drive API enabled.
+* Service account created with appropriate permissions and JSON key file generated.
+* Google Drive folder containing VM disk images shared with the service account.
+
+.Procedure
+
+. In the {ocp} web console, click *Workloads* > *Secrets*.
+
+. Select your project from the *Project* list.
+
+. Click *Create* > *From YAML*.
+
+. Replace the default content with the following `Secret` manifest:
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <google_drive_secret> <1>
+  namespace: openshift-mtv
+  labels:
+    createdForProviderType: google-drive
+type: Opaque
+stringData:
+  key.json: | <2>
+    {
+      "type": "service_account",
+      "project_id": "<your-gcp-project-id>",
+      "private_key_id": "<your-private-key-id>",
+      "private_key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
+      "client_email": "<your-service-account-email>",
+      "client_id": "<your-client-id>",
+      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+      "token_uri": "https://oauth2.googleapis.com/token",
+      "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+      "client_x509_cert_url": "<your-cert-url>",
+      "universe_domain": "googleapis.com"
+    }
+----
+<1> Specify a name for the secret.
+<2> Paste the entire JSON content from the service account key file downloaded from Google Cloud Platform. Do not encode or modify the JSON content.
+
+. Click *Create*.
+
+. Click *Migration for Virtualization* > *Providers for virtualization*.
+
+. Click *Create Provider* > *From YAML*.
+
+. Replace the default content with the following `Provider` manifest:
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Provider
+metadata:
+  name: <google_drive_provider> <1>
+  namespace: openshift-mtv
+spec:
+  type: google-drive <2>
+  url: "gdrive://<google-drive-folder-id>" <3>
+  secret:
+    name: <google_drive_secret> <4>
+    namespace: openshift-mtv
+----
+<1> Specify a name for the provider.
+<2> The provider type must be `google-drive`.
+<3> Specify the Google Drive folder ID. You can find this in the Google Drive folder URL after `/folders/`. For example, if the URL is `https://drive.google.com/drive/folders/1a2b3c4d5e6f`, the folder ID is `1a2b3c4d5e6f`.
+<4> Specify the name of the secret created in the previous steps.
+
+. Click *Create*.
+
+.Verification
+
+* The provider appears in the list of providers with a status of *Ready*.
+* If the provider status shows an error, verify that:
+** The service account JSON key is valid and correctly formatted.
+** The Google Drive folder ID is correct.
+** The Google Drive folder or files are shared with the service account email address.
+** The OpenShift cluster has network connectivity to `*.googleapis.com`.

--- a/documentation/modules/adding-google-drive-source-provider.adoc
+++ b/documentation/modules/adding-google-drive-source-provider.adoc
@@ -19,7 +19,7 @@ You can add a Google Drive source provider in the {ocp} web console by creating 
 
 . In the {ocp} web console, click *Workloads* > *Secrets*.
 
-. Select your project from the *Project* list.
+. Select the +{namespace}+ project from the *Project* list.
 
 . Click *Create* > *From YAML*.
 
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: <google_drive_secret>
-  namespace: openshift-mtv
+  namespace: <namespace>
   labels:
     createdForProviderType: google-drive
 type: Opaque
@@ -57,6 +57,9 @@ where:
 `<google_drive_secret>`::
 Specifies the name of the secret.
 +
+`<namespace>`::
+Specifies the namespace. The default namespace for {project-short} is +{namespace}+.
++
 `key.json`::
 Specifies the entire JSON content from the service account key file downloaded from Google Cloud Platform. Do not encode or modify the JSON content.
 
@@ -74,19 +77,22 @@ apiVersion: forklift.konveyor.io/v1beta1
 kind: Provider
 metadata:
   name: <google_drive_provider>
-  namespace: openshift-mtv
+  namespace: <namespace>
 spec:
   type: google-drive
   url: "gdrive://<google-drive-folder-id>"
   secret:
     name: <google_drive_secret>
-    namespace: openshift-mtv
+    namespace: <namespace>
 ----
 +
 where:
 +
 `<google_drive_provider>`::
 Specifies the name of the provider.
++
+`<namespace>`::
+Specifies the namespace. The default namespace for {project-short} is +{namespace}+.
 +
 `type`::
 Specifies the provider type. Must be `google-drive`.

--- a/documentation/modules/canceling-migration-cli-specific.adoc
+++ b/documentation/modules/canceling-migration-cli-specific.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-cnv.adoc
+// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-google-drive.adoc
 // * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-osp.adoc
 // * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-ova.adoc
 // * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-rhv.adoc
@@ -39,7 +40,24 @@ where:
 `id` or `name`::
 Specifies a VM by using the `id` key or the `name` key.
 +
-The value of the `id` key is the _managed object reference_, for a {vmw} VM, or the _VM UUID_, for a {rhv-full} VM.
+ifdef::vmware[]
+The value of the `id` key is the _managed object reference_ for a {vmw} VM.
+endif::[]
+ifdef::rhv[]
+The value of the `id` key is the _VM UUID_ for a {rhv-full} VM.
+endif::[]
+ifdef::ostack[]
+The value of the `id` key is the _VM UUID_ for an {osp} VM.
+endif::[]
+ifdef::ova[]
+The value of the `id` key is the _VM name_ from the OVA file for an OVA VM.
+endif::[]
+ifdef::google-drive[]
+The value of the `id` key is the _VM disk image file name_ (or Google Drive File ID) as it appears in Google Drive.
+endif::[]
+ifdef::cnv[]
+The value of the `id` key is the _VM name_ for a {virt} VM.
+endif::[]
 
 . Retrieve the `Migration` custom resource (CR) to monitor the progress of the remaining VMs, following this example:
 +

--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -2,7 +2,8 @@
 // Attributes for Forklift (upstream) are in ../upstream-attributes.adoc
 // text
 :kebab: Options menu image:kebab.png[title="Options menu",height=20]
-// If namespace must be formatted with backticks, use + instead.
+// Note: Backticks (`) block variable substitution. To format {namespace} in monospace
+// while allowing it to resolve, use +{namespace}+ instead of `{namespace}`.
 :namespace: openshift-mtv
 :oc: oc
 :ocp: Red Hat OpenShift

--- a/documentation/modules/con_google-drive-scope-and-limitations.adoc
+++ b/documentation/modules/con_google-drive-scope-and-limitations.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-google-drive.adoc
+
+:_mod-docs-content-type: CONCEPT
+
+[id="con_google-drive-scope-and-limitations_{context}"]
+= Google Drive scope and limitations
+
+[role="_abstract"]
+
+Google Drive migration is validated for importing virtual machine disk image files stored in Google Drive to {virt}. Supported file formats include QCOW2, VMDK, and OVA files created by {vmw} vSphere.
+
+The Google Drive import process is a file-based migration similar to OVA imports. It utilizes `virt-v2v` to prepare guest operating systems for KVM when importing files such as VMDK or OVA. For third-party networking or security appliances, check with the vendor for native QCOW2 or KVM images.
+
+Vendor-supplied appliances often use proprietary bootloaders or disk layouts that are incompatible with this conversion process. Moreover, converting a vendor appliance may invalidate vendor support agreements.
+
+To ensure stability and vendor support, always prioritize importing the vendor's native QCOW2 image by using either the {virt} "Upload Image" or the {virt} "Import from URL" workflow rather than using the {project-first} Google Drive import path for vendor appliances.
+
+.Supported file formats
+
+* QCOW2 (QEMU Copy-On-Write version 2) disk images
+* VMDK (Virtual Machine Disk) images
+* OVA (Open Virtual Appliance) packages created by VMware vSphere
+
+.Limitations
+
+* Google Drive migration supports only cold migration. Warm migration is not supported for file-based imports.
+* The service account must have read access to all files and folders containing VM disk images in Google Drive.
+* Network connectivity from the OpenShift cluster to Google Drive API endpoints (`*.googleapis.com`) is required.
+* Large file transfers may be subject to Google Drive API rate limits and quotas. Monitor your API usage in the Google Cloud Console for large-scale migrations.
+* A migration plan cannot contain more than 500 VMs or 500 disks.

--- a/documentation/modules/con_google-drive-scope-and-limitations.adoc
+++ b/documentation/modules/con_google-drive-scope-and-limitations.adoc
@@ -9,7 +9,7 @@
 
 [role="_abstract"]
 
-Google Drive migration is validated for importing virtual machine disk image files stored in Google Drive to {virt}. Supported file formats include QCOW2, VMDK, and OVA files created by {vmw} vSphere.
+Google Drive migration is validated for importing virtual machine disk image files stored in Google Drive to {virt}. Supported file formats include QEMU Copy-On-Write version 2 (QCOW2) disk images, Virtual Machine Disk (VMDK) images, and Open Virtual Appliance (OVA) packages created by {vmw} vSphere.
 
 The Google Drive import process is a file-based migration similar to OVA imports. It utilizes `virt-v2v` to prepare guest operating systems for KVM when importing files such as VMDK or OVA. For third-party networking or security appliances, check with the vendor for native QCOW2 or KVM images.
 
@@ -17,13 +17,7 @@ Vendor-supplied appliances often use proprietary bootloaders or disk layouts tha
 
 To ensure stability and vendor support, always prioritize importing the vendor's native QCOW2 image by using either the {virt} "Upload Image" or the {virt} "Import from URL" workflow rather than using the {project-first} Google Drive import path for vendor appliances.
 
-.Supported file formats
-
-* QCOW2 (QEMU Copy-On-Write version 2) disk images
-* VMDK (Virtual Machine Disk) images
-* OVA (Open Virtual Appliance) packages created by VMware vSphere
-
-.Limitations
+Limitations::
 
 * Google Drive migration supports only cold migration. Warm migration is not supported for file-based imports.
 * The service account must have read access to all files and folders containing VM disk images in Google Drive.

--- a/documentation/modules/con_google-drive-scope-and-limitations.adoc
+++ b/documentation/modules/con_google-drive-scope-and-limitations.adoc
@@ -1,6 +1,11 @@
 // Module included in the following assemblies:
 //
 // * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-google-drive.adoc
+//
+// TODO: Check with SME to clarify the "500 VMs or 500 disks" limit (line 26).
+// Is this: (a) independent limits (500 VMs AND 500 disks), or
+//          (b) combined/first-hit limit (500 VMs OR 500 disks, whichever comes first)?
+// This ambiguity exists across all provider docs (vmware, rhv, ova, ostack, cnv).
 
 :_mod-docs-content-type: CONCEPT
 
@@ -15,7 +20,7 @@ The Google Drive import process is a file-based migration similar to OVA imports
 
 Vendor-supplied appliances often use proprietary bootloaders or disk layouts that are incompatible with this conversion process. Moreover, converting a vendor appliance may invalidate vendor support agreements.
 
-To ensure stability and vendor support, always prioritize importing the vendor's native QCOW2 image by using either the {virt} "Upload Image" or the {virt} "Import from URL" workflow rather than using the {project-first} Google Drive import path for vendor appliances.
+To ensure stability and vendor support, always prioritize importing the vendor's native QCOW2 image by using either the {virt} "Upload Image" or the {virt} "Import from URL" workflow rather than by using the {project-first} Google Drive import path for vendor appliances.
 
 Limitations::
 

--- a/documentation/modules/con_google-drive-scope-and-limitations.adoc
+++ b/documentation/modules/con_google-drive-scope-and-limitations.adoc
@@ -2,10 +2,9 @@
 //
 // * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-google-drive.adoc
 //
-// TODO: Check with SME to clarify the "500 VMs or 500 disks" limit (line 26).
-// Is this: (a) independent limits (500 VMs AND 500 disks), or
-//          (b) combined/first-hit limit (500 VMs OR 500 disks, whichever comes first)?
-// This ambiguity exists across all provider docs (vmware, rhv, ova, ostack, cnv).
+// TODO (SME): Clarify the "500 VMs or 500 disks" limit (line 26).
+//             Are these independent limits (500 VMs AND 500 disks) or whichever limit is reached first?
+//             This wording appears in all provider docs.
 
 :_mod-docs-content-type: CONCEPT
 

--- a/documentation/modules/creating-form-based-network-maps-ui-google-drive.adoc
+++ b/documentation/modules/creating-form-based-network-maps-ui-google-drive.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-google-drive.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="creating-form-based-network-maps-ui-google-drive_{context}"]
+= Creating ownerless network maps by using the form page of the {project-short} UI
+
+[role="_abstract"]
+You can add ownerless network maps by using the form page of the {project-first} UI. Later, you can add these maps to a migration plan by using the *Use an existing network map* option in the *Network map* page of the {project-short} wizard.
+
+For more information about network and storage maps in {project-short}, see link:{mtv-plan}assembly_mapping-networks-storage_mtv[Mapping networks and storage in migration plans].
+
+.Prerequisites
+
+* Have a Google Drive source provider and {a-virt} destination provider. For more information, see xref:adding-google-drive-source-provider_google-drive[Adding a Google Drive source provider] or xref:adding-source-provider_dest_google-drive[Adding {a-virt} destination provider].
+
+.Procedure
+
+. In the {ocp} web console, click *Migration for Virtualization* > *Network maps*.
+. Click *Create network map* > *Create with form*.
+. Specify the following:
+
+* *Network map name*: Name of the network map.
+* *Project*: Select from the list.
+* *Source provider*: Select from the list.
+* *Target provider*: Select from the list.
+* *Source network*: Select from the list.
+* *Target network*: Select from the list.
+
+. Optional: Click *Add mapping* to create additional network maps, including mapping multiple network sources to a single target network.
+. Click *Create*.
++
+Your map appears in the list of network maps.

--- a/documentation/modules/creating-form-based-network-maps-ui-google-drive.adoc
+++ b/documentation/modules/creating-form-based-network-maps-ui-google-drive.adoc
@@ -13,7 +13,7 @@ For more information about network and storage maps in {project-short}, see link
 
 .Prerequisites
 
-* Have a Google Drive source provider and {a-virt} destination provider. For more information, see xref:adding-google-drive-source-provider_google-drive[Adding a Google Drive source provider] or xref:adding-source-provider_dest_google-drive[Adding {a-virt} destination provider].
+* Have a Google Drive source provider and {a-virt} destination provider. For more information, see xref:adding-google-drive-source-provider_google-drive[Adding a Google Drive source provider] or xref:proc_adding-source-provider_dest_google-drive[Adding {a-virt} destination provider].
 
 .Procedure
 

--- a/documentation/modules/creating-form-based-storage-maps-ui-google-drive.adoc
+++ b/documentation/modules/creating-form-based-storage-maps-ui-google-drive.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-google-drive.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="creating-form-based-storage-maps-ui-google-drive_{context}"]
+= Creating ownerless storage maps by using the form page of the {project-short} UI
+
+[role="_abstract"]
+You can add ownerless storage maps by using the form page of the {project-first} UI. Later, you can add these maps to a migration plan by using the *Use an existing storage map* option in the *Storage map* page of the {project-short} wizard.
+
+For more information about network and storage maps in {project-short}, see link:{mtv-plan}assembly_mapping-networks-storage_mtv[Mapping networks and storage in migration plans].
+
+.Prerequisites
+
+* Have a Google Drive source provider and {a-virt} destination provider. For more information, see xref:adding-google-drive-source-provider_google-drive[Adding a Google Drive source provider] or xref:adding-source-provider_dest_google-drive[Adding {a-virt} destination provider].
+
+.Procedure
+
+. In the {ocp} web console, click *Migration for Virtualization* > *Storage maps*.
+. Click *Create storage map* > *Create with form*.
+. Specify the following:
+
+* *Map name*: Name of the storage map.
+* *Project*: Select from the list.
+* *Source provider*: Select from the list.
+* *Target provider*: Select from the list.
+* *Source storage*: Select from the list.
+* *Target storage*: Select from the list.
+
+. Optional: Click *Add mapping* to create additional storage maps, including mapping multiple storage sources to a single target storage class.
+. Click *Create*.
++
+Your map appears in the list of storage maps.

--- a/documentation/modules/creating-form-based-storage-maps-ui-google-drive.adoc
+++ b/documentation/modules/creating-form-based-storage-maps-ui-google-drive.adoc
@@ -13,7 +13,7 @@ For more information about network and storage maps in {project-short}, see link
 
 .Prerequisites
 
-* Have a Google Drive source provider and {a-virt} destination provider. For more information, see xref:adding-google-drive-source-provider_google-drive[Adding a Google Drive source provider] or xref:adding-source-provider_dest_google-drive[Adding {a-virt} destination provider].
+* Have a Google Drive source provider and {a-virt} destination provider. For more information, see xref:adding-google-drive-source-provider_google-drive[Adding a Google Drive source provider] or xref:proc_adding-source-provider_dest_google-drive[Adding {a-virt} destination provider].
 
 .Procedure
 

--- a/documentation/modules/creating-plan-wizard-google-drive.adoc
+++ b/documentation/modules/creating-plan-wizard-google-drive.adoc
@@ -1,0 +1,185 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-google-drive.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="creating-plan-wizard-google-drive_{context}"]
+= Creating a Google Drive migration plan by using the MTV wizard
+
+[role="_abstract"]
+You can migrate virtual machine disk image files from Google Drive by using the {project-full} plan creation wizard.
+
+The wizard is designed to lead you step-by-step in creating a migration plan.
+
+[WARNING]
+====
+Do not include virtual machines with guest-initiated storage connections, such as Internet Small Computer Systems Interface (iSCSI) connections or Network File System (NFS) mounts. These require either additional planning before migration or reconfiguration after migration.
+
+This prevents concurrent disk access to the storage the guest points to.
+====
+
+[IMPORTANT]
+====
+A plan cannot contain more than 500 VMs or 500 disks.
+====
+
+[IMPORTANT]
+====
+When you click *Create plan* on the *Review and create* page of the wizard, {project-first} validates your plan. If everything is OK, the *Plan details* page for your plan opens. This page contains settings that do not appear in the wizard, but are important. Be sure to read and follow the instructions for this page carefully, even though it is outside the plan creation wizard. The page can be opened later, any time before you run the plan, so you can come back to it if needed.
+====
+
+.Prerequisites
+
+* Have a Google Drive source provider and {a-virt} destination provider. For more information, see xref:adding-google-drive-source-provider_google-drive[Adding a Google Drive source provider] or xref:adding-source-provider_dest_google-drive[Adding {a-virt} destination provider].
+* If you plan to create a *Network map* or a *Storage map* that will be used by more than one migration plan, create it in the *Network maps* or *Storage maps* page of the UI before you create a migration plan that uses that map.
+* If you are using a user-defined network (UDN), note the name of its namespace as defined in {virt}.
+
+.Procedure
+
+. In the {ocp} web console, click *Migration for Virtualization* > *Migration plans*.
+. Click *Create plan*.
++
+The *Create migration plan* wizard opens.
++
+// General page
+. On the *General* page, specify the following fields:
+
+* *Plan name*: Enter a name.
+* *Plan project*: Select from the list.
+* *Source provider*: Select from the list.
+* *Target project*: Click the list and do one of the following:
+
+.. Select an existing project from the list.
+.. Create a new project by clicking *Create project* and doing the following:
+
+... Enter the *Name* of the project. A project name must consist of lowercase alphanumeric characters or `-`. A project name must start and end with alphanumeric characters. For example, `my-name` or `123-abc`.
+... Optional: Enter a *Display name* for the project.
+... Optional: Enter a *Description* of the project.
+... Click *Create Project*.
+
+. Click *Next*.
++
+// Virtual machines page
+. On the *Virtual machines* page, select the virtual machines you want to migrate and click *Next*.
+. If you are using a UDN, verify that the IP address of the provider is outside the subnet of the UDN. If the IP address is within the subnet of the UDN, the migration fails.
++
+// Network map page
+. On the *Network map* page, choose one of the following options:
+
+* *Use an existing network map*: Select an existing network map from the list.
++
+These are network maps available for all plans, and therefore, they are _ownerless_ in terms of the system. If you select this option and choose a map, a copy of that map is attached to your plan, and your plan is the _owner_ of that copy. Any changes you make to your copy do not affect the original plan or any copies that other users have.
++
+[NOTE]
+====
+If you choose an existing map, be sure it has the same source provider and the same target provider as the ones you want to use in your plan.
+====
+
+* *Use a new network map*: Allows you to create a new network map by supplying the following data. This map is attached to this plan, which is then considered to be its owner. Maps that you create using this option are not available in the *Use an existing network map* option because each is created with an owner.
++
+[NOTE]
+====
+You can create an ownerless network map, which you and others can use for additional migration plans, in the *Network maps* section of the UI.
+====
+
+** *Source network*: Select from the list.
+** *Target network*: Select from the list.
++
+If needed, click *Add mapping* to add another mapping.
+** *Network map name*: Enter a name or let {project-short} automatically generate a name for the network map.
+
+. Click *Next*.
++
+// Storage map page
+. On the *Storage map* page, choose one of the following options:
+
+* *Use an existing storage map*: Select an existing storage map from the list.
++
+These are storage maps available for all plans, and therefore, they are _ownerless_ in terms of the system. If you select this option and choose a map, a copy of that map is attached to your plan, and your plan is the _owner_ of that copy. Any changes you make to your copy do not affect the original plan or any copies that other users have.
++
+[NOTE]
+====
+If you choose an existing map, be sure it has the same source provider and the same target provider as the ones you want to use in your plan.
+====
+
+* *Use new storage map*: Allows you to create one or two new storage maps by supplying the following data. These maps are attached to this plan, which is then their owner. Maps that you create using this option are not available in the *Use an existing storage map* option because each is created with an owner.
++
+[NOTE]
+====
+You can create an ownerless storage map, which you and others can use for additional migration plans, in the *Storage maps* section of the UI.
+====
+
+** *Source storage*: Select from the list.
+** *Target storage*: Select from the list.
++
+If needed, click *Add mapping* to add another mapping.
+** *Storage map name*: Enter a name or let {project-short} automatically generate a name for the storage map.
+
+. Click *Next*.
++
+// Other settings page
+. On the *Other settings (optional)* page, you have the option to change the *Transfer network* of your migration plan.
++
+The transfer network is the network used to transfer the VMs to {virt}. This is the default transfer network of the provider.
+
+** Verify that the transfer network is in the selected target project.
+
+** To choose a different transfer network, select a different transfer network from the list.
+** Optional: To configure another {ocp-short} network in the {ocp-short} web console, click *Networking > NetworkAttachmentDefinitions*.
++
+To learn more about the different types of networks {ocp-short} supports, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html-single/networking/index#additional-networks-provided_understanding-multiple-networks[Additional Networks in OpenShift Container Platform].
+
+. Click *Next*.
++
+// Hooks page
+. On the *Hooks (optional)* page, you can add a pre-migration hook, a post-migration hook, or both types of migration hooks. All are optional.
+
+. To add a hook, select the appropriate *Enable hook* checkbox.
+. Enter the *Hook runner image*.
+. Enter the *Ansible playbook* of the hook in the window.
++
+[NOTE]
+====
+You cannot include more than one pre-migration hook or more than one post-migration hook in a migration plan.
+====
+
+. Click *Next*.
++
+// Review and create page
+. On the *Review and create* page, review the information displayed.
+. Edit any item by doing the following:
+
+.. Click its *Edit step* link.
++
+The wizard opens to the page where you defined the item.
+.. Edit the item.
+.. Either click *Next* to advance to the next page of the wizard, or click *Skip to review* to return directly to the *Review and create* page.
+
+. When you finish reviewing the details of the plan, click *Create plan*. {project-short} validates your plan.
++
+When your plan is validated, the *Plan details* page for your plan opens in the *Details* tab.
+
+. In addition to listing details based on your entries in the wizard, the *Plan details* tab includes the following two sections after the details of the plan:
+
+* *Migration history*: Details about successful and unsuccessful attempts to run the plan
+* *Conditions*: Any changes that need to be made to the plan so that it can run successfully
+
+. When you have fixed all conditions listed, you can run your plan from the *Plans* page.
++
+The *Plan details* page also includes five additional tabs, which are described in the table that follows:
++
+[cols="1,1,1,1,1",options="header"]
+.Tabs of the Plan details page
+|===
+|YAML
+|Virtual Machines
+|Resources
+|Mappings
+|Hooks
+
+|Editable YAML `Plan` manifest based on your plan's details including source provider, network and storage maps, VMs, and any issues with your VMs
+|The VMs the plan migrates
+|Calculated resources: VMs, CPUs, and total memory for both total VMs and running VMs
+|Editable specification of the network and storage maps used by your plan
+|Updatable specification of the hooks used by your plan, if any
+|===

--- a/documentation/modules/creating-plan-wizard-google-drive.adoc
+++ b/documentation/modules/creating-plan-wizard-google-drive.adoc
@@ -11,22 +11,11 @@ You can migrate virtual machine disk image files from Google Drive by using the 
 
 The wizard is designed to lead you step-by-step in creating a migration plan.
 
-[WARNING]
-====
-Do not include virtual machines with guest-initiated storage connections, such as Internet Small Computer Systems Interface (iSCSI) connections or Network File System (NFS) mounts. These require either additional planning before migration or reconfiguration after migration.
+Considerations::
 
-This prevents concurrent disk access to the storage the guest points to.
-====
-
-[IMPORTANT]
-====
-A plan cannot contain more than 500 VMs or 500 disks.
-====
-
-[IMPORTANT]
-====
-When you click *Create plan* on the *Review and create* page of the wizard, {project-first} validates your plan. If everything is OK, the *Plan details* page for your plan opens. This page contains settings that do not appear in the wizard, but are important. Be sure to read and follow the instructions for this page carefully, even though it is outside the plan creation wizard. The page can be opened later, any time before you run the plan, so you can come back to it if needed.
-====
+* Do not include virtual machines with guest-initiated storage connections, such as Internet Small Computer Systems Interface (iSCSI) connections or Network File System (NFS) mounts. These require either additional planning before migration or reconfiguration after migration. This prevents concurrent disk access to the storage the guest points to.
+* A plan cannot contain more than 500 VMs or 500 disks.
+* When you click *Create plan* on the *Review and create* page of the wizard, {project-first} validates your plan. If everything is OK, the *Plan details* page for your plan opens. This page contains settings that do not appear in the wizard, but are important. Be sure to read and follow the instructions for this page carefully, even though it is outside the plan creation wizard. The page can be opened later, any time before you run the plan, so you can come back to it if needed.
 
 .Prerequisites
 

--- a/documentation/modules/creating-plan-wizard-google-drive.adoc
+++ b/documentation/modules/creating-plan-wizard-google-drive.adoc
@@ -2,10 +2,9 @@
 //
 // * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-google-drive.adoc
 //
-// TODO: Check with SME to clarify the "500 VMs or 500 disks" limit (line 17).
-// Is this: (a) independent limits (500 VMs AND 500 disks), or
-//          (b) combined/first-hit limit (500 VMs OR 500 disks, whichever comes first)?
-// This ambiguity exists across all provider docs (vmware, rhv, ova, ostack, cnv).
+// TODO (SME): Clarify the "500 VMs or 500 disks" limit (line 17).
+//             Are these independent limits (500 VMs AND 500 disks) or whichever limit is reached first?
+//             This wording appears in all provider docs.
 
 :_mod-docs-content-type: PROCEDURE
 [id="creating-plan-wizard-google-drive_{context}"]

--- a/documentation/modules/creating-plan-wizard-google-drive.adoc
+++ b/documentation/modules/creating-plan-wizard-google-drive.adoc
@@ -1,6 +1,11 @@
 // Module included in the following assemblies:
 //
 // * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-google-drive.adoc
+//
+// TODO: Check with SME to clarify the "500 VMs or 500 disks" limit (line 17).
+// Is this: (a) independent limits (500 VMs AND 500 disks), or
+//          (b) combined/first-hit limit (500 VMs OR 500 disks, whichever comes first)?
+// This ambiguity exists across all provider docs (vmware, rhv, ova, ostack, cnv).
 
 :_mod-docs-content-type: PROCEDURE
 [id="creating-plan-wizard-google-drive_{context}"]
@@ -19,9 +24,9 @@ Considerations::
 
 .Prerequisites
 
-* Have a Google Drive source provider and {a-virt} destination provider. For more information, see xref:adding-google-drive-source-provider_google-drive[Adding a Google Drive source provider] or xref:adding-source-provider_dest_google-drive[Adding {a-virt} destination provider].
+* Have a Google Drive source provider and {a-virt} destination provider. For more information, see xref:adding-google-drive-source-provider_google-drive[Adding a Google Drive source provider] or xref:proc_adding-source-provider_dest_google-drive[Adding {a-virt} destination provider].
 * If you plan to create a *Network map* or a *Storage map* that will be used by more than one migration plan, create it in the *Network maps* or *Storage maps* page of the UI before you create a migration plan that uses that map.
-* If you are using a user-defined network (UDN), note the name of its namespace as defined in {virt}.
+* If you are using a user-defined network (UDN), note the name of its namespace as defined in {virt}. Verify that the IP address of the provider is outside the subnet of the UDN. If the IP address is within the subnet of the UDN, the migration fails.
 
 .Procedure
 
@@ -50,7 +55,6 @@ The *Create migration plan* wizard opens.
 +
 // Virtual machines page
 . On the *Virtual machines* page, select the virtual machines you want to migrate and click *Next*.
-. If you are using a UDN, verify that the IP address of the provider is outside the subnet of the UDN. If the IP address is within the subnet of the UDN, the migration fails.
 +
 // Network map page
 . On the *Network map* page, choose one of the following options:
@@ -64,7 +68,7 @@ These are network maps available for all plans, and therefore, they are _ownerle
 If you choose an existing map, be sure it has the same source provider and the same target provider as the ones you want to use in your plan.
 ====
 
-* *Use a new network map*: Allows you to create a new network map by supplying the following data. This map is attached to this plan, which is then considered to be its owner. Maps that you create using this option are not available in the *Use an existing network map* option because each is created with an owner.
+* *Use a new network map*: Allows you to create a new network map by supplying the following data. This map is attached to this plan, which is then considered to be its owner. Maps that you create by using this option are not available in the *Use an existing network map* option because each is created with an owner.
 +
 [NOTE]
 ====
@@ -91,7 +95,7 @@ These are storage maps available for all plans, and therefore, they are _ownerle
 If you choose an existing map, be sure it has the same source provider and the same target provider as the ones you want to use in your plan.
 ====
 
-* *Use new storage map*: Allows you to create one or two new storage maps by supplying the following data. These maps are attached to this plan, which is then their owner. Maps that you create using this option are not available in the *Use an existing storage map* option because each is created with an owner.
+* *Use new storage map*: Allows you to create one or two new storage maps by supplying the following data. These maps are attached to this plan, which is then their owner. Maps that you create by using this option are not available in the *Use an existing storage map* option because each is created with an owner.
 +
 [NOTE]
 ====

--- a/documentation/modules/creating-yaml-based-network-maps-ui-google-drive.adoc
+++ b/documentation/modules/creating-yaml-based-network-maps-ui-google-drive.adoc
@@ -1,0 +1,64 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-google-drive.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="creating-yaml-based-network-maps-ui-google-drive_{context}"]
+= Creating ownerless network maps by using YAML or JSON definitions in the {project-short} UI
+
+[role="_abstract"]
+You can add ownerless network maps by using YAML or JSON definitions in the YAML page of the {project-first} UI to map source networks to {virt} networks. Later, you can add these maps to a migration plan by using the *Use an existing network map* option in the *Network map* page of the {project-short} wizard.
+
+For more information about network and storage maps in {project-short}, see link:{mtv-plan}assembly_mapping-networks-storage_mtv[Mapping networks and storage in migration plans].
+
+.Prerequisites
+
+* Have a Google Drive source provider and {a-virt} destination provider. For more information, see xref:adding-google-drive-source-provider_google-drive[Adding a Google Drive source provider] or xref:adding-source-provider_dest_google-drive[Adding {a-virt} destination provider].
+
+.Procedure
+
+. In the {ocp} web console, click *Migration for Virtualization* > *Network maps*.
+. Click *Create network map* > *Create with YAML*.
+. Enter the YAML or JSON definitions into the editor, or drag and drop a file into the editor.
+. If you enter YAML definitions, use the following:
++
+[source,yaml,subs="attributes+"]
+----
+$  cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: NetworkMap
+metadata:
+  name: <network_map>
+  namespace: <namespace>
+spec:
+  map:
+    - destination:
+        name: <network_name>
+        type: pod
+      source:
+        id: <source_network_id>
+    - destination:
+        name: <network_attachment_definition>
+        namespace: <network_attachment_definition_namespace>
+        type: multus
+      source:
+        id: <source_network_id>
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+EOF
+----
++
+* `type`: Allowed values are `pod` and `multus`.
+* `source`: Specify the source network identifier.
+* `<network_attachment_definition>`: Specify a network attachment definition for each additional {virt} network.
+* `<network_attachment_definition_namespace>`: Required only when `type` is `multus`. Specify the namespace of the {virt} network attachment definition.
+
+. Optional: To download your input, click *Download*.
+. Click *Create*.
++
+Your map appears in the list of network maps.

--- a/documentation/modules/creating-yaml-based-network-maps-ui-google-drive.adoc
+++ b/documentation/modules/creating-yaml-based-network-maps-ui-google-drive.adoc
@@ -13,7 +13,7 @@ For more information about network and storage maps in {project-short}, see link
 
 .Prerequisites
 
-* Have a Google Drive source provider and {a-virt} destination provider. For more information, see xref:adding-google-drive-source-provider_google-drive[Adding a Google Drive source provider] or xref:adding-source-provider_dest_google-drive[Adding {a-virt} destination provider].
+* Have a Google Drive source provider and {a-virt} destination provider. For more information, see xref:adding-google-drive-source-provider_google-drive[Adding a Google Drive source provider] or xref:proc_adding-source-provider_dest_google-drive[Adding {a-virt} destination provider].
 
 .Procedure
 

--- a/documentation/modules/creating-yaml-based-storage-maps-ui-google-drive.adoc
+++ b/documentation/modules/creating-yaml-based-storage-maps-ui-google-drive.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-google-drive.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="creating-yaml-based-storage-maps-ui-google-drive_{context}"]
+= Creating ownerless storage maps by using YAML or JSON definitions in the {project-short} UI
+
+[role="_abstract"]
+You can add ownerless storage maps by using YAML or JSON definitions in the YAML page of the {project-first} UI. Later, you can add these maps to a migration plan by using the *Use an existing storage map* option in the *Storage map* page of the {project-short} wizard.
+
+For more information about network and storage maps in {project-short}, see link:{mtv-plan}assembly_mapping-networks-storage_mtv[Mapping networks and storage in migration plans].
+
+.Prerequisites
+
+* Have a Google Drive source provider and {a-virt} destination provider. For more information, see xref:adding-google-drive-source-provider_google-drive[Adding a Google Drive source provider] or xref:adding-source-provider_dest_google-drive[Adding {a-virt} destination provider].
+
+.Procedure
+
+. In the {ocp} web console, click *Migration for Virtualization* > *Storage maps*.
+. Click *Create storage map* > *Create with YAML*.
++
+The *Create StorageMap* page opens.
+. Enter the YAML or JSON definitions into the editor, or drag and drop a file into the editor.
+. If you enter YAML definitions, use the following:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: StorageMap
+metadata:
+  name: <storage_map>
+  namespace: <namespace>
+spec:
+  map:
+    - destination:
+        storageClass: <storage_class>
+        accessMode: <access_mode>
+      source:
+        name:  Dummy storage for source provider <provider_name>
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+EOF
+----
++
+* `accessMode`: Allowed values are `ReadWriteOnce` and `ReadWriteMany`.
+* `name`: For Google Drive, the `StorageMap` can map only a single storage, which all the disks from the Google Drive source are associated with, to a storage class at the destination. For this reason, the storage is referred to in the UI as "Dummy storage for source provider <provider_name>". In the YAML, write the phrase as it appears above, without the quotation marks and replacing <provider_name> with the actual name of the provider.
+
+. Optional: To download your input, click *Download*.
+. Click *Create*.
++
+Your map appears in the list of storage maps.

--- a/documentation/modules/creating-yaml-based-storage-maps-ui-google-drive.adoc
+++ b/documentation/modules/creating-yaml-based-storage-maps-ui-google-drive.adoc
@@ -1,6 +1,9 @@
 // Module included in the following assemblies:
 //
 // * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-google-drive.adoc
+//
+// TODO (SME): Verify the storage name string "Dummy storage for source provider <provider_name>" is correct
+//             for Google Drive, or confirm if it should be "Google Drive storage for source provider <provider_name>".
 
 :_mod-docs-content-type: PROCEDURE
 [id="creating-yaml-based-storage-maps-ui-google-drive_{context}"]

--- a/documentation/modules/creating-yaml-based-storage-maps-ui-google-drive.adoc
+++ b/documentation/modules/creating-yaml-based-storage-maps-ui-google-drive.adoc
@@ -13,7 +13,7 @@ For more information about network and storage maps in {project-short}, see link
 
 .Prerequisites
 
-* Have a Google Drive source provider and {a-virt} destination provider. For more information, see xref:adding-google-drive-source-provider_google-drive[Adding a Google Drive source provider] or xref:adding-source-provider_dest_google-drive[Adding {a-virt} destination provider].
+* Have a Google Drive source provider and {a-virt} destination provider. For more information, see xref:adding-google-drive-source-provider_google-drive[Adding a Google Drive source provider] or xref:proc_adding-source-provider_dest_google-drive[Adding {a-virt} destination provider].
 
 .Procedure
 

--- a/documentation/modules/creating-yaml-based-storage-maps-ui-google-drive.adoc
+++ b/documentation/modules/creating-yaml-based-storage-maps-ui-google-drive.adoc
@@ -1,9 +1,6 @@
 // Module included in the following assemblies:
 //
 // * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-google-drive.adoc
-//
-// TODO (SME): Verify the storage name string "Dummy storage for source provider <provider_name>" is correct
-//             for Google Drive, or confirm if it should be "Google Drive storage for source provider <provider_name>".
 
 :_mod-docs-content-type: PROCEDURE
 [id="creating-yaml-based-storage-maps-ui-google-drive_{context}"]

--- a/documentation/modules/google-drive-prerequisites.adoc
+++ b/documentation/modules/google-drive-prerequisites.adoc
@@ -1,0 +1,65 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Planning_your_migration/assemblies/assembly_provider-specific-requirements-for-migration.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="google-drive-prerequisites_{context}"]
+= Google Drive prerequisites
+
+[role="_abstract"]
+Google Drive migrations to {virt} require virtual machine disk image files stored in Google Drive with proper authentication configured through Google Cloud Platform. {project-first} accesses these files using OAuth 2.0 service account credentials and imports them directly into the target environment.
+
+Considerations::
+
+* Like OVA migrations, Google Drive migrations are file-based imports. The network mapping, storage mapping, and migration execution procedures are identical to OVA migrations. The key differences are in the prerequisites and provider configuration.
+* The service account JSON key file contains sensitive credentials. Store this file securely and limit access to authorized personnel only.
+* You can share individual files instead of folders if needed. Ensure that all files required for the migration are accessible to the service account.
+* *File organization*: Organize your VM disk images in Google Drive folders for easier management. Note the Google Drive folder ID from the URL (the string after `/folders/` in the browser address bar).
+* *File size and transfer time*: Large VM disk images may take significant time to transfer. Plan your migration windows accordingly.
+* *API quotas and limits*: Google Drive API has usage quotas. For large-scale migrations, monitor your API usage in the Google Cloud Console to avoid rate limiting.
+
+Prerequisites::
+
+* *Google Cloud Platform project*: You must have an active project in the Google Cloud Console with the Google Drive API enabled.
+* *Google Drive API access*: The Google Drive API must be enabled for your project with the necessary permissions configured.
+* *OAuth 2.0 service account*: A service account must be created with appropriate roles (such as Storage Object Viewer or Drive API Read-only) and a JSON key file generated.
+* *Shared Google Drive folder*: The Google Drive folder or files containing the VM disk images must be shared with the service account's email address with at least read permissions.
+* *Network connectivity*: The OpenShift cluster nodes must have egress network connectivity to Google Drive API endpoints (`*.googleapis.com`).
+* *Supported file formats*: VM disk images must be in a supported format, such as:
+** QCOW2 (QEMU Copy-On-Write version 2)
+** VMDK (Virtual Machine Disk)
+** OVA (Open Virtual Appliance) files created by VMware vSphere
+
+.Configuring Google Cloud Platform for {project-short}
+
+To prepare your Google Cloud Platform environment for importing VM disk images from Google Drive:
+
+. Create or select a Google Cloud project in the link:https://console.cloud.google.com[Google Cloud Console].
+
+. Enable the Google Drive API:
+.. Navigate to *APIs & Services* > *Library*.
+.. Search for "Google Drive API" and click *Enable*.
+
+. Create a service account:
+.. Navigate to *IAM & Admin* > *Service Accounts*.
+.. Click *Create Service Account*.
+.. Enter a name and description for the service account.
+.. Click *Create and Continue*.
+
+. Grant the service account appropriate permissions:
+.. Assign roles such as *Storage Object Viewer* or *Drive API Read-only*.
+.. Click *Continue* and then *Done*.
+
+. Generate a service account key:
+.. Click the created service account to open its details page.
+.. Navigate to the *Keys* tab.
+.. Click *Add Key* > *Create new key*.
+.. Select *JSON* as the key type.
+.. Click *Create* to download the JSON key file to your machine.
+
+. Share the Google Drive folder containing VM disk images:
+.. In Google Drive, navigate to the folder containing your VM disk image files.
+.. Right-click the folder and select *Share*.
+.. Enter the service account's email address (found in the JSON key file or the service account details page).
+.. Grant at least *Viewer* permissions.
+.. Click *Share*.

--- a/documentation/modules/proc_adding-source-provider.adoc
+++ b/documentation/modules/proc_adding-source-provider.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-cnv.adoc
+// * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-google-drive.adoc
 // * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-osp.adoc
 // * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-ova.adoc
 // * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-rhv.adoc
@@ -64,14 +65,14 @@ The {ocp} cluster version of the source provider must be 4.16 or later.
 ====
 endif::[]
 
-ifdef::dest_vmware,dest_rhv,dest_ostack,dest_ova,dest_cnv[]
+ifdef::dest_vmware,dest_rhv,dest_ostack,dest_ova,dest_google-drive,dest_cnv[]
 = Adding {a-virt} destination provider
 
 [role="_abstract"]
 Use a Red Hat {virt} provider as both source and destination provider. You can migrate VMs from the cluster that {project-first} is deployed on to another cluster or from a remote cluster to the cluster that {project-short} is deployed on.
 endif::[]
 
-ifdef::vmware,rhv,dest_vmware,dest_rhv,dest_ostack,dest_ova,dest_cnv[]
+ifdef::vmware,rhv,dest_vmware,dest_rhv,dest_ostack,dest_ova,dest_google-drive,dest_cnv[]
 .Prerequisites
 endif::[]
 
@@ -88,7 +89,7 @@ ifdef::rhv[]
 * {manager} CA certificate, unless it was replaced by a third-party certificate, in which case, specify the {manager} Apache CA certificate
 endif::[]
 
-ifdef::dest_vmware,dest_rhv,dest_ostack,dest_ova,dest_cnv[]
+ifdef::dest_vmware,dest_rhv,dest_ostack,dest_ova,dest_google-drive,dest_cnv[]
 * You must have {a-virt} link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/authentication_and_authorization/using-service-accounts[service account token] with `cluster-admin` privileges.
 endif::[]
 
@@ -364,7 +365,7 @@ If both *URL* and *Service account bearer token* are left blank, the local {ocp-
 Once confirmed, the CA certificate will be used to validate subsequent communication with the API endpoint.
 endif::[]
 
-ifdef::dest_vmware,dest_rhv,dest_ostack,dest_ova,dest_cnv[]
+ifdef::dest_vmware,dest_rhv,dest_ostack,dest_ova,dest_google-drive,dest_cnv[]
 . Access the *Create {virt} provider* interface by doing one of the following:
 
 .. In the {ocp} web console, click *Migration for Virtualization > Providers*.

--- a/documentation/modules/proc_configuring-google-cloud-platform-google-drive.adoc
+++ b/documentation/modules/proc_configuring-google-cloud-platform-google-drive.adoc
@@ -7,28 +7,17 @@
 = Configuring Google Cloud Platform for {project-short}
 
 [role="_abstract"]
-Google Drive migrations to {virt} require virtual machine disk image files stored in Google Drive with proper authentication configured through Google Cloud Platform. {project-first} accesses these files by using OAuth 2.0 service account credentials and imports them directly into the target environment.
+To prepare your Google Cloud Platform environment for importing VM disk images from Google Drive, you must create a service account, enable the Google Drive API, and share the Google Drive folder with the service account.
 
 Considerations::
 
+* {project-first} accesses Google Drive files by using OAuth 2.0 service account credentials and imports them directly into the target environment.
 * Like OVA migrations, Google Drive migrations are file-based imports. The network mapping, storage mapping, and migration execution procedures are identical to OVA migrations. The key differences are in the prerequisites and provider configuration.
 * The service account JSON key file contains sensitive credentials. Store this file securely and limit access to authorized personnel only.
 * You can share individual files instead of folders if needed. Ensure that all files required for the migration are accessible to the service account.
 * *File organization*: Organize your VM disk images in Google Drive folders for easier management. Note the Google Drive folder ID from the URL (the string after `/folders/` in the browser address bar).
 * *File size and transfer time*: Large VM disk images may take significant time to transfer. Plan your migration windows accordingly.
 * *API quotas and limits*: Google Drive API has usage quotas. For large-scale migrations, monitor your API usage in the Google Cloud Console to avoid rate limiting.
-
-.Prerequisites
-
-* *Google Cloud Platform project*: You must have an active project in the Google Cloud Console with the Google Drive API enabled.
-* *Google Drive API access*: The Google Drive API must be enabled for your project with the necessary permissions configured.
-* *OAuth 2.0 service account*: A service account must be created with appropriate roles (such as Storage Object Viewer or Drive API Read-only) and a JSON key file generated.
-* *Shared Google Drive folder*: The Google Drive folder or files containing the VM disk images must be shared with the service account's email address with at least read permissions.
-* *Network connectivity*: The OpenShift cluster nodes must have egress network connectivity to Google Drive API endpoints (`*.googleapis.com`).
-* *Supported file formats*: VM disk images must be in a supported format, such as:
-** QCOW2 (QEMU Copy-On-Write version 2)
-** VMDK (Virtual Machine Disk)
-** OVA (Open Virtual Appliance) files created by VMware vSphere
 
 .Procedure
 

--- a/documentation/modules/proc_configuring-google-cloud-platform-google-drive.adoc
+++ b/documentation/modules/proc_configuring-google-cloud-platform-google-drive.adoc
@@ -2,12 +2,12 @@
 //
 // * documentation/doc-Planning_your_migration/assemblies/assembly_provider-specific-requirements-for-migration.adoc
 
-:_mod-docs-content-type: REFERENCE
-[id="google-drive-prerequisites_{context}"]
-= Google Drive prerequisites
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-google-cloud-platform-google-drive_{context}"]
+= Configuring Google Cloud Platform for {project-short}
 
 [role="_abstract"]
-Google Drive migrations to {virt} require virtual machine disk image files stored in Google Drive with proper authentication configured through Google Cloud Platform. {project-first} accesses these files using OAuth 2.0 service account credentials and imports them directly into the target environment.
+Google Drive migrations to {virt} require virtual machine disk image files stored in Google Drive with proper authentication configured through Google Cloud Platform. {project-first} accesses these files by using OAuth 2.0 service account credentials and imports them directly into the target environment.
 
 Considerations::
 
@@ -18,7 +18,7 @@ Considerations::
 * *File size and transfer time*: Large VM disk images may take significant time to transfer. Plan your migration windows accordingly.
 * *API quotas and limits*: Google Drive API has usage quotas. For large-scale migrations, monitor your API usage in the Google Cloud Console to avoid rate limiting.
 
-Prerequisites::
+.Prerequisites
 
 * *Google Cloud Platform project*: You must have an active project in the Google Cloud Console with the Google Drive API enabled.
 * *Google Drive API access*: The Google Drive API must be enabled for your project with the necessary permissions configured.
@@ -30,9 +30,7 @@ Prerequisites::
 ** VMDK (Virtual Machine Disk)
 ** OVA (Open Virtual Appliance) files created by VMware vSphere
 
-.Configuring Google Cloud Platform for {project-short}
-
-To prepare your Google Cloud Platform environment for importing VM disk images from Google Drive:
+.Procedure
 
 . Create or select a Google Cloud project in the link:https://console.cloud.google.com[Google Cloud Console].
 

--- a/documentation/modules/proc_configuring-google-cloud-platform-google-drive.adoc
+++ b/documentation/modules/proc_configuring-google-cloud-platform-google-drive.adoc
@@ -32,10 +32,8 @@ Considerations::
 .. Click *Create Service Account*.
 .. Enter a name and description for the service account.
 .. Click *Create and Continue*.
-
-. Grant the service account appropriate permissions:
-.. Assign roles such as *Storage Object Viewer* or *Drive API Read-only*.
-.. Click *Continue* and then *Done*.
+.. Click *Continue* to skip granting project roles (Google Drive access is managed by file/folder sharing, not IAM roles).
+.. Click *Done*.
 
 . Generate a service account key:
 .. Click the created service account to open its details page.

--- a/documentation/modules/proc_migrating-vms-cli-google-drive.adoc
+++ b/documentation/modules/proc_migrating-vms-cli-google-drive.adoc
@@ -1,0 +1,321 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-google-drive.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc_migrating-vms-cli-google-drive_{context}"]
+
+= Running a Google Drive migration from the command-line
+
+[role="_abstract"]
+You can migrate virtual machine disk image files from Google Drive by using the command-line interface (CLI).
+
+.Prerequisites
+* If you are using a user-defined network (UDN), note the name of its namespace as defined in {virt}.
+* Google Cloud Platform service account JSON key file.
+* Google Drive folder ID where VM disk images are stored.
+
+.Procedure
+. Create a `Secret` manifest for the source provider credentials:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <secret>
+  namespace: <namespace>
+  ownerReferences:
+    - apiVersion: forklift.konveyor.io/v1beta1
+      kind: Provider
+      name: <provider_name>
+      uid: <provider_uid>
+  labels:
+    createdForProviderType: google-drive
+    createdForResourceType: providers
+type: Opaque
+stringData:
+  key.json: |
+    {
+      "type": "service_account",
+      "project_id": "<your-gcp-project-id>",
+      "private_key_id": "<your-private-key-id>",
+      "private_key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
+      "client_email": "<your-service-account-email>",
+      "client_id": "<your-client-id>",
+      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+      "token_uri": "https://oauth2.googleapis.com/token",
+      "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+      "client_x509_cert_url": "<your-cert-url>",
+      "universe_domain": "googleapis.com"
+    }
+EOF
+----
++
+where:
+
+`ownerReferences`::
+Is an optional section in which you can specify a provider's `name` and `uid`.
+
+`key.json`::
+Specifies the entire JSON content from the service account key file downloaded from Google Cloud Platform. Paste the complete JSON object as shown above, replacing the placeholder values with your actual service account credentials.
+
+. Create a `Provider` manifest for the source provider:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Provider
+metadata:
+  name: <source_provider>
+  namespace: <namespace>
+spec:
+  type: google-drive
+  url: "gdrive://<google-drive-folder-id>"
+  secret:
+    name: <secret>
+    namespace: <namespace>
+EOF
+----
++
+where:
+
+`type`::
+Must be set to `google-drive` for Google Drive source providers.
+
+`url`::
+Specifies the Google Drive folder ID in the format `gdrive://<folder-id>`. You can find the folder ID in the Google Drive URL after `/folders/`. For example, if the URL is `https://drive.google.com/drive/folders/1a2b3c4d5e6f`, use `gdrive://1a2b3c4d5e6f`.
+
+`<secret>`::
+Specifies the name of the provider `Secret` CR.
+
+. Create a `NetworkMap` manifest to map the source and destination networks:
++
+[source,yaml,subs="attributes+"]
+----
+$  cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: NetworkMap
+metadata:
+  name: <network_map>
+  namespace: <namespace>
+spec:
+  map:
+    - destination:
+        name: <network_name>
+        type: pod
+      source:
+        id: <source_network_id>
+    - destination:
+        name: <network_attachment_definition>
+        namespace: <network_attachment_definition_namespace>
+        type: multus
+      source:
+        id: <source_network_id>
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+EOF
+----
++
+where:
+
+`type`::
+Specifies the network type. Allowed values are `pod` and `multus`.
+
+`<source_network_id>`::
+Specifies the source network identifier.
+
+`<network_attachment_definition>`::
+Specifies a network attachment definition (NAD) for each additional {virt} network.
+
+`<network_attachment_definition_namespace>`::
+Specifies the namespace of the {virt} NAD. Required only when `type` is `multus`.
+
+`namespace`::
+Specifies the namespace. If you are using a user-defined network (UDN), its namespace is defined in {virt}.
+
+. Create a `StorageMap` manifest to map source and destination storage:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: StorageMap
+metadata:
+  name: <storage_map>
+  namespace: <namespace>
+spec:
+  map:
+    - destination:
+        storageClass: <storage_class>
+        accessMode: <access_mode>
+      source:
+        name: Dummy storage for source provider <provider_name>
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+EOF
+----
++
+where:
+
+`<access_mode>`::
+Specifies the access mode. Allowed values are `ReadWriteOnce` and `ReadWriteMany`.
+
+`name`::
+Specifies the source provider. For Google Drive, the `StorageMap` can map only a single storage, which all the disks from the Google Drive source are associated with, to a storage class at the destination. For this reason, the storage is referred to in the UI as *Dummy storage for source provider <provider_name>*. In the `StorageMap` CR, write the phrase as it appears above, without the quotation marks and replacing <provider_name> with the actual name of the provider.
+
+. Optional: Create a `Hook` manifest to run custom code on a VM during the phase specified in the `Plan` CR:
++
+[source,yaml,subs="attributes+"]
+----
+$  cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Hook
+metadata:
+  name: <hook>
+  namespace: <namespace>
+spec:
+  image: quay.io/kubev2v/hook-runner
+  serviceAccount: <service_account>
+  playbook: |
+    LS0tCi0gbm...
+EOF
+----
++
+where:
+
+`<service_account>`::
+Specifies the {ocp} service account. This is an optional label. Use the `serviceAccount` parameter to modify any cluster resources.
+
+`playbook`::
+Specifies the Base64-encoded Ansible Playbook. If you specify a playbook, the `image` must include an `ansible-runner`.
++
+[NOTE]
+====
+You can use the default `hook-runner` image or specify a custom image. If you specify a custom image, you do not have to specify a playbook.
+====
+
+. Enter the following command to create the network attachment definition (NAD) of the transfer network used for {project-short} migrations.
++
+You use this definition to configure an IP address for the interface, either from the Dynamic Host Configuration Protocol (DHCP) or statically.
++
+Configuring the IP address enables the interface to reach the configured gateway.
++
+[source,yaml,subs="attributes+"]
+----
+$ oc edit NetworkAttachmentDefinitions <name_of_the_NAD_to_edit>
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: <name_of_transfer_network>
+  namespace: <namespace>
+  annotations:
+    forklift.konveyor.io/route: <IP_address>
+----
+
+. Create a `Plan` manifest for the migration:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Plan
+metadata:
+  name: <plan>
+  namespace: <namespace>
+spec:
+  provider:
+    source:
+      name: <source_provider>
+      namespace: <namespace>
+    destination:
+      name: <destination_provider>
+      namespace: <namespace>
+  map:
+    network:
+      name: <network_map>
+      namespace: <namespace>
+    storage:
+      name: <storage_map>
+      namespace: <namespace>
+  targetNamespace: <target_namespace>
+  vms:
+    - id: <source_vm1>
+    - name: <source_vm2>
+      hooks:
+        - hook:
+            namespace: <namespace>
+            name: <hook>
+          step: <step>
+EOF
+----
++
+where:
+
+`<plan>`::
+Specifies the name of the `Plan` CR.
+
+`map`::
+Specifies only one network map and one storage map per plan.
+
+`network`::
+Specifies a network mapping, even if the VMs to be migrated are not assigned to a network. The mapping can be empty in this case.
+
+`<network_map>`::
+Specifies the name of the `NetworkMap` CR.
+
+`storage`::
+Specifies a storage mapping even if the VMs to be migrated are not assigned with disk images. The mapping can be empty in this case.
+
+`<storage_map>`::
+Specifies the name of the `StorageMap` CR.
+
+`vms`::
+Specifies the source VMs and their hooks. Accepts either the `id` or the `name` parameter to specify the source VMs. If you are using a UDN, verify that the IP address of the provider is outside the subnet of the UDN. If the IP address is within the subnet of the UDN, the migration fails.
+
+`<source_vm1>`::
+Specifies the VM disk image file name as it appears in Google Drive.
+
+`hooks`::
+Specifies up to two hooks for a migration. Each hook must run during a separate migration step. This is an optional label.
+
+`<hook>`::
+Specifies the name of the `Hook` CR.
+
+`<step>`::
+Specifies the type of hook. Allowed values are `PreHook`, before the migration plan starts, or `PostHook`, after the migration is complete.
+
+. Create a `Migration` manifest to run the `Plan` CR:
++
+[source,yaml,subs="attributes+"]
+----
+$ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
+kind: Migration
+metadata:
+  name: <name_of_migration_cr>
+  namespace: <namespace>
+spec:
+  plan:
+    name: <name_of_plan_cr>
+    namespace: <namespace>
+  cutover: <optional_cutover_time>
+EOF
+----
++
+[NOTE]
+====
+If you specify a cutover time, use the ISO 8601 format with the UTC time offset, for example, `2024-04-04T01:23:45.678+09:00`.
+====

--- a/documentation/modules/proc_migrating-vms-cli-google-drive.adoc
+++ b/documentation/modules/proc_migrating-vms-cli-google-drive.adoc
@@ -1,6 +1,9 @@
 // Module included in the following assemblies:
 //
 // * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-google-drive.adoc
+//
+// TODO (SME): Does the 'id' value (line 289) expect the literal file name (e.g., "my-vm.qcow2")
+//             or the Google Drive File ID (alphanumeric string from the API)?
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc_migrating-vms-cli-google-drive_{context}"]

--- a/documentation/modules/proc_migrating-vms-cli-google-drive.adoc
+++ b/documentation/modules/proc_migrating-vms-cli-google-drive.adoc
@@ -215,7 +215,7 @@ Configuring the IP address enables the interface to reach the configured gateway
 +
 [source,yaml,subs="attributes+"]
 ----
-$ oc edit NetworkAttachmentDefinitions <name_of_the_NAD_to_edit>
+$ oc edit network-attachment-definitions <name_of_the_NAD_to_edit> -n <namespace>
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:

--- a/documentation/modules/proc_migrating-vms-cli-google-drive.adoc
+++ b/documentation/modules/proc_migrating-vms-cli-google-drive.adoc
@@ -218,7 +218,7 @@ Configuring the IP address enables the interface to reach the configured gateway
 +
 [source,yaml,subs="attributes+"]
 ----
-$ oc edit network-attachment-definitions <name_of_the_NAD_to_edit> -n <namespace>
+$ {oc} edit network-attachment-definitions <name_of_the_NAD_to_edit> -n <namespace>
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:

--- a/documentation/modules/proc_migrating-vms-cli-google-drive.adoc
+++ b/documentation/modules/proc_migrating-vms-cli-google-drive.adoc
@@ -2,7 +2,7 @@
 //
 // * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-google-drive.adoc
 //
-// TODO (SME): Does the 'id' value (line 289) expect the literal file name (e.g., "my-vm.qcow2")
+// TODO (SME): Does <source_vm1> (line 292) expect the literal file name (e.g., "my-vm.qcow2")
 //             or the Google Drive File ID (alphanumeric string from the API)?
 
 :_mod-docs-content-type: PROCEDURE

--- a/documentation/modules/ref_google-drive-prerequisites.adoc
+++ b/documentation/modules/ref_google-drive-prerequisites.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Planning_your_migration/assemblies/assembly_provider-specific-requirements-for-migration.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="google-drive-prerequisites_{context}"]
+= Google Drive prerequisites
+
+[role="_abstract"]
+Google Drive migrations to {virt} require virtual machine disk image files stored in Google Drive with proper authentication configured through Google Cloud Platform.
+
+Prerequisites::
+
+* *Google Cloud Platform project*: You must have an active project in the Google Cloud Console with the Google Drive API enabled.
+* *Google Drive API access*: The Google Drive API must be enabled for your project with the necessary permissions configured.
+* *OAuth 2.0 service account*: A service account must be created with appropriate roles (such as Storage Object Viewer or Drive API Read-only) and a JSON key file generated.
+* *Shared Google Drive folder*: The Google Drive folder or files containing the VM disk images must be shared with the service account's email address with at least read permissions.
+* *Network connectivity*: The OpenShift cluster nodes must have egress network connectivity to Google Drive API endpoints (`*.googleapis.com`).
+* *Supported file formats*: VM disk images must be in a supported format, such as:
+** QCOW2 (QEMU Copy-On-Write version 2)
+** VMDK (Virtual Machine Disk)
+** OVA (Open Virtual Appliance) files created by VMware vSphere

--- a/documentation/modules/ref_google-drive-prerequisites.adoc
+++ b/documentation/modules/ref_google-drive-prerequisites.adoc
@@ -19,4 +19,4 @@ Prerequisites::
 * *Supported file formats*: VM disk images must be in a supported format, such as:
 ** QCOW2 (QEMU Copy-On-Write version 2)
 ** VMDK (Virtual Machine Disk)
-** OVA (Open Virtual Appliance) files created by VMware vSphere
+** OVA (Open Virtual Appliance) files created by {vmw} vSphere

--- a/documentation/modules/ref_google-drive-prerequisites.adoc
+++ b/documentation/modules/ref_google-drive-prerequisites.adoc
@@ -13,8 +13,8 @@ Prerequisites::
 
 * *Google Cloud Platform project*: You must have an active project in the Google Cloud Console with the Google Drive API enabled.
 * *Google Drive API access*: The Google Drive API must be enabled for your project with the necessary permissions configured.
-* *OAuth 2.0 service account*: A service account must be created with appropriate roles (such as Storage Object Viewer or Drive API Read-only) and a JSON key file generated.
-* *Shared Google Drive folder*: The Google Drive folder or files containing the VM disk images must be shared with the service account's email address with at least read permissions.
+* *OAuth 2.0 service account*: A service account must be created with a JSON key file generated. Access to Google Drive is granted by sharing files and folders with the service account's email address (for example, `service-account@project.iam.gserviceaccount.com`). For shared drives, add the service account as a member with a role such as Reader, Content Manager, or Contributor. For organizations using Google Workspace with restricted sharing, domain-wide delegation may be required.
+* *Shared Google Drive folder*: The Google Drive folder or files containing the VM disk images must be shared with the service account's email address with at least read (Viewer) permissions.
 * *Network connectivity*: The OpenShift cluster nodes must have egress network connectivity to Google Drive API endpoints (`*.googleapis.com`).
 * *Supported file formats*: VM disk images must be in a supported format, such as:
 ** QCOW2 (QEMU Copy-On-Write version 2)

--- a/documentation/modules/running-migration-plan.adoc
+++ b/documentation/modules/running-migration-plan.adoc
@@ -55,7 +55,7 @@ endif::vmware,rhv[]
 +
 [WARNING]
 ====
-Do not take a snapshot of a VM after you start a migration. Taking a snaphot after a migration starts might cause the migration to fail.
+Do not take a snapshot of a VM after you start a migration. Taking a snapshot after a migration starts might cause the migration to fail.
 ====
 
 . Optional: Click the links in the migration's *Status* to see its overall status and the status of each VM:

--- a/documentation/modules/selecting-migration-network-for-virt-provider.adoc
+++ b/documentation/modules/selecting-migration-network-for-virt-provider.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-cnv.adoc
+// * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-google-drive.adoc
 // * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-osp.adoc
 // * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-ova.adoc
 // * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-rhv.adoc
@@ -19,15 +20,10 @@ In {project-short} version 2.9 and earlier, {project-short} used the `pod` netwo
 
 In version 2.10.0 and later, {project-short} detects if you have selected a user-defined network (UDN) as your default network. Therefore, if you set the UDN to be the migration's namespace, you do not need to select a new default network when you create your migration plan.
 
-[IMPORTANT]
-====
-{project-short} supports using UDNs for all providers except {virt}.
-====
+Considerations::
 
-[NOTE]
-====
-You can override the default migration network of the provider by selecting a different network when you create a migration plan.
-====
+* {project-short} supports using UDNs for all providers except {virt}.
+* You can override the default migration network of the provider by selecting a different network when you create a migration plan.
 
 .Procedure
 

--- a/documentation/modules/selecting-migration-network-for-virt-provider.adoc
+++ b/documentation/modules/selecting-migration-network-for-virt-provider.adoc
@@ -30,7 +30,7 @@ Considerations::
 . In the {ocp} web console, click *Migration for Virtualization* > *Providers*.
 . Click the {virt} provider whose migration network you want to change.
 +
-When the *Providers detail* page opens:
+When the *Provider details* page opens:
 
 . Click the *Networks* tab.
 . Click *Set default transfer network*.


### PR DESCRIPTION
Do not merge: Obsolete
Non Google Drive doc fixes moved to https://github.com/kubev2v/forklift-documentation/pull/907/ 

Jiras:
https://redhat.atlassian.net/browse/MTV-3004 
https://redhat.atlassian.net/browse/MTV-3377 

Previews:

_Planning_ guide

- Google Drive Prerequisites: https://forklift-documentation-git-fork-je-0a7fd7-yaacov-8047s-projects.vercel.app/documentation/doc-Planning_your_migration/master.html#google-drive-prerequisites_mtv

- Planning a migration of virtual machines from Google Drive: https://forklift-documentation-git-fork-je-0a7fd7-yaacov-8047s-projects.vercel.app/documentation/doc-Planning_your_migration/master.html#assembly_planning-migration-google-drive_mtv

_Migrating_ guide

- Migrating from Google Drive: https://forklift-documentation-git-fork-je-0a7fd7-yaacov-8047s-projects.vercel.app/documentation/doc-Migrating_your_virtual_machines/master.html#assembly_migrating-from-google-drive_mtv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Google Drive VM migration docs: planning, migration guides, and assemblies.
  * New procedures for Google Cloud Platform setup and adding Google Drive as a source provider.
  * Documented UI and CLI workflows for creating migration plans, network maps, and storage maps (YAML and form-based).
  * Added scope, limitations, prerequisites, and cancellation/operation guidance for Google Drive migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->