### PR TITLE
General documentation improvements

### DIFF
--- a/documentation/modules/canceling-migration-cli-specific.adoc
+++ b/documentation/modules/canceling-migration-cli-specific.adoc
@@ -39,7 +39,21 @@ where:
 `id` or `name`::
 Specifies a VM by using the `id` key or the `name` key.
 +
-The value of the `id` key is the _managed object reference_, for a {vmw} VM, or the _VM UUID_, for a {rhv-full} VM.
+ifdef::vmware[]
+The value of the `id` key is the _managed object reference_ for a {vmw} VM.
+endif::[]
+ifdef::rhv[]
+The value of the `id` key is the _VM UUID_ for a {rhv-full} VM.
+endif::[]
+ifdef::ostack[]
+The value of the `id` key is the _VM UUID_ for an {osp} VM.
+endif::[]
+ifdef::ova[]
+The value of the `id` key is the _VM name_ from the OVA file for an OVA VM.
+endif::[]
+ifdef::cnv[]
+The value of the `id` key is the _VM name_ for a {virt} VM.
+endif::[]
 
 . Retrieve the `Migration` custom resource (CR) to monitor the progress of the remaining VMs, following this example:
 +

--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -2,7 +2,8 @@
 // Attributes for Forklift (upstream) are in ../upstream-attributes.adoc
 // text
 :kebab: Options menu image:kebab.png[title="Options menu",height=20]
-// If namespace must be formatted with backticks, use + instead.
+// Note: Backticks (`) block variable substitution. To format {namespace} in monospace
+// while allowing it to resolve, use +{namespace}+ instead of `{namespace}`.
 :namespace: openshift-mtv
 :oc: oc
 :ocp: Red Hat OpenShift

--- a/documentation/modules/running-migration-plan.adoc
+++ b/documentation/modules/running-migration-plan.adoc
@@ -55,7 +55,7 @@ endif::vmware,rhv[]
 +
 [WARNING]
 ====
-Do not take a snapshot of a VM after you start a migration. Taking a snaphot after a migration starts might cause the migration to fail.
+Do not take a snapshot of a VM after you start a migration. Taking a snapshot after a migration starts might cause the migration to fail.
 ====
 
 . Optional: Click the links in the migration's *Status* to see its overall status and the status of each VM:

--- a/documentation/modules/selecting-migration-network-for-virt-provider.adoc
+++ b/documentation/modules/selecting-migration-network-for-virt-provider.adoc
@@ -19,22 +19,17 @@ In {project-short} version 2.9 and earlier, {project-short} used the `pod` netwo
 
 In version 2.10.0 and later, {project-short} detects if you have selected a user-defined network (UDN) as your default network. Therefore, if you set the UDN to be the migration's namespace, you do not need to select a new default network when you create your migration plan.
 
-[IMPORTANT]
-====
-{project-short} supports using UDNs for all providers except {virt}.
-====
+Considerations::
 
-[NOTE]
-====
-You can override the default migration network of the provider by selecting a different network when you create a migration plan.
-====
+* {project-short} supports using UDNs for all providers except {virt}.
+* You can override the default migration network of the provider by selecting a different network when you create a migration plan.
 
 .Procedure
 
 . In the {ocp} web console, click *Migration for Virtualization* > *Providers*.
 . Click the {virt} provider whose migration network you want to change.
 +
-When the *Providers detail* page opens:
+When the *Provider details* page opens:
 
 . Click the *Networks* tab.
 . Click *Set default transfer network*.


### PR DESCRIPTION
Minor fixes carried over from https://github.com/kubev2v/forklift-documentation/pull/892 

- Fix typo: 'snaphot' → 'snapshot' in running-migration-plan.adoc
- Fix typo: 'Providers detail' → 'Provider details' in selecting-migration-network-for-virt-provider.adoc
- Improve namespace attribute comment for better clarity in common-attributes.adoc
- Convert NOTE/IMPORTANT blocks to 'Considerations::' list format in selecting-migration-network-for-virt-provider.adoc
- Improve canceling-migration-cli-specific.adoc to use separate ifdef blocks for each provider type (vmware, rhv, ostack, ova, cnv) instead of combining them

These changes improve consistency, readability, and documentation quality across all provider types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded cancellation guidance with backend-specific instructions and CLI examples
  * Enhanced migration plan documentation with warm migration details, VM logs access, and vmware configuration warnings
  * Added network configuration examples and considerations for migration network setup
  * Improved formatting guidance for documentation placeholders

<!-- end of auto-generated comment: release notes by coderabbit.ai -->