### PR TITLE
MTV-4890: Pre-existing snapshots and SCO migrations

### DIFF
--- a/documentation/modules/about-storage-copy-offload.adoc
+++ b/documentation/modules/about-storage-copy-offload.adoc
@@ -19,6 +19,17 @@ The storage copy offload feature has some unique configuration prerequisites, wh
 
 You must ensure that your migration plans do not mix VDDK mappings with copy-offload mappings. Because the migration controller copies disks either through CDI volumes (VDDK) or through Volume Populators (copy-offload), all storage pairs in the plan must either include copy-offload details (a `Secret` + product) or none of them must. Otherwise, the plan fails.
 
+For storage copy offload migrations, especially performance-sensitive migrations, it is strongly recommended to delete any preexisting snapshots before you start the migration.
+
+[IMPORTANT]
+====
+Preexisting snapshots cause {project-short} to create snapshot delta chains. These chains prevent the array from performing block-level hardware acceleration for the hardware clone because the `vmkfstools` clone path used for offload cannot use hardware-accelerated `XCOPY`. 
+
+As a result, the operation falls back to a software clone (host-based copy). Although such a fallback migration is faster than a standard migration, it increases migration time and Esxi workload compared to an `XCOPY` migration.
+
+Snapshots created by a warm migration do not affect storage copy offload migrations. Only preexisting snapshots cause this issue.
+====
+
 For {project-first} 2.11, storage copy offload is available as GA for cold migration and as a Technology Preview feature for warm migration.
 
 [IMPORTANT]
@@ -51,7 +62,7 @@ The Forklift project, a key component of {project-short}, includes a specialized
 
 [IMPORTANT]
 ====
-The storage arrays must be the ones specified above. Otherwise, XCOPY performs a fallback network disk copy on the ESXi. Although a fallback network disk copy on the ESXi is usually considerably faster than a standard migration using a VDDK image over the network, it is not as quick as a properly configured storage copy offload migration.
+The storage arrays must be the ones specified above. Otherwise, `XCOPY` performs a fallback network disk copy on the ESXi. Although a fallback network disk copy on the ESXi is usually considerably faster than a standard migration using a VDDK image over the network, it is not as quick as a properly configured storage copy offload migration.
 ====
 
 [id="storage-copy-offload-works-supported-providers_{context}"]

--- a/documentation/modules/about-storage-copy-offload.adoc
+++ b/documentation/modules/about-storage-copy-offload.adoc
@@ -25,7 +25,7 @@ For storage copy offload migrations, especially performance-sensitive migrations
 ====
 Preexisting snapshots cause {project-short} to create snapshot delta chains. These chains prevent the array from performing block-level hardware acceleration for the hardware clone because the `vmkfstools` clone path used for offload cannot use hardware-accelerated `XCOPY`. 
 
-As a result, the operation falls back to a software clone (host-based copy). Although such a fallback migration is faster than a standard migration, it increases migration time and Esxi workload compared to an `XCOPY` migration.
+As a result, the operation falls back to a software clone (host-based copy). Although such a fallback migration is faster than a standard migration, it increases migration time and ESXi workload compared to an `XCOPY` migration.
 
 Snapshots created by a warm migration do not affect storage copy offload migrations. Only preexisting snapshots cause this issue.
 ====

--- a/documentation/modules/proc_storage-copy-offload-cli.adoc
+++ b/documentation/modules/proc_storage-copy-offload-cli.adoc
@@ -36,6 +36,12 @@ In addition to the regular link:https://docs.redhat.com/en/documentation/migrati
 *** Advanced settings
 *** Query patch
 *** Storage partition configuration
+* It is strongly recommended to delete any preexisting snapshots before you start a storage copy offload migration, especially performance-sensitive migrations. Pre-existing snapshots prevent use of `XCOPY` and force `vmkfstools` to use a slower software-based cloning method.
+
+[IMPORTANT]
+====
+Snapshots created by a warm migration do not affect storage copy offload migrations. Only preexisting snapshots cause this issue.
+====
 
 .Procedure
 

--- a/documentation/modules/proc_storage-copy-offload-ui.adoc
+++ b/documentation/modules/proc_storage-copy-offload-ui.adoc
@@ -36,6 +36,12 @@ In addition to the regular link:{mtv-plan}assembly_provider-specific-requirement
 *** Advanced settings
 *** Query patch
 *** Storage partition configuration
+* It is strongly recommended to delete any preexisting snapshots before you start a storage copy offload migration, especially performance-sensitive migrations. Pre-existing snapshots prevent use of `XCOPY` and force `vmkfstools` to use a slower software-based cloning method.
+
+[IMPORTANT]
+====
+Snapshots created by a warm migration do not affect storage copy offload migrations. Only preexisting snapshots cause this issue.
+====
 
 .Procedure
 


### PR DESCRIPTION
MTV 2.11.2 

Resolves https://redhat.atlassian.net/browse/MTV-4690 by including a strong recommendation to delete any pre-existing snapshots before starting a storage copy offload migration. 

Previews:

- https://forklift-documentation-git-fork-ri-3e7ac5-yaacov-8047s-projects.vercel.app/documentation/doc-Planning_your_migration/master.html#about-storage-copy-offload_vmware [Starting with "For storage copy offload migrations, ..." through the first note.
- https://forklift-documentation-git-fork-ri-3e7ac5-yaacov-8047s-projects.vercel.app/documentation/doc-Planning_your_migration/master.html#proc_storage-copy-offload-ui_vmware [Last prerequisite and note]
- https://forklift-documentation-git-fork-ri-3e7ac5-yaacov-8047s-projects.vercel.app/documentation/doc-Migrating_your_virtual_machines/master.html#proc_storage-copy-offload-cli_vmware [Last prerequisite and note]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated storage copy offload migration guidance to recommend deleting preexisting snapshots before migration, ensuring optimal cloning performance and preventing fallback to slower operations.
  * Clarified that snapshots created during warm migrations do not require removal—only preexisting snapshots need to be deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->