### PR TITLE
MTV 2.12: MTV-5553 Post migration cleanup

### DIFF
--- a/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-aws.adoc
+++ b/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-aws.adoc
@@ -22,6 +22,10 @@ include::../modules/proc_running-migration-plan.adoc[leveloffset=+1]
 
 include::../modules/ref_migration-plan-options-ui.adoc[leveloffset=+2]
 
+include::../modules/con_post-migration-cleanup.adoc[leveloffset=+2]
+
+include::../modules/proc_recommended-post-migration-workflow.adoc[leveloffset=+2]
+
 include::../modules/proc_canceling-migration-ui.adoc[leveloffset=+2]
 
 include::../modules/proc_migrating-vms-cli-aws.adoc[leveloffset=+1]

--- a/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-cnv.adoc
+++ b/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-cnv.adoc
@@ -20,6 +20,10 @@ include::../modules/proc_running-migration-plan.adoc[leveloffset=+1]
 
 include::../modules/ref_migration-plan-options-ui.adoc[leveloffset=+2]
 
+include::../modules/con_post-migration-cleanup.adoc[leveloffset=+2]
+
+include::../modules/proc_recommended-post-migration-workflow.adoc[leveloffset=+2]
+
 include::../modules/proc_canceling-migration-ui.adoc[leveloffset=+2]
 
 include::../modules/proc_migrating-vms-cli-cnv.adoc[leveloffset=+1]

--- a/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-hyperv.adoc
+++ b/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-hyperv.adoc
@@ -22,6 +22,10 @@ include::../modules/proc_running-migration-plan.adoc[leveloffset=+1]
 
 include::../modules/ref_migration-plan-options-ui.adoc[leveloffset=+2]
 
+include::../modules/con_post-migration-cleanup.adoc[leveloffset=+2]
+
+include::../modules/proc_recommended-post-migration-workflow.adoc[leveloffset=+2]
+
 include::../modules/proc_canceling-migration-ui.adoc[leveloffset=+2]
 
 include::../modules/proc_migrating-vms-cli-hyperv.adoc[leveloffset=+1]

--- a/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-osp.adoc
+++ b/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-osp.adoc
@@ -22,6 +22,10 @@ include::../modules/proc_running-migration-plan.adoc[leveloffset=+1]
 
 include::../modules/ref_migration-plan-options-ui.adoc[leveloffset=+2]
 
+include::../modules/con_post-migration-cleanup.adoc[leveloffset=+2]
+
+include::../modules/proc_recommended-post-migration-workflow.adoc[leveloffset=+2]
+
 include::../modules/proc_canceling-migration-ui.adoc[leveloffset=+2]
 
 include::../modules/proc_migrating-vms-cli-ostack.adoc[leveloffset=+1]

--- a/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-ova.adoc
+++ b/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-ova.adoc
@@ -22,6 +22,10 @@ include::../modules/proc_running-migration-plan.adoc[leveloffset=+1]
 
 include::../modules/ref_migration-plan-options-ui.adoc[leveloffset=+2]
 
+include::../modules/con_post-migration-cleanup.adoc[leveloffset=+2]
+
+include::../modules/proc_recommended-post-migration-workflow.adoc[leveloffset=+2]
+
 include::../modules/proc_canceling-migration-ui.adoc[leveloffset=+2]
 
 include::../modules/proc_migrating-vms-cli-ova.adoc[leveloffset=+1]

--- a/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-rhv.adoc
+++ b/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-rhv.adoc
@@ -22,6 +22,10 @@ include::../modules/proc_running-migration-plan.adoc[leveloffset=+1]
 
 include::../modules/ref_migration-plan-options-ui.adoc[leveloffset=+2]
 
+include::../modules/con_post-migration-cleanup.adoc[leveloffset=+2]
+
+include::../modules/proc_recommended-post-migration-workflow.adoc[leveloffset=+2]
+
 include::../modules/proc_canceling-migration-ui.adoc[leveloffset=+2]
 
 include::../modules/proc_migrating-vms-cli-rhv.adoc[leveloffset=+1]

--- a/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-vmware.adoc
+++ b/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-vmware.adoc
@@ -25,6 +25,10 @@ include::../modules/proc_running-migration-plan.adoc[leveloffset=+1]
 
 include::../modules/ref_migration-plan-options-ui.adoc[leveloffset=+2]
 
+include::../modules/con_post-migration-cleanup.adoc[leveloffset=+2]
+
+include::../modules/proc_recommended-post-migration-workflow.adoc[leveloffset=+2]
+
 include::../modules/proc_canceling-migration-ui.adoc[leveloffset=+2]
 
 include::../modules/proc_migrating-vms-cli-vmware.adoc[leveloffset=+1]

--- a/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_troubleshooting-migration.adoc
+++ b/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_troubleshooting-migration.adoc
@@ -20,6 +20,18 @@ include::../modules/proc_using-lightspeed-troubleshooting.adoc[leveloffset=+1]
 
 include::../modules/ref_common-migration-issues.adoc[leveloffset=+1]
 
+:mtv!:
+:context: cleanup1
+:cleanup1:
+
+include::../modules/con_post-migration-cleanup.adoc[leveloffset=+1]
+
+include::../modules/proc_recommended-post-migration-workflow.adoc[leveloffset=+1]
+
+:cleanup1!:
+:context: mtv
+:mtv:
+
 include::../modules/ref_error-messages.adoc[leveloffset=+1]
 
 include::../modules/proc_troubleshooting-warm-import-retry-limit.adoc[leveloffset=+2]

--- a/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_understanding-mtv-migration.adoc
+++ b/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_understanding-mtv-migration.adoc
@@ -16,6 +16,18 @@ Understand the {project-first} custom resources, services, and workflows that en
 
 include::../modules/con_mtv-resources-and-services.adoc[leveloffset=+1]
 
+:mtv!:
+:context: cleanup2
+:cleanup2:
+
+include::../modules/con_post-migration-cleanup.adoc[leveloffset=+1]
+
+include::../modules/proc_recommended-post-migration-workflow.adoc[leveloffset=+1]
+
+:cleanup2!:
+:context: mtv
+:mtv:
+
 include::../modules/con_mtv-workflow.adoc[leveloffset=+1]
 
 include::../modules/con_virt-migration-workflow.adoc[leveloffset=+2]

--- a/documentation/modules/con_collected-logs-cr-info.adoc
+++ b/documentation/modules/con_collected-logs-cr-info.adoc
@@ -7,34 +7,35 @@
 = Collected logs and custom resource information
 
 [role="_abstract"]
-You can download logs and custom resource (CR) YAML files for the following targets by using the {ocp} web console or the command-line interface (CLI):
+You can download logs and custom resource (CR) YAML files for migration plans, virtual machines (VMs), and namespaces.
 
-* Migration plan: Web console or CLI.
-* Virtual machine: Web console or CLI.
-* Namespace: CLI only.
+Depending on the target, you can use the {ocp} web console or the command-line interface (CLI):
 
-The `must-gather` tool collects the following logs and CR files in an archive file:
+* Migration plans: Web console or CLI.
+* VMs: Web console or CLI.
+* Namespaces: CLI only.
+
+You can use the `must-gather` tool to collect the following logs and CR files in an archive file:
 
 * CRs:
 ** `DataVolume` CR: Represents a disk mounted on a migrated VM.
 ** `VirtualMachine` CR: Represents a migrated VM.
 ** `Plan` CR: Defines the VMs and storage and network mapping.
-** `Job` CR: Optional: Represents a pre-migration hook, a post-migration hook, or both.
+** `Job` CR: Represents an optional pre-migration hook, a post-migration hook, or both.
 
 * Logs:
 ** `importer` pod: Disk-to-data-volume conversion log. The `importer` pod naming convention is `importer-<migration_plan>-<vm_id><5_char_id>`, for example, `importer-mig-plan-ed90dfc6-9a17-4a8btnfh`, where `ed90dfc6-9a17-4a8` is a truncated {rhv-short} VM ID and `btnfh` is the generated 5-character ID.
-** `conversion` pod: VM conversion log. The `conversion` pod runs `virt-v2v`, which installs and configures device drivers on the PVCs of the VM. The `conversion` pod naming convention is `<migration_plan>-<vm_id><5_char_id>`.
+** `conversion` pod: VM conversion log. The `conversion` pod runs `virt-v2v`, which installs and configures device drivers on the persistent volume claims (PVCs) of the VM. The `conversion` pod naming convention is `<migration_plan>-<vm_id><5_char_id>`.
 ** `virt-launcher` pod: VM launcher log. When a migrated VM is powered on, the `virt-launcher` pod runs `QEMU-KVM` with the PVCs attached as VM disks.
-** `forklift-controller` pod: The log is filtered for the migration plan, virtual machine, or namespace specified by the `must-gather` command.
-** `forklift-must-gather-api` pod: The log is filtered for the migration plan, virtual machine, or namespace specified by the `must-gather` command.
+** `forklift-controller` pod: The log is filtered for the migration plan, VM, or namespace specified by the `must-gather` command.
 ** `hook-job` pod: The log is filtered for hook jobs. The `hook-job` naming convention is `<migration_plan>-<vm_id><5_char_id>`, for example, `plan2j-vm-3696-posthook-4mx85` or `plan2j-vm-3696-prehook-mwqnl`.
 +
 [NOTE]
 ====
-Empty or excluded log files are not included in the `must-gather` archive file.
+* For failed migrations, archiving a migration plan removes temporary migration pods and PVC mounts and can make pod logs unavailable in the web console. Collect logs before you archive a plan if you need them for troubleshooting. For successful migrations, {project-short} automatically deletes PVC mounts, conversion pods, and populator pods.
+* The `must-gather` archive file does not include empty or excluded log files.
 ====
-
-The following schematic drawing shows the `must-gather` archive structure for an example VMware migration plan:
+The following diagram shows the `must-gather` archive structure for an example VMware migration plan:
 
 ----
 must-gather
@@ -65,7 +66,5 @@ must-gather
         │       └── mig-plan-cold.yaml
         └── logs
             ├── forklift-controller-67656d574-w74md
-            │   └── current.log
-            └── forklift-must-gather-api-89fc7f4b6-hlwb6
                 └── current.log
 ----

--- a/documentation/modules/con_mtv-resources-and-services.adoc
+++ b/documentation/modules/con_mtv-resources-and-services.adoc
@@ -7,16 +7,16 @@
 = {project-short} custom resources and services
 
 [role="_abstract"]
-The {operator-name} is provided as a {ocp} Operator. It creates and manages the following custom resources (CRs) and services.
+The {operator-name} is a {ocp} Operator that creates and manages the {project-short} custom resources (CRs) and services.
 
 [id="mtv-custom-resources_{context}"]
 == {project-short} custom resources
 
-* `Provider` CR stores attributes that enable {project-short} to connect to and interact with the source and target providers.
-* `NetworkMapping` CR maps the networks of the source and target providers.
-* `StorageMapping` CR maps the storage of the source and target providers.
-* `Plan` CR contains a list of VMs with the same migration parameters and associated network and storage mappings.
-* `Migration` CR runs a migration plan.
+* A `Provider` CR stores attributes that {project-short} uses to connect to and interact with the source and target providers.
+* A `NetworkMapping` CR maps the networks of the source and target providers.
+* A `StorageMapping` CR maps the storage of the source and target providers.
+* A `Plan` CR contains a list of virtual machines (VMs) with the same migration parameters and associated network and storage mappings.
+* A `Migration` CR runs a migration plan.
 +
 Only one `Migration` CR per migration plan can run at a given time. You can create multiple `Migration` CRs for a single `Plan` CR.
 
@@ -27,13 +27,22 @@ Only one `Migration` CR per migration plan can run at a given time. You can crea
 ** Connects to the source and target providers.
 ** Maintains a local inventory for mappings and plans.
 ** Stores VM configurations.
-** Runs the `Validation` service if a VM configuration change is detected.
+** Runs the `Validation` service if it detects a VM configuration change.
 
-* The `Validation` service checks the suitability of a VM for migration by applying rules.
-* The `Migration Controller` service orchestrates migrations.
+* The `Validation` service checks whether a VM is suitable for migration by applying rules.
+* The `Forklift Controller` service orchestrates migrations.
 +
-When you create a migration plan, the `Migration Controller` service validates the plan and adds a status label. If the plan fails validation, the plan status is `Not ready` and the plan cannot be used to perform a migration. If the plan passes validation, the plan status is `Ready` and it can be used to perform a migration. After a successful migration, the `Migration Controller` service changes the plan status to `Completed`.
+When you create a migration plan, the `Forklift Controller` service validates the plan and adds a status label. If the plan fails validation, the status is *Not ready*, and you cannot use the plan to perform a migration. If the plan passes validation, the status is *Ready*, and you can use it to perform a migration. After a successful migration, the `Forklift Controller` service changes the plan status to *Complete*.
++
+[IMPORTANT]
+====
+For successful migrations, {project-short} automatically deletes temporary PVC mounts, conversion pods, and populator pods and changes the plan's status to *Complete* in the UI, or `Succeeded` in the YAML file. For failed migrations, the plan's status is *Incomplete* in the UI, or `failed` in the YAML file, and temporary PVC mounts are kept so you can investigate the failure. You must archive a failed migration plan to clean up temporary resources.
+====
 
 * The `Populator Controller` service orchestrates disk transfers using Volume Populators.
 
 * The `Kubevirt Controller` and `Containerized Data Import (CDI) Controller` services handle most technical operations.
+
+[role="_additional-resources"]
+.Additional resources
+* link:{mtv-mig}assembly_troubleshooting-migration_mtv#con_post-migration-cleanup_mtv[Post-migration cleanup and archiving migration plans]

--- a/documentation/modules/con_mtv-workflow.adoc
+++ b/documentation/modules/con_mtv-workflow.adoc
@@ -36,4 +36,4 @@ If you cannot migrate all the VMs for any reason, you can create multiple `Migra
 . For each VM in the `Plan` CR, the `Migration Controller` service records the VM migration progress in the `Migration` CR.
 . Once the data transfer for each VM in the `Plan` CR completes, the `Migration Controller` service creates a `VirtualMachine` CR.
 +
-When all VMs have been migrated, the `Migration Controller` service updates the status of the `Plan` CR to `Completed`. The power state of each source VM is maintained after migration.
+When all VMs have been migrated, the `Migration Controller` service updates the status of the `Plan` CR to `Succeeded`, which displays as *Complete* in the UI. The power state of each source VM is maintained after migration.

--- a/documentation/modules/con_post-migration-cleanup.adoc
+++ b/documentation/modules/con_post-migration-cleanup.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-cnv.adoc
+// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-osp.adoc
+// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-ova.adoc
+// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-rhv.adoc
+// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-vmware.adoc
+// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_troubleshooting-migration.adoc
+// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_understanding-mtv-migration.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="con_post-migration-cleanup_{context}"]
+= Post-migration cleanup and archiving migration plans
+
+[role="_abstract"]
+{project-short} automatically cleans up temporary resources for successful migrations. For failed migrations, you must archive the migration plan to release temporary resources.
+
+The status of a migration plan determines which temporary resources are retained:
+
+* *Successful migrations*: The plan status is `Succeeded` in the YAML file and *Complete* in the UI. The migration process automatically deletes conversion pods, populator pods, and temporary persistent volume claim (PVC) mounts. Permanent PVCs are attached to the target virtual machines (VMs). 
+* *Failed migrations*: The plan status is `Failed` in the YAML file and *Incomplete* in the UI. PVC mounts remain attached to the source VMs. Conversion and populator pods are not deleted until you archive the plan. These resources are retained so that you can investigate the failure.
+
+[id="archive-versus-delete-migration-plan_{context}"]
+== Archive versus delete
+
+You can use the *Archive* and *Delete* options on the *Migration plans* page for different purposes:
+
+*Archive*::
+Use this option to remove temporary migration resources for failed migrations. These resources include completed migration and validation pods and all PVC mounts, temporary and permanent. Archiving also removes the logs, history, and detailed metadata of the plan from active use. You cannot edit or restart the plan. You can still view, duplicate, or delete an archived plan.
++
+[NOTE]
+====
+For successful migrations, {project-short} automatically deletes temporary resources, so archiving is not required for cleanup purposes. However, you might still want to archive successful plans to remove their logs, history, and detailed metadata from active use.
+====
+
+*Delete*::
+Use this option to permanently remove the migration plan custom resource (CR) from the {ocp} web console or the CLI. For failed migrations, deleting a plan does not remove temporary resources. You must archive the plan first to clean up temporary resources, then delete it.
+
+[id="downstream-dr-impact-unarchived-plans_{context}"]
+== Impact on downstream disaster recovery workflows
+
+[WARNING]
+====
+If you do not archive migration plans, mounted PVCs can remain in use. This continued use can block downstream disaster recovery (DR) or downstream remote disaster recovery (RDR) workflows that share the same storage. Relocation and failover operations can become stuck when PVCs are still mounted to VMs or completed {project-short} pods. Archive completed migration plans as part of your post-migration workflows. This action is especially important when you use DR or replication tooling on the same cluster storage.
+====
+
+[role="_additional-resources"]
+.Additional resources
+* link:{mtv-mig}assembly_troubleshooting-migration_mtv#ref_common-migration-issues_mtv[Common migration issues]
+* link:{mtv-mig}assembly_troubleshooting-migration_mtv#con_collected-logs-cr-info_mtv[Collected logs and custom resource information]

--- a/documentation/modules/proc_installing-mtv-operator.adoc
+++ b/documentation/modules/proc_installing-mtv-operator.adoc
@@ -146,7 +146,6 @@ Example:
 NAME                                                    READY   STATUS    RESTARTS   AGE
 forklift-api-bb45b8db4-cpzlg                            1/1     Running   0          6m34s
 forklift-controller-7649db6845-zd25p                    2/2     Running   0          6m38s
-forklift-must-gather-api-78fb4bcdf6-h2r4m               1/1     Running   0          6m28s
 forklift-operator-59c87cfbdc-pmkfc                      1/1     Running   0          28m
 forklift-ui-plugin-5c5564f6d6-zpd85                     1/1     Running   0          6m24s
 forklift-validation-7d84c74c6f-fj9xg                    1/1     Running   0          6m30s

--- a/documentation/modules/proc_recommended-post-migration-workflow.adoc
+++ b/documentation/modules/proc_recommended-post-migration-workflow.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-cnv.adoc
+// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-osp.adoc
+// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-ova.adoc
+// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-rhv.adoc
+// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-vmware.adoc
+// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_troubleshooting-migration.adoc
+// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_understanding-mtv-migration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc_recommended-post-migration-workflow_{context}"]
+= Clean up resources and archive migration plans
+
+[role="_abstract"]
+After a migration, follow this workflow to clean up your resources.
+
+.Procedure
+
+. Verify that migrated virtual machines (VMs) are running as expected in {virt}.
+. For successful migrations, {project-short} automatically cleans up temporary resources. For failed migrations, you must archive the plan to release temporary resources.
+. Optional: Download or collect migration logs from the *Plan details* page while pods are still available. For more information about accessing logs, see link:{mtv-mig}assembly_troubleshooting-migration_mtv#proc_accessing-logs-ui_mtv[Accessing logs in the web console].
+. Archive the migration plan by using the *Archive* option on the *Migration plans* page.
+. Optional: If you no longer need the plan record, delete the migration plan. You must archive the plan before you delete it.

--- a/documentation/modules/proc_running-migration-plan.adoc
+++ b/documentation/modules/proc_running-migration-plan.adoc
@@ -107,3 +107,17 @@ endif::hyperv[]
 
 .. To see the raw logs, click the *Raw* link.
 .. To download the logs, click the *Download* link.
+
+. After the migration completes and you have collected any logs you need, archive failed migration plans by doing the following.
++
+On the *Migration plans* page, click the {kebab} beside the plan and select *Archive*.
++
+[IMPORTANT]
+====
+For successful migrations, {project-short} automatically deletes temporary PVC mounts, conversion pods, and populator pods. For failed migrations, completed migration and validation pods retain PVC mounts until you archive the plan, allowing you to investigate the failure. Unarchived failed migration plans can block downstream disaster recovery (DR) or remote disaster recovery (RDR) workflows on shared storage.
+====
+
+[role="_additional-resources"]
+.Additional resources
+* xref:con_post-migration-cleanup_{context}[Post-migration cleanup and archiving migration plans]
+* xref:ref_migration-plan-options-ui_{context}[Migration plan options]

--- a/documentation/modules/ref_common-migration-issues.adoc
+++ b/documentation/modules/ref_common-migration-issues.adoc
@@ -56,8 +56,19 @@ For {vmw} environments, you can use Storage vMotion to rename the VM before migr
 
 For more information about renaming VMs in the {project-short} UI, see link:{mtv-plan}assembly_migrating-vms-web-console_mtv#proc_renaming-vms-for-migration_mtv[Renaming virtual machines].
 
+*Why do completed but failed migration or validation pods still show PVC mounts?*
+
+If a migration fails, the workflow finishes, but {project-short} does not remove temporary pods or release PVC mounts. A failed migration displays an **Incomplete** status in the UI or a `failed` status in the YAML file. Completed migration and validation pods, such as `conversion` and `importer` pods, continue to mount PVCs until you archive the migration plan. You can use these pods to investigate the migration failure. For successful migrations, {project-short} automatically deletes temporary PVC mounts, conversion pods, and populator pods.
+
+*Why are disaster recovery relocations or failovers stuck after MTV migrations?*
+
+Unarchived failed migration plans can leave PVCs mounted by completed {project-short} pods. Downstream disaster recovery tooling that uses the same storage can be blocked, causing relocation or failover operations to become stuck.
+
+To resolve this issue, archive failed migration plans as part of your post-migration workflow. For more information, see link:{mtv-mig}assembly_troubleshooting-migration_mtv#con_post-migration-cleanup_mtv[Post-migration cleanup and archiving migration plans].
+
 [role="_additional-resources"]
 .Additional resources
+* link:{mtv-mig}assembly_troubleshooting-migration_mtv#con_post-migration-cleanup_mtv[Post-migration cleanup and archiving migration plans]
 * link:{mtv-plan}assembly_software-requirements-for-migration_mtv#ref_source-vm-migration-considerations_mtv[Source VM migration considerations]
 * link:{mtv-plan}assembly_provider-specific-requirements-for-migration_mtv#ref_vmware-prerequisites_mtv[{vmw} prerequisites]
 * link:{mtv-plan}assembly_cold-warm-migration_mtv#con_about-cold-warm-migration_mtv[About cold and warm migration]

--- a/documentation/modules/ref_migration-plan-options-ui.adoc
+++ b/documentation/modules/ref_migration-plan-options-ui.adoc
@@ -1,5 +1,4 @@
-// Module included in the following assemblies:
-//
+
 // Module included in the following assemblies:
 //
 // * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-cnv.adoc
@@ -33,11 +32,16 @@ endif::vmware,rhv[]
 ** Edit an archived migration plan.
 ** Edit a migration plan with a different status, for example, failed, canceled, running, critical, or ready.
 
-* *Archive*: Delete the logs, history, and metadata of a migration plan. The plan cannot be edited or restarted. It can only be viewed, duplicated, or deleted.
+* *Archive*: Clean up temporary migration and validation resources, including completed pods and their PVC mounts. The plan cannot be edited or restarted. It can only be viewed, duplicated, or deleted.
 +
 [NOTE]
 ====
 *Archive* is irreversible. However, you can duplicate an archived plan.
+====
++
+[IMPORTANT]
+====
+For successful migrations, {project-short} automatically deletes temporary PVC mounts, conversion pods, and populator pods. For failed migrations, you must archive the plan to delete temporary PVC mounts and release temporary resources.
 ====
 
 * *Delete*: Permanently remove a migration plan. You cannot delete a running migration plan.
@@ -56,4 +60,9 @@ The results of archiving and then deleting a migration plan vary by whether you 
 * If you created them using the UI, then the migration plan and its mappings no longer appear in the UI.
 * If you created them using the CLI, then the mappings might still appear in the UI. This is because mappings in the CLI can be used by more than one migration plan, but mappings created in the UI can only be used in one migration plan.
 ====
+
+[role="_additional-resources"]
+.Additional resources
+* xref:con_post-migration-cleanup_{context}[Post-migration cleanup and archiving migration plans]
+* xref:proc_recommended-post-migration-workflow_{context}[Recommended post-migration workflow]
 


### PR DESCRIPTION
Resolves https://redhat.atlassian.net/browse/MTV-5553 by adding information and instructions related to post-migration cleanup.

Previews:

- https://forklift-documentation-git-fork-ri-27ec42-yaacov-8047s-projects.vercel.app/downstream/documentation/doc-Migrating_your_virtual_machines/master.html#con_post-migration-cleanup_vmware [new section]
- https://forklift-documentation-git-fork-ri-27ec42-yaacov-8047s-projects.vercel.app/downstream/documentation/doc-Migrating_your_virtual_machines/master.html#proc_recommended-post-migration-workflow_vmware [new section]
- https://forklift-documentation-git-fork-ri-27ec42-yaacov-8047s-projects.vercel.app/downstream/documentation/doc-Migrating_your_virtual_machines/master.html#con_collected-logs-cr-info_mtv [Note]
- https://forklift-documentation-git-fork-ri-27ec42-yaacov-8047s-projects.vercel.app/downstream/documentation/doc-Migrating_your_virtual_machines/master.html#mtv-services_mtv [Note]
- https://forklift-documentation-git-fork-ri-27ec42-yaacov-8047s-projects.vercel.app/downstream/documentation/doc-Migrating_your_virtual_machines/master.html#proc_running-migration-plan_ostack [Step 6, including note. The same text is used for all providers, the step number varies with the provider]
- https://forklift-documentation-git-fork-ri-27ec42-yaacov-8047s-projects.vercel.app/downstream/documentation/doc-Migrating_your_virtual_machines/master.html#ref_common-migration-issues_mtv [last two items]
- https://forklift-documentation-git-fork-ri-27ec42-yaacov-8047s-projects.vercel.app/downstream/documentation/doc-Migrating_your_virtual_machines/master.html#ref_migration-plan-options-ui_vmware [Description of "Archive"]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on post-migration cleanup (Archive vs Delete) and resource handling
  * Added a recommended post-migration workflow with step-by-step actions (verify VMs, collect logs, archive/delete plan)
  * Inserted post-migration sections across migration guides and troubleshooting content
  * Expanded migration-plan UI and troubleshooting notes about completed pods, PVC mounts, and log-collection implications
<!-- end of auto-generated comment: release notes by coderabbit.ai -->