### PR TITLE
MTV 2.11.5 Release notes

### DIFF
--- a/documentation/doc-Release_notes/master.adoc
+++ b/documentation/doc-Release_notes/master.adoc
@@ -22,6 +22,7 @@ include::modules/new-features-and-enhancements-2-11.adoc[leveloffset=+2]
 include::modules/rn-resolved-issues.adoc[leveloffset=+2]
 
 // Resolved issues by z-stream release. Most recent release goes first in the list.
+include::modules/rn-2-11-5-resolved-issues.adoc[leveloffset=+3]
 
 include::modules/rn-2-11-4-resolved-issues.adoc[leveloffset=+3]
 

--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -23,7 +23,7 @@
 :project-version: 2.11
 :mtv-plan: https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/{project-version}/html/planning_your_migration_to_red_hat_openshift_virtualization/
 :mtv-mig: https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/{project-version}/html/migrating_your_virtual_machines_to_red_hat_openshift_virtualization/
-:project-z-version: 2.11.4
+:project-z-version: 2.11.5
 :rhel-first: Red Hat Enterprise Linux (RHEL)
 :virt: OpenShift Virtualization
 :must-gather: registry.redhat.io/migration-toolkit-virtualization/mtv-must-gather-rhel8:{project-z-version}

--- a/documentation/modules/known-issues-2-11.adoc
+++ b/documentation/modules/known-issues-2-11.adoc
@@ -9,8 +9,14 @@
 [role="_abstract"]
 {project-first} 2.11 has the following known issues.
 
-VMware migrations fail when the disk count exceeds the ESXi host LUN ID limit::
+Migrations fail for VMs sharing the same BIOS UUID due to a Libvirt limitation:: 
+While {project-short} correctly handles source virtual machines (VMs), a known issue in Libvirt (RHEL-174300) causes conflicts on the target environment if multiple VMs share the same BIOS UUID. As a consequence, the migration fails.
++
+*Workaround:* Ensure that all VMs have unique BIOS UUIDs before you initiate the migration.
++
+link:https://redhat.atlassian.net/browse/MTV-5326[MTV-5326] and link:https://redhat.atlassian.net/browse/RHEL-174300[RHEL-174300]
 
+VMware migrations fail when the disk count exceeds the ESXi host LUN ID limit::
 VMware migrations with many disks fail if the disk count exceeds the host limit for discoverable SCSI LUN IDs.
 +
 *Workaround:* Increase the `Disk.MaxLUN` value on each ESXi host to support discovery of a higher number of LUN IDs during migrations.

--- a/documentation/modules/new-features-and-enhancements-2-11.adoc
+++ b/documentation/modules/new-features-and-enhancements-2-11.adoc
@@ -9,6 +9,16 @@
 [role="_abstract"]
 {project-first} 2.11 introduces the following features and enhancements.
 
+MTV preserves static IPs on migrated Windows VMs when the DHCP Client service is disabled (Developer Preview):: 
+{project-short} provides the capability to configure static IP addresses on a source Windows virtual machine (VM) even if the DHCP Client service is disabled. This enhancement allows the network configuration script to set static IPs during a migration without relying on the DHCP service. As a result, {project-short} preserves static IPs on migrated Windows VMs if you enable the `feature_windows_registry_network_config` feature flag. This capability is available as Developer Preview software.
++
+[IMPORTANT]
+====
+The `feature_windows_registry_network_config` feature flag is Developer Preview software only. Developer Preview software is not supported by Red{nbsp}Hat in any way and is not functionally complete or production-ready. Do not use Developer Preview software for production or business-critical workloads. This feature provides early access to upcoming product software in advance of its possible inclusion in a Red{nbsp}Hat product offering. For more information about the support scope of Red{nbsp}Hat Developer Preview software, see link:https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope].
+====
++
+link:https://redhat.atlassian.net/browse/MTV-4717[MTV-4717]
+
 You can configure a custom `ServiceAccount` object for all MTV pods::
 
 You can configure a custom `ServiceAccount` object for all {project-short} pods, including CDI pods. This enhancement supports migrating workloads that are run under specific service accounts with well-defined RBAC roles. As a result, feature {project-short} can access storage backends, pull secrets, or perform API calls that require a dedicated `ServiceAccount` object with specific permissions.

--- a/documentation/modules/rn-2-11-5-resolved-issues.adoc
+++ b/documentation/modules/rn-2-11-5-resolved-issues.adoc
@@ -30,7 +30,7 @@ Before this update, {project-short} could not distinguish between multiple VMs s
 link:https://redhat.atlassian.net/browse/MTV-5091[MTV-5091]
 
 MTV allocates sufficient disk space during RHEL 3, 4, and 5 migrations::
-Before this update, {project-short} did not allocate enough disk space when pre-creating output disks during migrations from Red Hat Enterprise Linux (RHEL) 3, 4, or 5. As a consequence, the migrations failed with an error indicating that the destination size was smaller than the source size. With this update, the estimated disk size was increased. As a result, {project-short} allocates the correct disk space and the migrations succeed.
+Before this update, {project-short} did not allocate enough disk space when pre-creating output disks during migrations from Red Hat Enterprise Linux (RHEL) 3, 4, or 5. As a consequence, the migrations failed with an error indicating that the destination size was smaller than the source size. With this update, the estimated disk size was increased. As a result, {project-short} allocates the correct disk space, and the migrations succeed.
 +
 link:https://redhat.atlassian.net/browse/MTV-4872[MTV-4872]
 

--- a/documentation/modules/rn-2-11-5-resolved-issues.adoc
+++ b/documentation/modules/rn-2-11-5-resolved-issues.adoc
@@ -25,7 +25,7 @@ Before this update, the {project-short} user interface (UI) displayed Hyper-V as
 link:https://redhat.atlassian.net/browse/MTV-5174[MTV-5174]
 
 MTV powers off the correct VM during migration when multiple VMs share a BIOS UUID::
-Before this update, {project-short} could not distinguish between multiple VMs sharing the same BIOS UUID. As a consequence, {project-short} incorrectly powered off the first matching VM during migration, leading to potential data loss and downtime. With this release, the migration process was modified to use `moRef` instead of BIOS UUID. AAs a result, {project-short} correctly identifies and powers off the correct VM during migration. While {project-short} correctly handles the power-off phase, environments with duplicate BIOS UUIDs might still experience migration failures due to a known issue in Libvirt. For more information, see the "Known issues" section.
+Before this update, {project-short} could not distinguish between multiple VMs sharing the same BIOS UUID. As a consequence, {project-short} incorrectly powered off the first matching VM during migration, leading to potential data loss and downtime. With this release, the migration process was modified to use `moRef` instead of BIOS UUID. As a result, {project-short} correctly identifies and powers off the correct VM during migration. While {project-short} correctly handles the power-off phase, environments with duplicate BIOS UUIDs might still experience migration failures due to a known issue in Libvirt. For more information, see the "Known issues" section.
 +
 link:https://redhat.atlassian.net/browse/MTV-5091[MTV-5091]
 

--- a/documentation/modules/rn-2-11-5-resolved-issues.adoc
+++ b/documentation/modules/rn-2-11-5-resolved-issues.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Release_notes/master.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="resolved-issues-2-11-5_{context}"]
+= Resolved issues 2.11.5
+
+[role="_abstract"]
+Review the resolved issues in this release of {project-short}. Some linked Jira tickets are accessible only with Red Hat credentials.
+
+MTV preserves static IPs on migrated Windows VMs when the DHCP Client service is disabled::
+Before this update, the network configuration script failed to set static IP addresses if the DHCP Client service was disabled in a source Windows virtual machine (VM). As a consequence, {project-short} did not preserve static IPs during the migration. With this update, a patch was implemented to enable static IP configuration even when the DHCP service is disabled. As a result, {project-short} preserves static IPs on migrated Windows VMs if the user enables the `feature_windows_registry_network_config` feature flag.
++
+link:https://redhat.atlassian.net/browse/MTV-5245[MTV-5245]
+
+MTV blocks a migration plan when a VM has no IP address::
+Before this update, a user could create a migration plan with the preserve static IP option selected for a VM that had no IP address. As a consequence, {project-short} allowed the migration to proceed. With this release, the system was modified to verify the presence of an IP address before running the plan. As a result, {project-short} blocks the migration plan.
++
+link:https://redhat.atlassian.net/browse/MTV-5244[MTV-5244]
+
+The MTV UI does not display Hyper-V as a source provider::
+Before this update, the {project-short} user interface (UI) displayed Hyper-V as a source provider even though it is not supported. As a consequence, users could view an unsupported source provider in the UI. With this release, the UI was modified to remove Hyper-V from the list of available source providers. As a result, the {project-short} UI does not display Hyper-V as a source provider.
++
+link:https://redhat.atlassian.net/browse/MTV-5174[MTV-5174]
+
+MTV powers off the correct VM during migration when multiple VMs share a BIOS UUID::
+Before this update, {project-short} could not distinguish between multiple VMs sharing the same BIOS UUID. As a consequence, {project-short} incorrectly powered off the first matching VM during migration, leading to potential data loss and downtime. With this release, the migration process was modified to use `moRef` instead of BIOS UUID. AAs a result, {project-short} correctly identifies and powers off the correct VM during migration. While {project-short} correctly handles the power-off phase, environments with duplicate BIOS UUIDs might still experience migration failures due to a known issue in Libvirt. For more information, see the "Known issues" section.
++
+link:https://redhat.atlassian.net/browse/MTV-5091[MTV-5091]
+
+MTV allocates sufficient disk space during RHEL 3, 4, and 5 migrations::
+Before this update, {project-short} did not allocate enough disk space when pre-creating output disks during migrations from Red Hat Enterprise Linux (RHEL) 3, 4, or 5. As a consequence, the migrations failed with an error indicating that the destination size was smaller than the source size. With this update, the estimated disk size was increased. As a result, {project-short} allocates the correct disk space and the migrations succeed.
++
+link:https://redhat.atlassian.net/browse/MTV-4872[MTV-4872]
+
+MTV resolves memory footprint and script truncation issues on ESX and ESXi::
+Before this update, migration failures occurred due to memory-related issues on more than 30 virtual machines (VMs). Additionally, during storage copy offload migrations that were set up by using SSH, a script was truncated on some uploads, which prevented other tasks from reading it. As a consequence, some VMs remained incomplete during migration, and the system returned a `failed to update task status: failed to get task status: failed to parse status response: failed to parse XML response: EOF` error. With this update, the memory footprint and script truncation issues on ESX and ESXi were fixed. As a result, the migration of more than 35 VMs is successful, improving the stability of the migration process. This fix applies only to storage copy offload migrations that are set up by using SSH; it does not apply to migrations that are set up by using a vSphere Installation on Bundle (VIB).
++
+link:https://redhat.atlassian.net/browse/MTV-4732[MTV-4732]

--- a/documentation/modules/technical-changes-2-11.adoc
+++ b/documentation/modules/technical-changes-2-11.adoc
@@ -19,3 +19,8 @@ Storage copy offload for Infinidat Infinibox is Developer Preview software only.
 
 For more information about the support scope of Red{nbsp}Hat Developer Preview software, see link:https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope].
 ====
+
+Storage copy offload supports VIB version 0.3.0::
+The vSphere Installation on Bundle (VIB) is updated to version 0.3.0. If you set up storage copy offload by using a VIB, manually install VIB version 0.3.0 or configure your system automation to install it.
++
+link:https://redhat.atlassian.net/browse/MTV-5321[MTV-5321]


### PR DESCRIPTION
MTV 2.11.5

Resolves https://redhat.atlassian.net/browse/MTV-5179 by updating the MTV release notes and attributes for version 2.11.5.

Previews:

- https://forklift-documentation-git-fork-ri-58e112-yaacov-8047s-projects.vercel.app/documentation/doc-Release_notes/master.html#technical-changes-2-11_release-notes [2nd item]
- https://forklift-documentation-git-fork-ri-58e112-yaacov-8047s-projects.vercel.app/documentation/doc-Release_notes/master.html#resolved-issues-2-11-5_release-notes
- https://forklift-documentation-git-fork-ri-58e112-yaacov-8047s-projects.vercel.app/documentation/doc-Release_notes/master.html#known-issues-2-11_release-notes[first item]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserve static IPs for migrated Windows VMs (Developer Preview; feature-flag gated).

* **Bug Fixes**
  * Migrations failing for VMs sharing the same BIOS UUID addressed.

* **Documentation**
  * Added 2.11.5 resolved-issues module and inserted it into release notes.
  * Bumped project version attribute to 2.11.5.
  * Added known-issues entry for Libvirt BIOS-UUID limitation.
  * Added Developer Preview note and VIB version info for Infinidat storage offload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->