### PR TITLE
PVC name template CNV

### DIFF
--- a/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-vmware.adoc
+++ b/documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-vmware.adoc
@@ -25,12 +25,6 @@ include::../modules/proc_canceling-migration-ui.adoc[leveloffset=+2]
 
 include::../modules/proc_migrating-vms-cli-vmware.adoc[leveloffset=+1]
 
-include::../modules/ref_pvc-name-template-variables-vmware.adoc[leveloffset=+2]
-
-include::../modules/ref_network-name-template-variables-vmware.adoc[leveloffset=+2]
-
-include::../modules/ref_volume-name-template-variables-vmware.adoc[leveloffset=+2]
-
 include::../modules/proc_storage-copy-offload-cli.adoc[leveloffset=+1]
 
 include::../modules/proc_retrieving-vmware-moref.adoc[leveloffset=+2]

--- a/documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-cnv.adoc
+++ b/documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-cnv.adoc
@@ -39,6 +39,8 @@ include::../modules/proc_selecting-migration-network-for-virt-provider.adoc[leve
 
 include::../modules/proc_creating-plan-wizard-cnv.adoc[leveloffset=+1]
 
+include::../modules/ref_pvc-name-template-variables-cnv.adoc[leveloffset=+2]
+
 include::../modules/proc_creating-plan-wizard-cnv-live.adoc[leveloffset=+2]
 
 :!cnv:

--- a/documentation/modules/proc_creating-plan-wizard-cnv.adoc
+++ b/documentation/modules/proc_creating-plan-wizard-cnv.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc_creating-plan-wizard-cnv_{context}"]
-= Creating an {virt} migration plan by using the MTV wizard
+= Creating {a-virt} migration plan by using the {project-short} wizard
 
 [role="_abstract"]
 You can migrate {virt} virtual machines (VMs) by using the {project-full} plan creation wizard.
@@ -30,7 +30,7 @@ When you click *Create plan* on the *Review and create* page of the wizard, {pro
 
 .Prerequisites
 
-* Have an {virt} source provider and an {virt} destination provider. For more information, see xref:proc_adding-source-provider_cnv[Adding an {virt} source provider] or xref:proc_adding-source-provider_dest_cnv[Adding {a-virt} destination provider].
+* Have {a-virt} source provider and {a-virt} destination provider. For more information, see xref:proc_adding-source-provider_cnv[Adding {a-virt} source provider] or xref:proc_adding-source-provider_dest_cnv[Adding {a-virt} destination provider].
 * If you plan to create a *Network map* or a *Storage map* that will be used by more than one migration plan, create it in the *Network maps* or *Storage maps* page of the UI before you create a migration plan that uses that map.
 
 .Procedure
@@ -184,4 +184,9 @@ The *Plan details* page also includes five additional tabs, which are described 
 |Editable specification of the network and storage maps used by your plan
 |Updatable specification of the hooks used by your plan, if any
 |===
++
+[NOTE]
+====
+You can customize the names of persistent volume claims (PVCs) for migrated VM disks by editing the YAML `Plan` manifest on the *YAML* tab and adding a `pvcNameTemplate` field. For more information, see xref:ref_pvc-name-template-variables-cnv_{context}[PVC name template variables for {virt}-to-{virt} migrations].
+====
 

--- a/documentation/modules/proc_migrating-live-cnv-cnv-vms-cli.adoc
+++ b/documentation/modules/proc_migrating-live-cnv-cnv-vms-cli.adoc
@@ -226,9 +226,11 @@ spec:
       namespace: <namespace>
   type: live
   targetNamespace: <target_namespace>
+  pvcNameTemplate: <pvc_name_template>
   vms:
     - name: <source_vm>
       namespace: <namespace>
+      pvcNameTemplate: <pvc_name_template_for_this_vm>
       hooks:
         - hook:
             namespace: <namespace>
@@ -242,17 +244,17 @@ where:
 `<plan>`::
 Specifies the name of the `Plan` CR.
 
-`map`::
-Specifies only one network map and one storage map per plan.
+`<namespace>`::
+Specifies the namespace for the resource. Use +{namespace}+ for the {project-short} namespace, or specify a custom namespace if you have configured providers in a different project.
 
-`network`::
-Specifies a network mapping, even if the VMs to be migrated are not assigned to a network. The mapping can be empty in this case.
+`<source_provider>`::
+Specifies the name of the source `Provider` CR.
+
+`<destination_provider>`::
+Specifies the name of the destination `Provider` CR.
 
 `<network_map>`::
 Specifies the name of the `NetworkMap` CR.
-
-`storage`::
-Specifies a storage mapping, even if the VMs to be migrated are not assigned with disk images. The mapping can be empty in this case.
 
 `<storage_map>`::
 Specifies the name of the `StorageMap` CR.
@@ -260,8 +262,18 @@ Specifies the name of the `StorageMap` CR.
 `type`::
 Specifies the type of migration. Must be set to `live`.
 
-`hooks`::
-Specifies up to two hooks for a VM. Each hook must run during a separate migration step. This is an optional label.
+`<target_namespace>`::
+Specifies the target namespace in the destination cluster.
+
+`<pvc_name_template>`::
+Specifies a template for the persistent volume claim (PVC) name for all VMs in the plan. This is an optional field.
+For a list of available variables, template functions, and examples, see link:{mtv-plan}assembly_planning-migration-cnv_mtv#ref_pvc-name-template-variables-cnv_cnv[PVC name template variables for {virt}-to-{virt} migrations].
+
+`<source_vm>`::
+Specifies the name of the source VM to migrate.
+
+`<pvc_name_template_for_this_vm>`::
+Specifies a template for the PVC name for this specific VM, overriding the plan-level template. This is an optional field.
 
 `<hook>`::
 Specifies the name of the `Hook` CR.

--- a/documentation/modules/proc_migrating-vms-cli-cnv.adoc
+++ b/documentation/modules/proc_migrating-vms-cli-cnv.adoc
@@ -7,7 +7,7 @@
 = Running a Red Hat {virt} migration from the command-line
 
 [role="_abstract"]
-You can use a Red Hat {virt} provider as either a source provider or as a destination provider. You can migrate from an {virt} source provider by using the command-line interface (CLI).
+You can use a Red Hat {virt} provider as either a source provider or as a destination provider. You can migrate from {a-virt} source provider by using the command-line interface (CLI).
 
 [NOTE]
 ====
@@ -252,18 +252,20 @@ spec:
     destination:
       name: <destination_provider>
       namespace: <namespace>
-  map: 
-    network: 
+  map:
+    network:
       name: <network_map>
       namespace: <namespace>
-    storage: 
+    storage:
       name: <storage_map>
       namespace: <namespace>
   targetNamespace: <target_namespace>
+  pvcNameTemplate: <pvc_name_template>
   vms:
     - name: <source_vm>
       namespace: <namespace>
-      hooks: 
+      pvcNameTemplate: <pvc_name_template_for_this_vm>
+      hooks:
         - hook:
             namespace: <namespace>
             name: <hook>
@@ -273,29 +275,36 @@ EOF
 +
 where:
 
-`<namespace>`::
-Specifies the namespace for the resource. Use +{namespace}+ for the {project-short} namespace, or specify a custom namespace if you have configured providers in a different project.
-
 `<plan>`::
 Specifies the name of the `Plan` CR.
 
-`map`::
-Specifies only one network map and one storage map per plan.
+`<namespace>`::
+Specifies the namespace for the resource. Use +{namespace}+ for the {project-short} namespace, or specify a custom namespace if you have configured providers in a different project.
 
-`network`::
-Specifies a network mapping, even if the VMs to be migrated are not assigned to a network. The mapping can be empty in this case.
+`<source_provider>`::
+Specifies the name of the source `Provider` CR.
+
+`<destination_provider>`::
+Specifies the name of the destination `Provider` CR.
 
 `<network_map>`::
 Specifies the name of the `NetworkMap` CR.
 
-`storage`::
-Specifies a storage mapping, even if the VMs to be migrated are not assigned with disk images. The mapping can be empty in this case.
-
 `<storage_map>`::
 Specifies the name of the `StorageMap` CR.
 
-`hooks`::
-Specifies up to two hooks for a VM. Each hook must run during a separate migration step. This is an optional label.
+`<target_namespace>`::
+Specifies the target namespace in the destination cluster.
+
+`<pvc_name_template>`::
+Specifies a template for the persistent volume claim (PVC) name for all VMs in the plan. This is an optional field.
+For a list of available variables, template functions, and examples, see link:{mtv-plan}assembly_planning-migration-cnv_mtv#ref_pvc-name-template-variables-cnv_cnv[PVC name template variables for {virt}-to-{virt} migrations].
+
+`<source_vm>`::
+Specifies the name of the source VM to migrate.
+
+`<pvc_name_template_for_this_vm>`::
+Specifies a template for the PVC name for this specific VM, overriding the plan-level template. This is an optional field.
 
 `<hook>`::
 Specifies the name of the `Hook` CR.

--- a/documentation/modules/proc_migrating-vms-cli-cnv.adoc
+++ b/documentation/modules/proc_migrating-vms-cli-cnv.adoc
@@ -206,7 +206,7 @@ where:
 Specifies the namespace for the resource. Use +{namespace}+ for the {project-short} namespace, or specify a custom namespace if you have configured providers in a different project.
 
 `<service account>`::
-Specifies the {ocp} service account. This is an optional label. Use the `serviceAccount` parameter to modify any cluster resources.
+Specifies the {ocp} service account. This is an optional field. Use the `serviceAccount` parameter to modify any cluster resources.
 
 `playbook`::
 Specifies the Base64-encoded Ansible Playbook. If you specify a playbook, the `image` must include an `ansible-runner`.

--- a/documentation/modules/proc_migrating-vms-cli-vmware.adoc
+++ b/documentation/modules/proc_migrating-vms-cli-vmware.adoc
@@ -103,7 +103,7 @@ Specifies the namespace for the resource. Use +{namespace}+ for the {project-sho
 Specifies the URL of the API endpoint, for example, `https://<vCenter_host>/sdk`.
 
 `<VDDK_image>`::
-Specifies the VDDK image. This is an optional label, but it is strongly recommended to create a VDDK image to accelerate migrations. Follow OpenShift documentation to specify the VDDK image you created.
+Specifies the VDDK image. This is an optional field, but it is strongly recommended to create a VDDK image to accelerate migrations. Follow OpenShift documentation to specify the VDDK image you created.
 
 `sdkEndpoint`::
 Specifies the URL used by the provider's SDK. Options: `vcenter` or `esxi`.
@@ -310,7 +310,7 @@ where:
 Specifies the namespace for the resource. Use +{namespace}+ for the {project-short} namespace, or specify a custom namespace if you have configured providers in a different project.
 
 `<service account>`::
-Specifies the {ocp} service account. This is an optional label. Use the `serviceAccount` parameter to modify any cluster resources.
+Specifies the {ocp} service account. This is an optional field. Use the `serviceAccount` parameter to modify any cluster resources.
 
 `playbook`::
 Specifies the Base64-encoded Ansible Playbook. If you specify a playbook, the `image` must include an `ansible-runner`.
@@ -502,22 +502,22 @@ Specifies the source VMs. Use either the `id` or the `name` parameter to specify
 Specifies the {vmw} vSphere VM moRef. To retrieve the moRef, see xref:proc_retrieving-vmware-moref_vmware[Retrieving a {vmw} vSphere moRef].
 
 `networkNameTemplate`::
-Specifies a network interface name for the specific VM. Overrides the value set in `spec:networkNameTemplate`. This is an optional label.
+Specifies a network interface name for the specific VM. Overrides the value set in `spec:networkNameTemplate`. This is an optional field.
 For a list of available variables and examples, see link:{mtv-plan}assembly_planning-migration-vmware_mtv#ref_network-name-template-variables-vmware_vmware[Network name template variables].
 
 `pvcNameTemplate`::
-Specifies a PVC name for the specific VM. Overrides the value set in `spec:pvcNameTemplate`. This is an optional label.
+Specifies a PVC name for the specific VM. Overrides the value set in `spec:pvcNameTemplate`. This is an optional field.
 For a list of available variables, template functions, and examples, see link:{mtv-plan}assembly_planning-migration-vmware_mtv#ref_pvc-name-template-variables-vmware_vmware[PVC name template variables].
 
 `volumeNameTemplate`::
-Specifies a volume name for the specific VM. Overrides the value set in `spec:volumeNameTemplate`. This is an optional label.
+Specifies a volume name for the specific VM. Overrides the value set in `spec:volumeNameTemplate`. This is an optional field.
 For a list of available variables and examples, see link:{mtv-plan}assembly_planning-migration-vmware_mtv#ref_volume-name-template-variables-vmware_vmware[Volume name template variables].
 
 `targetName`::
-Specifies the name of the target VM. {project-short} automatically generates a name for the target VM. You can override this name by using this parameter and entering a new name. The name you enter must be unique, and it must be a valid Kubernetes subdomain. Otherwise, the migration fails automatically. This is an optional label.
+Specifies the name of the target VM. {project-short} automatically generates a name for the target VM. You can override this name by using this parameter and entering a new name. The name you enter must be unique, and it must be a valid Kubernetes subdomain. Otherwise, the migration fails automatically. This is an optional field.
 
 `hooks`::
-Specifies up to two hooks for a migration. Each hook must run during a separate migration step. This is an optional label.
+Specifies up to two hooks for a migration. Each hook must run during a separate migration step. This is an optional field.
 
 `<hook>`::
 Specifies the name of the `Hook` CR.

--- a/documentation/modules/proc_migrating-vms-cli-vmware.adoc
+++ b/documentation/modules/proc_migrating-vms-cli-vmware.adoc
@@ -428,11 +428,11 @@ To avoid this, set `preserveStaticIPs` to `true`. {project-short} issues a warni
 
 `networkNameTemplate`::
 Specifies a template for the network interface name for the VMs in your plan. This is an optional field.
-For a list of available variables and examples, see xref:ref_network-name-template-variables-vmware_{context}[Network name template variables].
+For a list of available variables and examples, see link:{mtv-plan}assembly_planning-migration-vmware_mtv#ref_network-name-template-variables-vmware_vmware[Network name template variables].
 
 `pvcNameTemplate`::
 Specifies a template for the persistent volume claim (PVC) name for a plan. This is an optional field.
-For a list of available variables, template functions, and examples, see xref:ref_pvc-name-template-variables-vmware_{context}[PVC name template variables].
+For a list of available variables, template functions, and examples, see link:{mtv-plan}assembly_planning-migration-vmware_mtv#ref_pvc-name-template-variables-vmware_vmware[PVC name template variables].
 
 `pvcNameTemplateUseGenerateName`::
 Specifies whether to add alphanumeric characters to the name of a PVC.
@@ -493,7 +493,7 @@ Determines whether the migration uses VirtIO devices or compatibility devices wh
 
 `volumeNameTemplate`::
 Specifies a template for the volume interface name for the VMs in your plan. This is an optional field.
-For a list of available variables and examples, see xref:ref_volume-name-template-variables-vmware_{context}[Volume name template variables].
+For a list of available variables and examples, see link:{mtv-plan}assembly_planning-migration-vmware_mtv#ref_volume-name-template-variables-vmware_vmware[Volume name template variables].
 
 `vms`::
 Specifies the source VMs. Use either the `id` or the `name` parameter to specify the source VMs. If you are using a UDN, verify that the IP address of the provider is outside the subnet of the UDN. If the IP address is within the subnet of the UDN, the migration fails.
@@ -502,13 +502,16 @@ Specifies the source VMs. Use either the `id` or the `name` parameter to specify
 Specifies the {vmw} vSphere VM moRef. To retrieve the moRef, see xref:proc_retrieving-vmware-moref_vmware[Retrieving a {vmw} vSphere moRef].
 
 `networkNameTemplate`::
-Specifies a network interface name for the specific VM. Overrides the value set in `spec:networkNameTemplate`. Variables and examples as in `spec:networkNameTemplate`. This is an optional label.
+Specifies a network interface name for the specific VM. Overrides the value set in `spec:networkNameTemplate`. This is an optional label.
+For a list of available variables and examples, see link:{mtv-plan}assembly_planning-migration-vmware_mtv#ref_network-name-template-variables-vmware_vmware[Network name template variables].
 
 `pvcNameTemplate`::
-Specifies a PVC name for the specific VM. Overrides the value set in `spec:pvcNameTemplate`. Variables and examples as in `spec:pvcNameTemplate`. This is an optional label.
+Specifies a PVC name for the specific VM. Overrides the value set in `spec:pvcNameTemplate`. This is an optional label.
+For a list of available variables, template functions, and examples, see link:{mtv-plan}assembly_planning-migration-vmware_mtv#ref_pvc-name-template-variables-vmware_vmware[PVC name template variables].
 
 `volumeNameTemplate`::
-Specifies a volume name for the specific VM. Overrides the value set in `spec:volumeNameTemplate`. Variables and examples as in `spec:volumeNameTemplate`. This is an optional label.
+Specifies a volume name for the specific VM. Overrides the value set in `spec:volumeNameTemplate`. This is an optional label.
+For a list of available variables and examples, see link:{mtv-plan}assembly_planning-migration-vmware_mtv#ref_volume-name-template-variables-vmware_vmware[Volume name template variables].
 
 `targetName`::
 Specifies the name of the target VM. {project-short} automatically generates a name for the target VM. You can override this name by using this parameter and entering a new name. The name you enter must be unique, and it must be a valid Kubernetes subdomain. Otherwise, the migration fails automatically. This is an optional label.

--- a/documentation/modules/ref_network-name-template-variables-vmware.adoc
+++ b/documentation/modules/ref_network-name-template-variables-vmware.adoc
@@ -1,6 +1,5 @@
 // Module included in the following assemblies:
 //
-// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-vmware.adoc
 // * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-vmware.adoc
 
 :_mod-docs-content-type: REFERENCE

--- a/documentation/modules/ref_pvc-name-template-variables-cnv.adoc
+++ b/documentation/modules/ref_pvc-name-template-variables-cnv.adoc
@@ -8,13 +8,15 @@
 = PVC name template variables for {virt}-to-{virt} migrations
 
 [role="_abstract"]
-You can use template variables to customize persistent volume claim (PVC) names for migrated VM disks to satisfy storage policies, backup integration, or organizational naming standards. Templates use Go template syntax to define naming patterns for {virt}-to-{virt} migrations.
+You can use template variables to customize persistent volume claim (PVC) names for migrated VM disks to satisfy storage policies, backup requirements, or organizational naming standards.
+
+Templates use Go template syntax to define naming patterns for {virt}-to-{virt} migrations.
 
 You must ensure that PVC names are DNS-compliant: they must consist of lowercase alphanumeric characters or hyphens (`-`), start with an alphanumeric character, and not exceed 63 characters. If the template syntax is invalid or if the resulting PVC names are not DNS-compliant, {project-short} adds an error to the plan conditions and prevents the migration from running.
 
 == Available variables
 
-The `pvcNameTemplate` field has access to the following variables for {virt}-to-{virt} migrations:
+The following variables are available in the `pvcNameTemplate` field for {virt}-to-{virt} migrations:
 
 * `.VmName`: Name of the VM in the source {ocp} cluster.
 * `.TargetVmName`: Final VM name in the target cluster. May equal `.VmName` if no rename or normalization occurs.
@@ -41,12 +43,12 @@ If you do not specify a `pvcNameTemplate`, {project-short} preserves the origina
 
 [NOTE]
 ====
-Unlike VMware migrations, {virt}-to-{virt} migrations always use the template output as the exact PVC name. {virt}-to-{virt} migrations ignore the `pvcNameTemplateUseGenerateName` field.
+Unlike {vmw} migrations, {virt}-to-{virt} migrations always use the template output as the exact PVC name. {virt}-to-{virt} migrations ignore the `pvcNameTemplateUseGenerateName` field.
 ====
 
 == Examples
 
-Use the `trunc` function to ensure template output does not exceed the 63-character limit:
+The following examples show common PVC naming patterns. Use the `trunc` function to prevent template output from exceeding the 63-character limit:
 
 * `"{{.TargetVmName}}-{{.SourcePVCName}}"` – Prefix the source PVC name with the target VM name (for example, `myvm-data-disk` for a VM named `myvm` and PVC named `data-disk`)
 * `"migrated-{{.SourcePVCName}}-{{.DiskIndex}}"` – Add a migration prefix and disk index (where 0 is the first disk)

--- a/documentation/modules/ref_pvc-name-template-variables-cnv.adoc
+++ b/documentation/modules/ref_pvc-name-template-variables-cnv.adoc
@@ -19,7 +19,7 @@ The `pvcNameTemplate` field has access to the following variables for {virt}-to-
 * `.VmName`: Name of the VM in the source {ocp} cluster.
 * `.TargetVmName`: Final VM name in the target cluster. May equal `.VmName` if no rename or normalization occurs.
 * `.PlanName`: Name of the migration plan.
-* `.DiskIndex`: Sequential index of the disk (0-based).
+* `.DiskIndex`: Sequential index of the disk (0-based, where the first disk is 0, the second is 1, and so on).
 * `.SourcePVCName`: Original name of the PVC in the source cluster.
 * `.SourcePVCNamespace`: Namespace of the PVC in the source cluster.
 
@@ -31,7 +31,7 @@ You can use Go template functions to transform variable values into valid PVC na
 * `replace`: Replaces all occurrences of a substring. For example, `++{{++.SourcePVCName | replace "_" "-"}}` replaces underscores with hyphens.
 * `lower`: Converts a string to lowercase. For example, `++{{++.VmName | lower}}`.
 
-Functions can be chained together using the pipe (`|`) operator. Regular expression functions such as `mustRegexReplaceAll` are also available for advanced transformations.
+You can chain functions together by using the pipe (`|`) operator. You can also use regular expression functions such as `mustRegexReplaceAll` for advanced transformations.
 
 For a complete list of available template functions, see xref:con_mtv-template-utility_{context}[{project-short} template utility].
 
@@ -41,13 +41,15 @@ If you do not specify a `pvcNameTemplate`, {project-short} preserves the origina
 
 [NOTE]
 ====
-Unlike VMware migrations, {virt}-to-{virt} migrations always use the template output as the exact PVC name. The `pvcNameTemplateUseGenerateName` field is ignored for {virt}-to-{virt} migrations.
+Unlike VMware migrations, {virt}-to-{virt} migrations always use the template output as the exact PVC name. {virt}-to-{virt} migrations ignore the `pvcNameTemplateUseGenerateName` field.
 ====
 
 == Examples
 
+Use the `trunc` function to ensure template output does not exceed the 63-character limit:
+
 * `"{{.TargetVmName}}-{{.SourcePVCName}}"` – Prefix the source PVC name with the target VM name (for example, `myvm-data-disk` for a VM named `myvm` and PVC named `data-disk`)
-* `"migrated-{{.SourcePVCName}}-{{.DiskIndex}}"` – Add a migration prefix and disk index
+* `"migrated-{{.SourcePVCName}}-{{.DiskIndex}}"` – Add a migration prefix and disk index (where 0 is the first disk)
 * `"{{.TargetVmName}}-disk-{{.DiskIndex}}"` – Use the target VM name with a disk index
-* `"{{trunc 10 .PlanName}}-{{trunc 20 .TargetVmName}}-{{.DiskIndex}}"` – Truncated plan and target VM names with disk index for uniqueness
+* `"{{trunc 10 .PlanName}}-{{trunc 20 .TargetVmName}}-{{.DiskIndex}}"` – Truncate the plan and target VM names to prevent exceeding the 63-character limit
 * `"{{.TargetVmName}}-{{.SourcePVCNamespace}}-{{.SourcePVCName}}"` – Include source namespace for clarity in multi-namespace migrations

--- a/documentation/modules/ref_pvc-name-template-variables-cnv.adoc
+++ b/documentation/modules/ref_pvc-name-template-variables-cnv.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-cnv.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="ref_pvc-name-template-variables-cnv_{context}"]
+= PVC name template variables for {virt}-to-{virt} migrations
+
+[role="_abstract"]
+You can use template variables to customize persistent volume claim (PVC) names for migrated VM disks to satisfy storage policies, backup integration, or organizational naming standards. Templates use Go template syntax to define naming patterns for {virt}-to-{virt} migrations.
+
+You must ensure that PVC names are DNS-compliant: they must consist of lowercase alphanumeric characters or hyphens (`-`), start with an alphanumeric character, and not exceed 63 characters. If the template syntax is invalid or if the resulting PVC names are not DNS-compliant, {project-short} adds an error to the plan conditions and prevents the migration from running.
+
+== Available variables
+
+The `pvcNameTemplate` field has access to the following variables for {virt}-to-{virt} migrations:
+
+* `.VmName`: Name of the VM in the source {ocp} cluster.
+* `.TargetVmName`: Final VM name in the target cluster. May equal `.VmName` if no rename or normalization occurs.
+* `.PlanName`: Name of the migration plan.
+* `.DiskIndex`: Sequential index of the disk (0-based).
+* `.SourcePVCName`: Original name of the PVC in the source cluster.
+* `.SourcePVCNamespace`: Namespace of the PVC in the source cluster.
+
+== Template functions
+
+You can use Go template functions to transform variable values into valid PVC names. Common functions include:
+
+* `trunc`: Truncates a string to a specified length. For example, `++{{++trunc 10 .PlanName}}` limits the plan name to 10 characters.
+* `replace`: Replaces all occurrences of a substring. For example, `++{{++.SourcePVCName | replace "_" "-"}}` replaces underscores with hyphens.
+* `lower`: Converts a string to lowercase. For example, `++{{++.VmName | lower}}`.
+
+Functions can be chained together using the pipe (`|`) operator. Regular expression functions such as `mustRegexReplaceAll` are also available for advanced transformations.
+
+For a complete list of available template functions, see xref:con_mtv-template-utility_{context}[{project-short} template utility].
+
+== Default behavior
+
+If you do not specify a `pvcNameTemplate`, {project-short} preserves the original PVC name from the source cluster: `++{{++.SourcePVCName}}`.
+
+[NOTE]
+====
+Unlike VMware migrations, {virt}-to-{virt} migrations always use the template output as the exact PVC name. The `pvcNameTemplateUseGenerateName` field is ignored for {virt}-to-{virt} migrations.
+====
+
+== Examples
+
+* `"{{.TargetVmName}}-{{.SourcePVCName}}"` – Prefix the source PVC name with the target VM name (for example, `myvm-data-disk` for a VM named `myvm` and PVC named `data-disk`)
+* `"migrated-{{.SourcePVCName}}-{{.DiskIndex}}"` – Add a migration prefix and disk index
+* `"{{.TargetVmName}}-disk-{{.DiskIndex}}"` – Use the target VM name with a disk index
+* `"{{trunc 10 .PlanName}}-{{trunc 20 .TargetVmName}}-{{.DiskIndex}}"` – Truncated plan and target VM names with disk index for uniqueness
+* `"{{.TargetVmName}}-{{.SourcePVCNamespace}}-{{.SourcePVCName}}"` – Include source namespace for clarity in multi-namespace migrations

--- a/documentation/modules/ref_pvc-name-template-variables-vmware.adoc
+++ b/documentation/modules/ref_pvc-name-template-variables-vmware.adoc
@@ -1,6 +1,5 @@
 // Module included in the following assemblies:
 //
-// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-vmware.adoc
 // * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-vmware.adoc
 
 :_mod-docs-content-type: REFERENCE

--- a/documentation/modules/ref_volume-name-template-variables-vmware.adoc
+++ b/documentation/modules/ref_volume-name-template-variables-vmware.adoc
@@ -1,6 +1,5 @@
 // Module included in the following assemblies:
 //
-// * documentation/doc-Migrating_your_virtual_machines/assemblies/assembly_migrating-from-vmware.adoc
 // * documentation/doc-Planning_your_migration/assemblies/assembly_planning-migration-vmware.adoc
 
 :_mod-docs-content-type: REFERENCE


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/MTV-4264 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added reference documentation for `pvcNameTemplate` variables, available template functions, DNS-compliance rules, defaults, and examples for `{virt}-to-{virt}` migrations.
  * Updated migration procedures and Plan examples to support overriding PVC naming via plan-level and per-VM `pvcNameTemplate`, including new `namespace` placeholder details.
  * Refreshed VMware docs to improve template-variable cross-references and alignment with current wizard branding and prerequisites.
  * Removed outdated “migrating-from-vmware” assembly include references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->