### PR TITLE
GitHub workflows directory blocked from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ _site
 .claude/
 .jekyll-cache/
 Gemfile.lock
+!.github/workflows/


### PR DESCRIPTION
## Description

This PR resolves the issue encountered when attempting to add or modify GitHub Actions workflows: the .github/ or .github/workflows/ directory was being entirely ignored by Git. Because Git was treating this path as an invisible directory based on an implicit or explicit block rule, git status would not show new workflow additions (such as the newly added vale.yml linter configuration), and standard git add actions would fail with a path-ignore message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git configuration to ensure workflow files are properly tracked in the repository.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/forklift-documentation/pull/925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->