### PR TITLE
MTV-5106 CQA Release notes

### DIFF
--- a/documentation/doc-Release_notes/master.adoc
+++ b/documentation/doc-Release_notes/master.adoc
@@ -8,11 +8,12 @@ endif::[]
 :compat-mode:
 :context: release-notes
 
+[role="_abstract"]
+Review these release notes for {project-first} version {project-version}.
+
 include::modules/ref_rn-2-11.adoc[leveloffset=+1]
 
 // Technical changes by x-stream release
-
-
 include::modules/ref_technical-changes-2-11.adoc[leveloffset=+2]
 
 // New features and enhancements by z-stream release
@@ -34,12 +35,3 @@ include::modules/ref_resolved-issues-2-11-0.adoc[leveloffset=+3]
 
 // Known issues by x-stream release
 include::modules/ref_known-issues-2-11.adoc[leveloffset=+2]
-
-// Security fixes by y-stream release
-//include::modules/rn-security-fixes.adoc[leveloffset=+2]
-
-// Security fixes by z-stream release
-//include::modules/rn-2-11-z-security-fixes.adoc[leveloffset=+3]
-
-// == Release notes addendum
-// include::modules/mtv-selected-packages-2-11.adoc[leveloffset=+2]

--- a/documentation/modules/con_about-storage-copy-offload.adoc
+++ b/documentation/modules/con_about-storage-copy-offload.adoc
@@ -78,6 +78,6 @@ The following storage providers support storage copy offload:
 * Dell PowerStore
 * HPE 3PAR
 * HPE Primera
-* Infinidat Infinibox
+* Infinidat InfiniBox
 * IBM Flashsystem
 

--- a/documentation/modules/proc_storage-copy-offload-cli.adoc
+++ b/documentation/modules/proc_storage-copy-offload-cli.adoc
@@ -21,7 +21,7 @@ In addition to the regular link:https://docs.redhat.com/en/documentation/migrati
 ** Dell PowerFlex
 ** Dell PowerStore
 ** HPE 3PAR or HPE Primera
-** Infinidat Infinibox
+** Infinidat InfiniBox
 ** IBM Flashsystem
 * A working Container Storage Interface (CSI) driver connected to the above and to {virt}
 * A configured {vmw} vSphere provider
@@ -288,7 +288,7 @@ For HPE 3PAR, must also include Web Services API (WSAPI) port. Use the HPE 3PAR 
 |===
 +
 [width="100%",cols="22%,48%,15%,15%",options="header",]
-.Credentials for an Infinidat InfiBox storage copy offload Secret
+.Credentials for an Infinidat InfiniBox storage copy offload Secret
 |===
 |Key| Description| Mandatory?| Default
 

--- a/documentation/modules/proc_storage-copy-offload-ui.adoc
+++ b/documentation/modules/proc_storage-copy-offload-ui.adoc
@@ -21,7 +21,7 @@ In addition to the regular link:{mtv-plan}assembly_provider-specific-requirement
 ** Dell PowerFlex
 ** Dell PowerStore
 ** HPE 3PAR or HPE Primera
-** Infinidat Infinibox
+** Infinidat InfiniBox
 ** IBM Flashsystem
 * A working Container Storage Interface (CSI) driver connected to the above and to {virt}
 * A configured {vmw} vSphere provider
@@ -288,7 +288,7 @@ For HPE 3PAR, must also include Web Services API (WSAPI) port. Use the HPE 3PAR 
 |===
 +
 [width="100%",cols="22%,48%,15%,15%",options="header",]
-.Credentials for an Infinidat InfiBox storage copy offload Secret
+.Credentials for an Infinidat InfiniBox storage copy offload Secret
 |===
 |Key| Description| Mandatory?| Default
 

--- a/documentation/modules/ref_known-issues-2-11.adoc
+++ b/documentation/modules/ref_known-issues-2-11.adoc
@@ -9,81 +9,76 @@
 [role="_abstract"]
 {project-first} 2.11 has the following known issues.
 
-Migrations fail for VMs sharing the same BIOS UUID due to a Libvirt limitation:: 
-While {project-short} correctly handles source virtual machines (VMs), a known issue in Libvirt (RHEL-174300) causes conflicts on the target environment if multiple VMs share the same BIOS UUID. As a consequence, the migration fails.
+Migrations fail for VMs sharing the same BIOS UUID due to a libvirt limitation:: 
+While {project-short} correctly handles source virtual machines (VMs), a known issue in libvirt (RHEL-174300) causes conflicts on the target environment if multiple VMs share the same BIOS UUID. As a consequence, the migration fails.
 +
-*Workaround:* Ensure that all VMs have unique BIOS UUIDs before you initiate the migration.
+To work around this problem, ensure that all VMs have unique BIOS UUIDs before you initiate the migration.
 +
 link:https://redhat.atlassian.net/browse/MTV-5326[MTV-5326] and link:https://redhat.atlassian.net/browse/RHEL-174300[RHEL-174300]
 
 VMware migrations fail when the disk count exceeds the ESXi host LUN ID limit::
-VMware migrations with many disks fail if the disk count exceeds the host limit for discoverable SCSI LUN IDs.
-+
-*Workaround:* Increase the `Disk.MaxLUN` value on each ESXi host to support discovery of a higher number of LUN IDs during migrations.
+When VMware migrations involve many disks, the disk count might exceed the host limit for discoverable SCSI LUN IDs. As a consequence, the migrations fail.
++ 
+To work around this problem, increase the `Disk.MaxLUN` value on each ESXi host to support discovery of a higher number of LUN IDs during migrations.
 +
 link:https://issues.redhat.com/browse/MTV-4719[MTV-4719]
 
-Live migration support limit in custom namespaces with host providers:: 
-
-Host providers in custom namespaces operate with restricted permissions that prevent {project-short} from accessing resources for live migration support, for example, verifying a feature gate is enabled or synchronizing certificates between namespaces. As a result, live migration currently has limited supported in custom namespaces with host providers. 
+Live migration is limited in custom namespaces with host providers::
+Host providers in custom namespaces have restricted permissions that prevent {project-short} from accessing live migration resources. As a consequence, {project-short} provides limited support for live migration in these namespaces.
 +
-*Workaround:* Use the default host provider or create a provider with an appropriate access token. 
+To work around this problem, use the default host provider or create a provider with an appropriate access token.
 +
 link:https://issues.redhat.com/browse/MTV-3347[MTV-3347]
 
 Forklift console plugin fails to load on IPv6-only {ocp-short} clusters::
-
-When {project-short} 2.9.1 is deployed on an IPv6-only {ocp-short} cluster, an incorrect API endpoint prevents the forklift-console-plugin from serving a valid plugin manifest, displaying the error `Failed to get a valid plugin manifest from /api/plugins/forklift-console-plugins/`. While the forklift-ui-plugin pod runs successfully, the console plugin cannot load, preventing access to the {project-short} user interface in the {ocp-short} web console. This issue affects all IPv6-only cluster deployments with {ocp-short} 4.19.7 and CNV 4.19.1.
+When {project-short} is deployed on an IPv6-only {ocp-short} cluster, an incorrect API endpoint prevents the `forklift-console` plugin from serving a valid plugin manifest. As a consequence, the error `Failed to get a valid plugin manifest from /api/plugins/forklift-console-plugins/` is displayed in the {project-short} extension to the {ocp} web console. While the `forklift-ui-plugin` pod runs successfully, the console plugin cannot load, preventing access to the {project-short} user interface.
 +
-*Workaround:* Deploy {project-short} on dual-stack or IPv4 clusters until this issue is resolved.
+This issue applies to all IPv6-only cluster deployments with {ocp-short} 4.19.7 and CNV 4.19.1. This issue was first observed in {project-short} version 2.9.1 and continues to exist in {project-short} version 2.11.
++
+To work around this problem, deploy {project-short} on dual-stack or IPv4 clusters.
 +
 link:https://issues.redhat.com/browse/MTV-3116[MTV-3116]
 
-Incorrect labeling of inactive migration plans::
-
-Inactive migration plans are incorrectly labeled as `Running` when `max_vms_inflight` exceeds the total number of disks per migration. This label leads to confusion about the actual state of the plans, as all migration plans appear to be `Running` in the user interface.
+Inactive migration plans are incorrectly displayed as Running::
+When `max_vms_inflight` exceeds the total number of disks per migration, inactive migration plans receive an incorrect status. As a consequence, these inactive migration plans are displayed as *Running* in the user interface.
 +
-*Workaround:* Currently, there is no workaround for this issue.
+No known workaround exists.
 +
 link:https://issues.redhat.com/browse/MTV-1736[MTV-1736]
 
 Migration between {ocp-short} namespaces causes MAC address collisions::
-
-During migration between {ocp-short} namespaces in a cluster, MAC address collisions result in VM creation failure.
+During migration between {ocp-short} namespaces in a cluster, MAC address collisions occur. As a consequence, VM creation fails.
 +
-*Workaround:* Disable the KubeMacPool. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/virtualization/networking#virt-managing-kubemacpool-cli_virt-using-mac-address-pool-for-vms[Managing KubeMacPool by using the CLI] in the {ocp-short} documentation.
+To work around this problem, disable the `KubeMacPool`. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/virtualization/networking#virt-managing-kubemacpool-cli_virt-using-mac-address-pool-for-vms[Managing KubeMacPool by using the CLI] in the {ocp-short} documentation.
 +
 link:https://issues.redhat.com/browse/MTV-2446[MTV-2446]
 
-{vmw} vSphere 6 or 7 migration fails on FIPS-enabled clusters::
 
-In {project-short} 2.11.0, an update to Golang 1.25 causes a connection failure on FIPS-enabled clusters with {vmw} vSphere 6 or 7, due to unsupported TLS 1.2 with Extended Master Secret. As a consequence, users cannot migrate {vmw} vSphere 6 or 7 VMs to a FIPS-compliant cluster.
+{vmw} vSphere 6 or 7 migration fails on FIPS-enabled clusters::
+In {project-short} 2.11.0, an update to Golang 1.25 causes a connection failure on FIPS-enabled clusters with {vmw} vSphere 6 or 7 due to unsupported TLS 1.2 with Extended Master Secret (EMS). As a consequence, you cannot migrate {vmw} vSphere 6 or 7 VMs to a FIPS-compliant cluster.
 +
-*Workaround:* Disable FIPS mode on the cluster or use a {vmw} vSphere version that supports TLS 1.2 with Extended Master Secret to migrate VMs.
+To work around this problem, disable FIPS mode on the cluster. Alternatively, use a {vmw} vSphere version that supports TLS 1.2 with EMS to migrate VMs.
 +
 link:https://issues.redhat.com/browse/MTV-4411[MTV-4411]
 
 Second migration plan with shared RDM disks fails when shared disk migration is disabled::
-
-When migrating two VMs with shared RDM disks using copyoffload in separate migration plans, the second migration plan fails at the `ImageConversion` step if shared disk migration is disabled. After successfully migrating the first VM with shared disk migration enabled, creating a second migration plan with shared disk migration disabled incorrectly creates two populate pods—one for the OS disk and one for the shared RDM disk—instead of creating only the OS disk populate pod. This causes the second migration to fail.
+You might migrate two VMs with shared Raw Device Mapping (RDM) disks by using `copyoffload` in separate migration plans. If you disable shared disk migration after successfully migrating the first VM, the second plan incorrectly creates two populated pods: one for the operating system disk and one for the shared RDM disk. As a consequence, the second migration plan fails at the `ImageConversion` step.
 +
-*Workaround:* Currently, there is no workaround for this issue.
+No known workaround exists.
 +
 link:https://issues.redhat.com/browse/MTV-4549[MTV-4549]
 
-VDDK image only in +{namespace}+ namespace::
-
-When you upload a {vmw} Virtual Disk Development Kit (VDDK) init image, the image URL is located in the +{namespace}+ namespace. If you create a provider in a different namespace, there is an error when pulling the image.
+VDDK image pulls fail outside the +{namespace}+ namespace::
+When you upload a {vmw} Virtual Disk Development Kit (VDDK) init image, the image URL is located in the +{namespace}+ namespace. If you create a provider in a different namespace, an error occurs. As a consequence, the image pull fails.
++
+No known workaround exists.
 +
 link:https://issues.redhat.com/browse/MTV-3673[MTV-3673]
 
-Fibre Channel (FC) protocol VM migration fails to identify existing FC host objects in Infinibox::
-
-Fibre Channel (FC) protocol VM migration fails to identify existing FC host objects in Infinibox due to incorrect adapter ID comparison. As a consequence, FC protocol VM migration fails to identify existing FC hosts, causing volume creation failure due to incorrect `port_name`.
+Fibre Channel protocol VM migration fails to identify existing FC host objects in Infinidat InfiniBox::
+During Fibre Channel (FC) protocol VM migration, an incorrect adapter ID comparison prevents {project-short} from identifying existing FC host objects in Infinidat InfiniBox. As a consequence, volume creation fails due to an incorrect `port_name`.
 +
-*Workaround:* Currently, there is no workaround for this issue.
+No known workaround exists.
 +
 link:https://issues.redhat.com/browse/MTV-4338[MTV-4338]
-
-//For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/issues/?filter=12472621[Known Issues] in Jira.
 

--- a/documentation/modules/ref_new-features-and-enhancements-2-11.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-11.adoc
@@ -14,7 +14,9 @@ MTV preserves static IPs on migrated Windows VMs when the DHCP Client service is
 +
 [IMPORTANT]
 ====
-The `feature_windows_registry_network_config` feature flag is Developer Preview software only. Developer Preview software is not supported by Red{nbsp}Hat in any way and is not functionally complete or production-ready. Do not use Developer Preview software for production or business-critical workloads. This feature provides early access to upcoming product software in advance of its possible inclusion in a Red{nbsp}Hat product offering. For more information about the support scope of Red{nbsp}Hat Developer Preview software, see link:https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope].
+The `feature_windows_registry_network_config` feature flag is Developer Preview software only. Developer Preview software is not supported by Red{nbsp}Hat in any way and is not functionally complete or production-ready. Do not use Developer Preview software for production or business-critical workloads. This feature provides early access to upcoming product software in advance of its possible inclusion in a Red{nbsp}Hat product offering.
+
+For more information about the support scope of Red{nbsp}Hat Developer Preview software, see link:https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope].
 ====
 +
 link:https://redhat.atlassian.net/browse/MTV-4717[MTV-4717]
@@ -37,14 +39,15 @@ Storage copy offload migrations support mapping Raw Device Mapping (RDM) disks a
 +
 link:https://redhat.atlassian.net/browse/MTV-5020[MTV-5020]
 
-
 Volume-to-volume copy now supported for HPE Primera and HPE 3PAR, enabling storage copy offload migrations for these storage providers::
 
 {project-short} 2.11.2 supports volume-to-volume copy operations for storage copy offload migrations on HPE Primera and HPE 3PAR arrays. These operations copy the underlying VMware Raw Device Mapping (RDM) or VMware vSphere Virtual Volumes (vVols) volume onto the target volume that the CSI driver creates. This improvement allows storage copy offload migrations for HPE Primera or HPE 3PAR storage providers.
 +
 [IMPORTANT]
 ====
-Storage copy offload for HPE Primera and HPE 3PAR, for both cold and warm migrations, is Developer Preview software only. Developer Preview software is not supported by Red{nbsp}Hat in any way and is not functionally complete or production-ready. Do not use Developer Preview software for production or business-critical workloads. This feature provides early access to upcoming product software in advance of its possible inclusion in a Red{nbsp}Hat product offering. For more information about the support scope of Red{nbsp}Hat Developer Preview software, see link:https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope].
+Storage copy offload for HPE Primera and HPE 3PAR, for both cold and warm migrations, is Developer Preview software only. Developer Preview software is not supported by Red{nbsp}Hat in any way and is not functionally complete or production-ready. Do not use Developer Preview software for production or business-critical workloads. This feature provides early access to upcoming product software in advance of its possible inclusion in a Red{nbsp}Hat product offering.
+
+For more information about the support scope of Red{nbsp}Hat Developer Preview software, see link:https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope].
 ====
 +
 link:https://redhat.atlassian.net/browse/MTV-4717[MTV-4717]
@@ -106,7 +109,7 @@ link:https://issues.redhat.com/browse/MTV-3712[MTV-3712]
 
 Enhanced learning experience in {project-short} UI::
 
-With this update, the `Tips and tricks` section in the {project-short} UI is significantly expanded, offering curated learning paths and improved user guidance. This enhancement simplifies complex workflow steps, integrates with Red Hat {virt} LightSpeed AI for dynamic guidance, and reorganizes content for a better learning process for {project-short} administrators.
+With this update, the *Tips and tricks* section in the {project-short} UI is significantly expanded, offering curated learning paths and improved user guidance. This enhancement simplifies complex workflow steps, integrates with Red Hat {virt} LightSpeed AI for dynamic guidance, and reorganizes content for a better learning process for {project-short} administrators.
 +
 link:https://issues.redhat.com/browse/MTV-3718[MTV-3718]
 
@@ -197,9 +200,9 @@ In {project-short} 2.11.0, you can customize ephemeral storage during migration,
 +
 link:https://issues.redhat.com/browse/MTV-3709[MTV-3709]
 
-OS-specific VM configuration for improved performance::
+Operating system-specific VM configuration for improved performance::
 
-With this update, {project-short} detects the operating system that VMs are running on automatically. This enhancement optimizes VM performance in {project-short} and reduces the need for manual adjustments, saving time and reducing potential errors.
+{project-short} automatically detects the operating system of the VMs. This enhancement reduces the need for manual adjustments. As a result, you optimize VM performance in {project-short}, save time, and reduce potential errors.
 +
 link:https://issues.redhat.com/browse/MTV-3963[MTV-3963]
 
@@ -213,4 +216,4 @@ Updated virtio-win drivers for improved migration stability::
 
 The `virtio-win` package, which provides drivers for Microsoft Windows virtual machines, is rebased to version 1.9.57. With this update, virtual machine migrations are more stable and include security updates. This update also resolves rare instances of stop errors that occurred during migrations.
 +
-// link:https://redhat.atlassian.net/browse/MTV-5077[MTV-5077]
+link:https://access.redhat.com/errata/RHSA-2026:5077[RHSA-2026:5077 - Security Advisory]

--- a/documentation/modules/ref_resolved-issues-2-11-0.adoc
+++ b/documentation/modules/ref_resolved-issues-2-11-0.adoc
@@ -137,8 +137,6 @@ link:https://issues.redhat.com/browse/MTV-3659[MTV-3659]
 
 Changes in device identification during OVA to {ocp-short} migration::
 
-Before this update, the migration of VMs with DHCP settings from an OVA provider to an {ocp-short} cluster resulted in the loss of interface settings in the VM YAML file, causing only one default interface with a pod network to remain in the VM. As a consequence, users experienced VMs with incorrect interface settings after migration. The issue occurred because the OVA scanner identified NICs and other device types based on the display name, which was unreliable. With this update, device identification is based on the resource type provided in the OVF specification, preserving interface settings during migration and preventing incorrect configurations.
+Before this update, the migration of VMs with DHCP settings from an OVA provider to an {ocp-short} cluster resulted in the loss of interface settings in the VM YAML file. This caused only one default interface with a pod network to remain in the VM. As a consequence, users experienced VMs with incorrect interface settings after migration. The issue occurred because the OVA scanner identified NICs and other device types based on the display name, which was unreliable. With this update, device identification is based on the resource type provided in the OVF specification, preserving interface settings during migration and preventing incorrect configurations.
 +
 link:https://issues.redhat.com/browse/MTV-3654[MTV-3654]
-
-

--- a/documentation/modules/ref_resolved-issues-2-11-1.adoc
+++ b/documentation/modules/ref_resolved-issues-2-11-1.adoc
@@ -28,7 +28,7 @@ link:https://issues.redhat.com/browse/MTV-3613[MTV-3613]
 Forklift-controller no longer unexpectedly shuts down due to map deletion::
 +
 --
-Before this update, the deletion of network or storage maps in the `forklift-controller` could cause unexpected shutdowns. With this update, deletion of these maps now results in migration plans moving to a `NotReady` state, as opposed to actively terminating associated pods. 
+Before this update, the deletion of network or storage maps in the `forklift-controller` could cause unexpected shutdowns. With this update, deletion of these maps now results in migration plans moving to a `NotReady` state, instead of actively terminating associated pods. 
 
 link:https://issues.redhat.com/browse/MTV-4413[MTV-4413]
 --
@@ -36,7 +36,7 @@ link:https://issues.redhat.com/browse/MTV-4413[MTV-4413]
 Increased memory limits for `forklift-cli-download` pod to prevent `OOMKilled` errors::
 +
 --
-Before this update, insufficient memory limits in the `forklift-cli-download` pod caused Kubernetes `OOMKilled` memory errors after an update of the {project-short} Operator. As a result, the pod entered `CrashLoopBackOff` state. This update increases memory limits for the `forklift-cli-download` pod to prevent `OOMKilled` errors, improving deployment stability.
+Before this update, insufficient memory limits in the `forklift-cli-download` pod caused Kubernetes `OOMKilled` memory errors after an update of the {project-short} Operator. As a result, the pod entered the `CrashLoopBackOff` state. This update increases memory limits for the `forklift-cli-download` pod to prevent `OOMKilled` errors, improving deployment stability.
 
 link:https://redhat.atlassian.net/browse/MTV-4482[MTV-4482]
 --
@@ -89,16 +89,14 @@ XFSv4 migrations failed::
 ====
 If you enable XFS support for a migration plan, then the plan cannot support Btrfs migration.
 ====
-link:https://redhat.atlassian.net/browse/MTV-4685[MTV-4685] and link:https://issues.redhat.com/browse/MTV-4709[MTV-4709]
 
+link:https://redhat.atlassian.net/browse/MTV-4685[MTV-4685] and link:https://issues.redhat.com/browse/MTV-4709[MTV-4709]
 --
 
 Active blocking of migration when target namespaces lack transfer network permissions::
 +
 --
-Before this update, during VM migration to Red Hat OpenShift Container Platform (OCP) with Fibre Channel, migration could stall when target namespaces lacked permission to transfer networks. This update enhances error handling with active blocking of migration when target namespaces lack transfer network permissions.
+Before this update, during VM migration to Red Hat OpenShift Container Platform with Fibre Channel, migration could stall when target namespaces lacked permission to transfer networks. This update enhances error handling with active blocking of migration when target namespaces lack transfer network permissions.
 
 link:https://issues.redhat.com/browse/MTV-4547[MTV-4547]
 --
-
-

--- a/documentation/modules/ref_resolved-issues-2-11-3.adoc
+++ b/documentation/modules/ref_resolved-issues-2-11-3.adoc
@@ -23,7 +23,7 @@ Storage copy offload: Pure Storage FlashArray HTTP client timeout is configurabl
 
 Before this update, the timeout for a Pure Storage FlashArray HTTP client was hard-coded to 30 seconds. As a consequence, during migrations of VMs with many disks, simultaneous `CopyVolume` requests to the Pure Storage FlashArray timed out, leaving PVCs stuck in `Pending` status.
 +
-With this update, you can configure the timeout by setting the new `STORAGE_HTTP_TIMEOUT_SECONDS` key and value in the Pure Storage FlashArray `Secret`. As a result, migrations complete successfully without timing out. Note that the key’s default value is 30 seconds.
+With this update, you can configure the timeout by setting the new `STORAGE_HTTP_TIMEOUT_SECONDS` key and value in the Pure Storage FlashArray `Secret`. As a result, migrations complete successfully without timing out. Note that the key's default value is 30 seconds.
 +
 link:https://issues.redhat.com/browse/MTV-5004[MTV-5004]
 

--- a/documentation/modules/ref_technical-changes-2-11.adoc
+++ b/documentation/modules/ref_technical-changes-2-11.adoc
@@ -9,13 +9,13 @@
 [role="_abstract"]
 Review the technical changes in this release of {project-short}.
 
-Storage copy offload for Infinidat Infinibox (Developer Preview)::
+Storage copy offload for Infinidat InfiniBox (Developer Preview)::
 
-{project-first} provides storage copy offload for Infinidat Infinibox for both cold and warm migrations as a Developer Preview.
+{project-first} provides storage copy offload for Infinidat InfiniBox for both cold and warm migrations as a Developer Preview.
 +
 [IMPORTANT]
 ====
-Storage copy offload for Infinidat Infinibox is Developer Preview software only. Developer Preview software is not supported by Red{nbsp}Hat in any way and is not functionally complete or production-ready. Do not use Developer Preview software for production or business-critical workloads. Developer Preview software provides early access to upcoming product software in advance of its possible inclusion in a Red{nbsp}Hat product offering. Customers can use this software to test functionality and provide feedback during the development process. This software might not have any documentation, is subject to change or removal at any time, and has received limited testing. Red{nbsp}Hat might provide ways to submit feedback on Developer Preview software without an associated SLA.
+Storage copy offload for Infinidat InfiniBox is Developer Preview software only. Developer Preview software is not supported by Red{nbsp}Hat in any way and is not functionally complete or production-ready. Do not use Developer Preview software for production or business-critical workloads. Developer Preview software provides early access to upcoming product software in advance of its possible inclusion in a Red{nbsp}Hat product offering. Customers can use this software to test functionality and provide feedback during the development process. This software might not have any documentation, is subject to change or removal at any time, and has received limited testing. Red{nbsp}Hat might provide ways to submit feedback on Developer Preview software without an associated SLA.
 
 For more information about the support scope of Red{nbsp}Hat Developer Preview software, see link:https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope].
 ====


### PR DESCRIPTION
MTV 2.11.4

Resolves https://redhat.atlassian.net/browse/MTV-5106 by making the required changes to release notes files. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a parameterized introductory note to the master release notes; removed disabled/commented sections and extraneous blank lines.
  * Rewrote multiple known-issues entries for clarity: standardized consequence/workaround language, added explicit plugin and version history where relevant, shortened FIPS/TLS wording to “EMS,” and marked several items as having no workaround.
  * Renamed a feature section heading and activated a previously commented reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->