### PR TITLE
Vale update - adding vale sync to vale workflow

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -14,15 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      checks: read
+      checks: write      # Reviewdog needs write access to create check runs
       contents: read
-      pull-requests: read
+      pull-requests: write # Reviewdog needs write access to post PR comments
     steps:
       - uses: actions/checkout@v4
+      
       - name: Install Asciidoctor
         run: sudo apt-get install -y asciidoctor
+        
       - uses: errata-ai/vale-action@reviewdog
         with:
+          sync: true # <--- THIS IS THE ADDITION. It runs 'vale sync' on-the-fly.
           filter_mode: diff_context
           vale_flags: "--no-exit --minAlertLevel=error --glob=*.adoc"
           reporter: github-pr-review


### PR DESCRIPTION
## Description

This PR optimizes our documentation linting workflow by enabling dynamic, runtime synchronization of upstream Vale style packages (proselint, write-good, AsciiDocDITA).

Rather than relying on manual file tracking, scheduled automated commits, or cron-triggered internal Pull Requests, this configuration leverages the native capabilities of errata-ai/vale-action to fetch the absolute latest rulesets directly inside the CI runner environment before the markdown/Asciidoc files are validated.

Modifications
.github/workflows/vale.yml (or your specific linting workflow file): Added the sync: true parameter to the errata-ai/vale-action step configuration.

Updated workflow permissions block to grant write access for pull-requests and checks, ensuring the Reviewdog reporter can successfully publish inline annotations on incoming contributions.