### PR TITLE
fixed conceptlink Vale warnings

### DIFF
--- a/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_advanced-migration-options.adoc
+++ b/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_advanced-migration-options.adoc
@@ -9,7 +9,12 @@ ifdef::context[:parent-context: {context}]
 //:context: advanced-migration-options
 
 [role="_abstract"]
-Perform advanced migration operations, such as changing precopy snapshot intervals for warm migration, configuring AIO buffering for performance optimization, creating custom rules for validation, or adding hooks to your migration plan. For performance test data and optimization recommendations, see link:{mtv-mig}assembly_mtv-performance-recommendations_mtv[MTV performance recommendations].
+Perform advanced migration operations, such as changing precopy snapshot intervals for warm migration, configuring AIO buffering for performance optimization, creating custom rules for validation, or adding hooks to your migration plan. For performance test data and optimization recommendations, see the "Additional resources" section.
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:{mtv-mig}assembly_mtv-performance-recommendations_mtv[MTV performance recommendations]
 
 include::../modules/proc_changing-precopy-intervals.adoc[leveloffset=+1]
 
@@ -52,6 +57,7 @@ include::../modules/con_target-vm-scheduling-options.adoc[leveloffset=+2]
 include::../modules/proc_configuring-target-vm-scheduling-cli.adoc[leveloffset=+2]
 
 include::../modules/con_configuring-target-vm-scheduling-ui.adoc[leveloffset=+2]
+
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_mtv-performance-recommendations.adoc
+++ b/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_mtv-performance-recommendations.adoc
@@ -13,14 +13,18 @@ ifdef::context[:parent-context: {context}]
 
 Performance metrics are available for all source providers. Performance recommendations and test data are based on {vmw} vSphere migrations.
 
-The data that forms the basis of the following recommendations was collected from testing in Red Hat labs and is provided for reference only. Overall, these numbers should be considered to show the best-case scenarios. The observed performance of migration can differ from these results and depends on several factors.
+The data that forms the basis of the following recommendations was collected from testing in Red Hat labs and is provided for reference only. Overall, these numbers should be considered to show the best-case scenarios. The observed performance of migration can differ from these results and depends on several factors. For procedures to configure performance optimizations, see the "Additional resources" section.
 
-For procedures to configure performance optimizations, see link:{mtv-mig}assembly_advanced-migration-options_mtv[Advanced migration options].
+[role="_additional-resources"]
+== Additional resources
+
+* link:{mtv-mig}assembly_advanced-migration-options_mtv[Advanced migration options]
 
 // TODO: SME REVIEW - Verify unit consistency: Some modules use MB/s (warm migrations, AIO), others use MiB/s (cold migrations, concurrency). Is this intentional (different measurement types) or should they be standardized? MB and MiB are different units (1 MiB ≈ 1.05 MB).
 
 :context: mtv
 :mtv:
+
 
 // Monitoring migration performance
 include::../modules/ref_mtv-performance-metrics.adoc[leveloffset=+1]
@@ -60,6 +64,7 @@ include::../modules/ref_migrating-vms-large-disks.adoc[leveloffset=+1]
 
 // AIO buffer performance
 include::../modules/ref_mtv-aio-buffer.adoc[leveloffset=+1]
+
 
 :mtv!:
 

--- a/documentation/doc-Planning_your_migration/assemblies/assembly_live-migration.adoc
+++ b/documentation/doc-Planning_your_migration/assemblies/assembly_live-migration.adoc
@@ -12,10 +12,14 @@ Live migration is supported by {project-first} version 2.10.0 and later. It requ
 
 [IMPORTANT]
 ====
-There is a known issue with live migration: Migration between namespaces on the same {virt} cluster fails because of MAC address collisions. 
-
-link:https://issues.redhat.com/browse/MTV-2446[(MTV-2446)]
+Migration between namespaces on the same {virt} cluster fails because of MAC address collisions. For more information about this known issue, see the "Additional resources" section.
 ====
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://issues.redhat.com/browse/MTV-2446[(MTV-2446)]
+
 
 include::../modules/con_benefits-live-migration.adoc[leveloffset=+1]
 

--- a/documentation/doc-Planning_your_migration/assemblies/assembly_migrating-vms-cli.adoc
+++ b/documentation/doc-Planning_your_migration/assemblies/assembly_migrating-vms-cli.adoc
@@ -24,8 +24,13 @@ To migrate to or from an {ocp-short} cluster that is different from the one the 
 
 [IMPORTANT]
 ====
-You must ensure that all prerequisites are met. For more information, see link:{mtv-plan}assembly_software-requirements-for-migration_mtv[Software requirements for migration].
+You must ensure that all prerequisites are met. For more information about prerequisites, see the "Additional resources" section.
 ====
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:{mtv-plan}assembly_software-requirements-for-migration_mtv[Software requirements for migration]
 
 :mtv!:
 :context: cli
@@ -36,6 +41,7 @@ include::../modules/con_non-admin-permissions.adoc[leveloffset=+1]
 :cli!:
 :context: mtv
 :mtv:
+
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/documentation/doc-Planning_your_migration/assemblies/assembly_migrating-vms-web-console.adoc
+++ b/documentation/doc-Planning_your_migration/assemblies/assembly_migrating-vms-web-console.adoc
@@ -18,13 +18,16 @@ For all migrations, you specify the source provider, the destination provider, a
 ====
 You must ensure that all prerequisites are met.
 
-{vmw} only: You must have the minimal set of {vmw} privileges.
+VMware only: You must have the minimal set of VMware privileges.
 
-{vmw} only: Creating a {vmw} Virtual Disk Development Kit (VDDK) image will increase migration speed.
+VMware only: Creating a VMware Virtual Disk Development Kit (VDDK) image will increase migration speed.
+
+For more information about the requirements, see the "Additional resources" section.
 ====
 
 [role="_additional-resources"]
-.Additional resources
+== Additional resources
+
 * link:{mtv-plan}assembly_software-requirements-for-migration_mtv[Software requirements for migration]
 * link:{mtv-plan}assembly_provider-specific-requirements-for-migration_mtv#vmware-privileges_mtv[VMware privileges]
 * link:{mtv-plan}assembly_provider-specific-requirements-for-migration_mtv#proc_creating-vddk-image_mtv[Creating a VDDK image]
@@ -44,6 +47,7 @@ include::../modules/con_preparing-vms-for-migration.adoc[leveloffset=+1]
 include::../modules/proc_renaming-vms-for-migration.adoc[leveloffset=+2]
 
 include::../modules/proc_configuring-target-power-state-vms.adoc[leveloffset=+2]
+
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/documentation/doc-Planning_your_migration/assemblies/assembly_software-requirements-for-migration.adoc
+++ b/documentation/doc-Planning_your_migration/assemblies/assembly_software-requirements-for-migration.adoc
@@ -14,7 +14,12 @@ Review the following software requirements to ensure that your environment is pr
 
 {project-first} has software requirements for all providers as well as specific software requirements per provider.
 
-You must install link:{mtv-plan}assembly_provider-specific-requirements-for-migration_mtv#ref_compatibility-guidelines_mtv[compatible versions] of {ocp} and {virt}.
+You must install compatible versions of {ocp} and {virt}. For more information about requirements, see the "Additional resources" section.
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:{mtv-plan}assembly_provider-specific-requirements-for-migration_mtv#ref_compatibility-guidelines_mtv[Provider-specific requirements for migration]
 
 include::../modules/ref_storage-support.adoc[leveloffset=+1]
 

--- a/documentation/modules/con_migrating-vms-by-using-mtv-ui.adoc
+++ b/documentation/modules/con_migrating-vms-by-using-mtv-ui.adoc
@@ -20,10 +20,19 @@ For all migrations, you specify the source provider, the destination provider, a
 
 [IMPORTANT]
 ====
-You must ensure that all prerequisites are met. For more information, see link:{mtv-plan}assembly_software-requirements-for-migration_mtv[Software requirements for migration].
+You must ensure that all prerequisites are met.
 
-VMware only: You must have the minimal set of link:{mtv-plan}assembly_provider-specific-requirements-for-migration_mtv#vmware-privileges_mtv[VMware privileges].
+VMware only: You must have the minimal set of VMware privileges.
 
-VMware only: Creating a link:{mtv-plan}assembly_provider-specific-requirements-for-migration_mtv#proc_creating-vddk-image_mtv[VMware Virtual Disk Development Kit (VDDK)] image increases migration speed.
+VMware only: Creating a VMware Virtual Disk Development Kit (VDDK) image increases migration speed.
+
+For more information about the requirements, see the "Additional resources" section.
 ====
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:{mtv-plan}assembly_software-requirements-for-migration_mtv[Software requirements for migration]
+* link:{mtv-plan}assembly_provider-specific-requirements-for-migration_mtv#vmware-privileges_mtv[VMware privileges]
+* link:{mtv-plan}assembly_provider-specific-requirements-for-migration_mtv#proc_creating-vddk-image_mtv[VMware Virtual Disk Development Kit (VDDK)]
 

--- a/documentation/modules/con_virt-v2v-mtv-customizing-removing-installing.adoc
+++ b/documentation/modules/con_virt-v2v-mtv-customizing-removing-installing.adoc
@@ -18,7 +18,8 @@
 For {rhel-first}-based guests, `virt-v2v` attempts to install the guest agent from the Red Hat registry. If the migration is run in a detached environment, the installation program fails, and you must use hooks or other automation to install the guest agent.
 ====
 
-For more information, see the man reference pages:
+[role="_additional-resources"]
+== Additional resources
 
 * link:https://libguestfs.org/virt-v2v.1.html[`virt-v2v` - Convert a guest to use KVM]
 * link:https://libguestfs.org/virt-customize.1.html[`virt-customize` - Customize a virtual machine]

--- a/documentation/modules/con_virt-v2v-mtv-main-functions.adoc
+++ b/documentation/modules/con_virt-v2v-mtv-main-functions.adoc
@@ -26,7 +26,12 @@ During migration, {project-short} uses `virt-v2v` to collect metadata about VMs,
 If you are migrating from {vmw} or from Open Virtual Appliances (OVA) files, `virt-v2v` also sets their IP addresses either during the migration or during the first reboot of the VMs after migration.
 [NOTE]
 ====
-You can also run predefined Ansible hooks before or after a migration using {project-short}. For more information, see xref:con_about-hooks-for-migration-plans_mtv[About hooks for MTV migration plans].
+You can also run predefined Ansible hooks before or after a migration using {project-short}. For more information, see the "Additional resources" section.
 
 These hooks do not necessarily use `virt-v2v`.
 ====
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:con_about-hooks-for-migration-plans_mtv[About hooks for MTV migration plans]

--- a/documentation/modules/con_warm-migration-stages-precopy.adoc
+++ b/documentation/modules/con_warm-migration-stages-precopy.adoc
@@ -9,8 +9,13 @@
 [role="_abstract"]
 The VMs are not shut down during the precopy stage.
 
-The VM disks are copied incrementally by using link:https://kb.vmware.com/s/article/1020128[changed block tracking (CBT)] snapshots. The snapshots are created at one-hour intervals by default. You can change the snapshot interval by updating the `forklift-controller` deployment.
+The VM disks are copied incrementally by using changed block tracking (CBT) snapshots. The snapshots are created at one-hour intervals by default. You can change the snapshot interval by updating the `forklift-controller` deployment.For more information about CBT snapshots, see the "Additional resources" section.
 
 A VM can support up to 28 CBT snapshots. If the source VM has too many CBT snapshots and the `Migration Controller` service is not able to create a new snapshot, warm migration might fail. The `Migration Controller` service deletes each snapshot when the snapshot is no longer required.
 
 The precopy stage runs until the cutover stage is started manually or is scheduled to start.
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://kb.vmware.com/s/article/1020128[Changed block tracking (CBT) on virtual machines]

--- a/documentation/modules/con_warm-migration.adoc
+++ b/documentation/modules/con_warm-migration.adoc
@@ -11,7 +11,12 @@ Warm migration copies most of the data while the source virtual machines (VMs) r
 
 The migration process has two stages:
 
-* *Precopy stage*: Most data is copied while VMs continue running. VM disks are copied incrementally using link:https://kb.vmware.com/s/article/1020128[changed block tracking (CBT)] snapshots.
+* *Precopy stage*: Most data is copied while VMs continue running. VM disks are copied incrementally using changed block tracking (CBT) snapshots. For more information about CBT snapshots, see the "Additional resources" section.
 * *Cutover stage*: VMs are shut down and the remaining data is migrated. Data stored in RAM is not migrated.
 
 Warm migration transfers snapshots to {ocp-short} first, then converts the VM during the cutover stage. This means disk blocks may be copied multiple times if the VM has high utilization, but VMs remain available during most of the migration process. You must enable CBT for each source VM and each VM disk before starting a warm migration.
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://kb.vmware.com/s/article/1020128[Changed Block Tracking (CBT) on virtual machines]

--- a/documentation/upstream-attributes.adoc
+++ b/documentation/upstream-attributes.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ATTRIBUTES
 // Upstream (Forklift) attribute overrides
 // Included conditionally by master.adoc files when building upstream docs.
 // Downstream (MTV) attributes are in modules/common-attributes.adoc.


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/DOCPLAN-370

I'm preparing some of the MTV files for the AEM migration. I fixed ConceptLink warnings by moving in-line links to the Additional resources section in assemblies and concept modules. I also added a mod docs content type to the upstream attributes file.

Versions: 4.20 and later

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Consolidated resource links into dedicated "Additional resources" sections across migration guides.
  * Reorganized prerequisites into clearer IMPORTANT blocks and NOTE/callout formatting for warnings (e.g., MAC address collision).
  * Moved inline links into bulleted resource lists for easier discovery and navigation.
  * Added a document attribute to improve content categorization and applied small spacing/formatting tweaks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/forklift-documentation/pull/922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->