### PR TITLE
MTV-5727: Clarify OCP-to-OCP migration does not require MTV on both clusters

### DIFF
--- a/documentation/modules/ref_cnv-prerequisites.adoc
+++ b/documentation/modules/ref_cnv-prerequisites.adoc
@@ -7,7 +7,12 @@
 = {virt} prerequisites
 
 [role="_abstract"]
-To migrate between {virt} clusters, verify that both clusters have matching {project-first} versions and the source uses {virt} 4.16 or later. You can migrate forward to newer {virt} versions if both are compatible with your {project-short} version.
+To migrate between {virt} clusters, verify that both clusters have compatible {virt} versions and that the source uses {virt} 4.16 or later. You can migrate forward to newer {virt} versions if both are compatible with your {project-short} version.
+
+[NOTE]
+====
+{project-first} does not need to be installed on both clusters. Install {project-short} on one cluster, and add the other cluster as a remote {virt} provider. {project-short} can run on the source cluster, the destination cluster, or a separate cluster, and it delegates the migration operations to the remote clusters.
+====
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
The CNV prerequisites incorrectly required matching **MTV** versions on both
clusters. The matching-version requirement applies to **OpenShift Virtualization**,
not MTV - MTV only needs to be installed on one cluster, which orchestrates the
other via a remote provider.

- Abstract: require compatible OpenShift Virtualization versions (not MTV versions)
- Added a NOTE that MTV runs on a single cluster and delegates to the remote cluster

Fixes https://issues.redhat.com/browse/MTV-5727


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated migration prerequisites to require compatible `{virt}` versions rather than exact version matches.
  * Reinforced that the source uses `{virt}` 4.16 or later.
  * Clarified that `{project-first}` doesn’t need to be installed on both clusters, and that forward migration is supported by using a `{project-short}` setup with remote `{virt}` providers to delegate migration operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->