### PR TITLE
MTV 2.12.0 release notes update: Include HyperV provider

### DIFF
--- a/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
@@ -125,3 +125,10 @@ spec:
 ----
 +
 link:https://issues.redhat.com/browse/MTV-5511[MTV-5511]
+
+`HyperV` provider for migrations (Technology Preview)::
+{project-short} provides a `HyperV` provider along with Red{nbsp}Hat-provided documentation. This feature enables you to perform migration operations from the `HyperV` platform by using the user interface (UI) instead of the command-line interface (CLI). As a result, you have a dependable migration path.
++
+This feature is hidden by default. To use the provider, you must opt in by enabling the feature flag in the UI. The `HyperV` provider is available as a Technology Preview, and is not recommended for production environments.
++
+link:https://redhat.atlassian.net/browse/MTV-4462[MTV-4462]

--- a/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
@@ -129,6 +129,6 @@ link:https://issues.redhat.com/browse/MTV-5511[MTV-5511]
 `HyperV` provider for migrations (Technology Preview)::
 {project-short} provides a `HyperV` provider along with Red{nbsp}Hat-provided documentation. This feature enables you to perform migration operations from the `HyperV` platform by using the user interface (UI) instead of the command-line interface (CLI). As a result, you have a dependable migration path.
 +
-This feature is hidden by default. To use the provider, you must opt in by enabling the feature flag in the UI. The `HyperV` provider is available as a Technology Preview, and is not recommended for production environments.
+The `HyperV` provider is available as a Technology Preview, and is not recommended for production environments.
 +
 link:https://redhat.atlassian.net/browse/MTV-4462[MTV-4462]

--- a/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
@@ -127,7 +127,7 @@ spec:
 link:https://issues.redhat.com/browse/MTV-5511[MTV-5511]
 
 `HyperV` provider for migrations (Technology Preview)::
-{project-short} provides a `HyperV` provider along with Red{nbsp}Hat-provided documentation. This feature enables you to perform migration operations from the `HyperV` platform by using the user interface (UI) instead of the command-line interface (CLI). As a result, you have a dependable migration path.
+{project-short} provides a `HyperV` provider for migrations. This feature enables you to perform migration operations from the `HyperV` platform by using the user interface (UI) in addition to the command-line interface (CLI). As a result, you can migrate virtual machines (VMs) from `HyperV` to {ocp-name}.
 +
 The `HyperV` provider is available as a Technology Preview, and is not recommended for production environments.
 +


### PR DESCRIPTION
Updating MTV 2.12.0 release notes to include Hyper V provider



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes documenting a HyperV provider for migrations (Technology Preview), enabling migration operations from the HyperV platform via the UI (instead of the CLI) using an opt-in feature. Not recommended for production environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->