### PR TITLE
MTV 2.12.1 Attributes and release notes

### DIFF
--- a/documentation/doc-Release_notes/master.adoc
+++ b/documentation/doc-Release_notes/master.adoc
@@ -14,7 +14,7 @@ Review these release notes for {project-first} version {project-version}.
 include::modules/ref_rn-2-12.adoc[leveloffset=+1]
 
 // Technical changes by x-stream release
-include::modules/ref_technical-changes-2-12.adoc[leveloffset=+2]
+// include::modules/ref_technical-changes-2-12.adoc[leveloffset=+2]
 
 // New features and enhancements by z-stream release
 include::modules/ref_new-features-and-enhancements-2-12.adoc[leveloffset=+2]
@@ -23,6 +23,8 @@ include::modules/ref_new-features-and-enhancements-2-12.adoc[leveloffset=+2]
 include::modules/ref_rn-resolved-issues.adoc[leveloffset=+2]
 
 // Resolved issues by z-stream release. Most recent release goes first in the list.
+include::modules/ref_resolved-issues-2-12-1.adoc[leveloffset=+3]
+
 include::modules/ref_resolved-issues-2-12-0.adoc[leveloffset=+3]
 
 // Known issues by x-stream release

--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -26,7 +26,7 @@
 :project-version: 2.12
 :mtv-plan: https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/{project-version}/html/planning_your_migration_to_red_hat_openshift_virtualization/
 :mtv-mig: https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/{project-version}/html/migrating_your_virtual_machines_to_red_hat_openshift_virtualization/
-:project-z-version: 2.12.0
+:project-z-version: 2.12.1
 :rhel-first: Red Hat Enterprise Linux (RHEL)
 :virt: OpenShift Virtualization
 :must-gather: registry.redhat.io/migration-toolkit-virtualization/mtv-must-gather-rhel8:{project-z-version}

--- a/documentation/modules/ref_known-issues-2-12.adoc
+++ b/documentation/modules/ref_known-issues-2-12.adoc
@@ -9,6 +9,13 @@
 [role="_abstract"]
 {project-first} {project-version} has the following known issues.
 
+Static IP loss during RHEL 9 and 10 VM migrations::
+On Red Hat Enterprise Linux (RHEL) 9 and 10 systems, predictable network interface naming overrides `udev` rename rules. As a consequence, NetworkManager fails to activate the connection, and the virtual machine (VM) loses its static IP address.
++
+To work around this problem, manually add systemd `.link` files into the `/etc/systemd/network/` directory to rename the interface. As a result, NetworkManager activates the connection and retains the static IP address.
++
+link:https://issues.redhat.com/browse/MTV-5530[MTV-5530]
+
 VM migrations with XFS v4 file systems fail during conversion::
 Migrating a virtual machine (VM) with an XFS v4 file system uses a Red Hat Enterprise Linux 9 `virt-v2v` image. This image does not support the `virt_v2v_memsize` and `virt_v2v_smp` parameters. As a consequence, the migration fails during the conversion phase if you set these parameters with `xfsCompatibility: true`.
 +
@@ -40,3 +47,10 @@ spec:
 As a result, the migration proceeds without the preflight inspection. Potential issues in the plan might not be caught before execution.
 +
 link:https://redhat.atlassian.net/browse/MTV-5750[MTV-5750]
+
+Duplicate default persistent routes retained after VM migrations::
+A script execution issue during a virtual machine (VM) migration causes duplicate default persistent routes to be retained. As a consequence, the duplicated routes cause network issues after the migration.
++
+To work around this problem, manually remove the duplicate persistent routes. As a result, the system uses the correct network configuration.
++
+link:https://issues.redhat.com/browse/MTV-5880[MTV-5880]

--- a/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
@@ -9,16 +9,24 @@
 [role="_abstract"]
 {project-first} 2.12 introduces the following features and enhancements.
 
+[id="new-features-and-enhancements-2-12-1_{context}"]
+== {project-short} 2.12.1
+
+Automatic retry mechanism added for QEMU guest agent installations on Windows systems::
+With this update, {project-short} includes an automatic retry mechanism for QEMU guest agent installations on Windows systems. This mechanism addresses internal Windows issues that cause installation failures. As a result, the guest agent installs more reliably, which ensures a smoother migration experience.
++
+link:https://issues.redhat.com/browse/MTV-5782[MTV-5782]
+
 [id="new-features-and-enhancements-2-12-0_{context}"]
 == {project-short} 2.12.0
 
 {project-short} UI integrates Red Hat OpenShift Lightspeed::
-With this release, the {project-short} user interface (UI) integrates Red Hat OpenShift Lightspeed. As a virtual infrastructure administrator, you can use free-text queries to generate AI-powered results. You can use this AI integration to quickly find specific answers during complex migrations. This feature also aligns Red Hat OpenShift Lightspeed across the OpenShift console and the UI. As a result, you can troubleshoot migration issues more efficiently.
+With this release, the {project-short} UI integrates Red Hat OpenShift Lightspeed. As a virtual infrastructure administrator, you can use free-text queries to generate AI-powered results. You can use this AI integration to quickly find specific answers during complex migrations. This feature also aligns Red Hat OpenShift Lightspeed across the OpenShift console and the UI. As a result, you can troubleshoot migration issues more efficiently.
 +
 link:https://redhat.atlassian.net/browse/MTV-4445[MTV-4445]
 
 {project-short} supports AWS EC2 as a source provider (Technology Preview)::
-With this release, {project-short} supports migrations from Amazon Web Services (AWS) Elastic Compute Cloud (EC2) as a Technology Preview. You can define AWS EC2 as a source provider by using the user interface (UI) or the command-line interface (CLI). To access this capability, you must enable the associated feature flag. You can migrate only Red{nbsp}Hat Enterprise Linux (RHEL) virtual machines (VMs) that were created from official Red{nbsp}Hat images. You cannot migrate AWS operating systems or Windows machines. As a result, you can migrate these supported workloads to a Red{nbsp}Hat-supported environment.
+With this release, {project-short} supports migrations from Amazon Web Services (AWS) Elastic Compute Cloud (EC2) as a Technology Preview. You can define AWS EC2 as a source provider by using the UI or the command-line interface (CLI). To access this capability, you must enable the associated feature flag. You can migrate only Red{nbsp}Hat Enterprise Linux (RHEL) virtual machines (VMs) that were created from official Red{nbsp}Hat images. You cannot migrate AWS operating systems or Windows machines. As a result, you can migrate these supported workloads to a Red{nbsp}Hat-supported environment.
 +
 link:https://redhat.atlassian.net/browse/MTV-4466[MTV-4466]
 
@@ -30,17 +38,17 @@ link:https://redhat.atlassian.net/browse/MTV-4562[MTV-4562]
 {project-short} integrates with the NetApp Shift toolkit for zero-copy migrations::
 With this release, {project-short} integrates with the NetApp Shift toolkit for {vmw} environments. You can use this integration to perform zero-copy cold migrations. As a result, you can reduce migration downtime and transfer data more quickly.
 +
-The {project-short} user interface (UI) generates specially labeled persistent volume claims (PVCs). These PVCs signal the NetApp Trident Container Storage Interface (CSI) to perform the disk transfer. After the transfer completes, the migration process automatically executes the guest conversion. The process also applies the necessary boot permissions and provisions the final virtual machine (VM) on {virt}. If a source VM is powered on when the migration starts, the migration process automatically powers it off.
+The {project-short} UI generates specially labeled persistent volume claims (PVCs). These PVCs signal the NetApp Trident Container Storage Interface (CSI) to perform the disk transfer. After the transfer completes, the migration process automatically executes the guest conversion. The process also applies the necessary boot permissions and provisions the final virtual machine (VM) on {virt}. If a source VM is powered on when the migration starts, the migration process automatically powers it off.
 +
 link:https://redhat.atlassian.net/browse/MTV-3142[MTV-3142]
 
 Deep inspection tool assesses VM readiness for migration (Technology Preview)::
-With this release, a deep inspection tool assesses the readiness of virtual machines (VMs) for migration as a Technology Preview. The tool inspects the VM file system, which is particularly useful for dual-boot VMs. The user interface (UI) displays this information. You can use this data to choose root mounts and determine migration readiness without manual planning. As a result, you reduce conversion failures and the time required to prepare a VM.
+With this release, a deep inspection tool assesses the readiness of virtual machines (VMs) for migration as a Technology Preview. The tool inspects the VM file system, which is particularly useful for dual-boot VMs. The UI displays this information. You can use this data to choose root mounts and determine migration readiness without manual planning. As a result, you reduce conversion failures and the time required to prepare a VM.
 +
 link:https://redhat.atlassian.net/browse/MTV-2482[MTV-2482], link:https://redhat.atlassian.net/browse/MTV-4472[MTV-4472]
 
 {project-short} supports explicit instance type selection for VMs::
-With this release, you can explicitly select an instance type for each virtual machine (VM). You can make this selection when you create a plan in a private cloud cluster. The user interface (UI) displays a list of all available instance types. You can use this feature to optimize resources for specific workloads. As a result, you can manage and scale your cloud infrastructure more efficiently.
+With this release, you can explicitly select an instance type for each virtual machine (VM). You can make this selection when you create a plan in a private cloud cluster. The UI displays a list of all available instance types. You can use this feature to optimize resources for specific workloads. As a result, you can manage and scale your cloud infrastructure more efficiently.
 +
 link:https://redhat.atlassian.net/browse/MTV-1661[MTV-1661]
 
@@ -55,12 +63,12 @@ You can include VMs with and without shared disks in a single plan. However, if 
 link:https://redhat.atlassian.net/browse/MTV-4635[MTV-4635]
 
 {project-short} UI supports adding virtual machines to existing plans::
-With this release, you can add virtual machines (VMs) to existing plans in the {project-short} user interface (UI). You can use this feature to dynamically scale your infrastructure. As a result, you can optimize your workloads and manage resources more efficiently.
+With this release, you can add virtual machines (VMs) to existing plans in the {project-short} UI. You can use this feature to dynamically scale your infrastructure. As a result, you can optimize your workloads and manage resources more efficiently.
 +
 link:https://redhat.atlassian.net/browse/MTV-1726[MTV-1726]
 
-User interface supports configuring tolerations and nodeSelector for importer pods::
-With this release, you can configure the `tolerations` and `nodeSelector` fields for importer pods in the user interface (UI). You can use this feature to customize pod placement and manage resource allocation for importer tasks. As a result, you can optimize workloads for specific infrastructure requirements.
+{project-short} UI supports configuring tolerations and nodeSelector for importer pods::
+With this release, you can configure the `tolerations` and `nodeSelector` fields for importer pods in the {project-short} UI. You can use this feature to customize pod placement and manage resource allocation for importer tasks. As a result, you can optimize workloads for specific infrastructure requirements.
 +
 link:https://redhat.atlassian.net/browse/MTV-3015[MTV-3015]
 
@@ -70,7 +78,7 @@ With this release, the custom firstboot scripts feature is provided as a Technol
 link:https://redhat.atlassian.net/browse/MTV-3641[MTV-3641]
 
 {project-short} supports direct hook triggers within AAP (Technology Preview)::
-With this release, you can use `{project-short}` to trigger hooks directly in the Ansible Automation Platform (AAP) as a Technology Preview. Before this update, you had to specify a hook inside the hook image or the hook `configmap`. These methods lacked a connection to AAP. You no longer need to specify hooks manually. As a result, you streamline the migration process and improve automation workflows.
+With this release, you can use {project-short} to trigger hooks directly in the Ansible Automation Platform (AAP) as a Technology Preview. Before this update, you had to specify a hook inside the hook image or the hook `configmap`. These methods lacked a connection to AAP. You no longer need to specify hooks manually. As a result, you streamline the migration process and improve automation workflows.
 +
 link:https://redhat.atlassian.net/browse/MTV-3663[MTV-3663]
 
@@ -79,8 +87,8 @@ With this release, migration plans support the `pvcNameTemplate` field for {virt
 +
 link:https://redhat.atlassian.net/browse/MTV-3669[MTV-3669]
 
-The web console user interface supports multiple languages::
-This update introduces comprehensive multilanguage translation and internationalization to the {project-short} web console user interface. With this enhancement, you can navigate migration plans, view provider status, and manage virtual machine (VM) migrations in your preferred language. As a result, the console plugin matches your language preference in the Red Hat OpenShift Container Platform web console. It supports the following languages:
+The {project-short} UI supports multiple languages::
+This update introduces comprehensive multilanguage translation and internationalization to the {project-short} UI. With this enhancement, you can navigate migration plans, view provider status, and manage virtual machine (VM) migrations in your preferred language. As a result, the console plugin matches your language preference in the Red Hat {virt} web console. It supports the following languages:
 +
 * Spanish
 * French
@@ -96,7 +104,7 @@ With this release, real-time monitoring of migration performance is fully suppor
 link:https://redhat.atlassian.net/browse/MTV-4458[MTV-4458]
 
 {project-short} UI provides storage offload recommendations::
-With this release, the {project-short} user interface (UI) validates and optimizes storage offload configurations. When you select source and target storage, the UI displays optimal storage classes in drop-down menus. The UI also clearly indicates when a migration uses storage copy offload or the Virtual Disk Development Kit (VDDK). You can use these recommendations to decrease migration times. As a result, you can configure your migrations more efficiently.
+With this release, the {project-short} UI validates and optimizes storage offload configurations. When you select source and target storage, the UI displays optimal storage classes in drop-down menus. The UI also clearly indicates when a migration uses storage copy offload or the Virtual Disk Development Kit (VDDK). You can use these recommendations to decrease migration times. As a result, you can configure your migrations more efficiently.
 +
 link:https://redhat.atlassian.net/browse/MTV-4492[MTV-4492]
 
@@ -126,7 +134,7 @@ spec:
 link:https://issues.redhat.com/browse/MTV-5511[MTV-5511]
 
 `HyperV` provider for migrations (Technology Preview)::
-{project-short} provides a `HyperV` provider for migrations. This feature enables you to perform migration operations from the `HyperV` platform by using the user interface (UI) in addition to the command-line interface (CLI). As a result, you can migrate virtual machines (VMs) from `HyperV` to {ocp-name}.
+{project-short} provides a `HyperV` provider for migrations. This feature enables you to perform migration operations from the `HyperV` platform by using the UI in addition to the command-line interface (CLI). As a result, you can migrate virtual machines (VMs) from `HyperV` to {ocp-name}.
 +
 The `HyperV` provider is available as a Technology Preview, and is not recommended for production environments.
 +

--- a/documentation/modules/ref_resolved-issues-2-12-1.adoc
+++ b/documentation/modules/ref_resolved-issues-2-12-1.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Release_notes/master.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ref_resolved-issues-2-12-1_{context}"]
+= Resolved issues 2.12.1
+
+[role="_abstract"]
+Review the resolved issues in this release of {project-short}.
+
+Correct handling of shared disks in {project-short} when multi-writer is set to false::
+Before this update, MTV incorrectly handled shared disks with `multi-writer` set to `false` as individual disks. As a consequence, the system incorrectly treated user data on multiple shared disks, and potentially caused data inconsistency. With this update, shared disks with `multi-writer` set to `false` behave as if the setting is `true`. As a result, the system handles shared disks correctly and maintains data consistency.
++
+link:https://issues.redhat.com/browse/MTV-4706[MTV-4706]
+
+Progress bars added in the {project-short} UI for cold storage copy offload migrations::
+Before this update, the {project-short} UI did not render progress bars during cold storage copy offload migrations. As a consequence, you could not track the progress of long-running multi-disk migrations. With this update, the *Disk transfer* and *Disk counter* columns include progress bars. As a result, you can monitor multi-disk migrations in real time.
++
+link:https://issues.redhat.com/browse/MTV-5679[MTV-5679]
+
+{project-short} {vmw} driver cleanup searches for devcon.exe in multiple paths::
+Before this update, the {project-short} {vmw} driver cleanup failed to search for `devcon.exe` in specified paths. As a consequence, you could not clean the driver properly, which led to potential system instability. With this update, the cleanup process searches for `devcon.exe` in `C:\Windows\Build\Tools`, `firstboot` scripts, and `PATH`. As a result, the driver correctly searches for the file and ensures a stable system.
++
+link:https://issues.redhat.com/browse/MTV-5781[MTV-5781]
+
+Correct transfer method displayed in the {project-short} UI for storage copy offload migrations::
+Before this update, the {project-short} UI incorrectly showed `DiskTransferV2v` during storage copy offload migrations due to misconfigured settings. As a consequence, you saw incorrect transfer reporting when you did not use `v2v` transfers. With this update, the UI displays the correct transfer method. As a result, you can accurately identify the transfer type.
++
+link:https://issues.redhat.com/browse/MTV-5783[MTV-5783]
+
+Runtime panics prevented during vSphere conversion plan cancellations::
+Before this update, canceling {vmw} vSphere conversion plans caused a `nil pointer dereference` error when accessing `Context.Map.Storage`. As a consequence, a runtime panic occurred. With this update, {project-short} validates `Context.Map.Storage` before processing the cancellation. As a result, the tool does not crash.
++
+link:https://issues.redhat.com/browse/MTV-5784[MTV-5784]
+
+Support for VLAN-aware network mapping for Hyper-V migrations:: 
+Before this update, a Hyper-V virtual machine (VM) might use multiple network interface controllers (NICs) on the same virtual switch. The *Network Map* page displayed these NICs as a single source network even if they used different VLANs. As a consequence, the system mapped all NICs on that network to the same destination, which caused incorrect network configurations after migration. With this update, the *Network Map* page detects VLAN conflicts and displays VLAN-qualified source entries, such as "Lab-External (VLAN 100)". As a result, you can map each VLAN to a different target network attachment definition (NAD) and correctly migrate your VMs.
++
+link:https://issues.redhat.com/browse/MTV-5806[MTV-5806]
+
+Pre-existing PVCs preserved during initialization to prevent data loss::
+Before this update, when the migration `type` was set to `conversion`, the process deleted pre-existing persistent volume claims (PVCs) during initialization. As a consequence, the migration failed and caused data loss during the storage copy offload workflow. With this update, the migration process preserves pre-existing PVCs. As a result, you can successfully complete the storage copy offload workflow without data loss.
++
+link:https://issues.redhat.com/browse/MTV-5879[MTV-5879]


### PR DESCRIPTION
Resolves https://redhat.atlassian.net/browse/MTV-5800 by adding release notes and updating attributes for MTV  2.12.1. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automatic retry mechanism for QEMU guest agent installations on Windows systems.

* **Bug Fixes**
  * Improved MTV handling for shared disks when `multi-writer` is disabled.
  * Enhanced MTV UI for cold storage copy offload migrations (progress bars and transfer method display).
  * Improved VMware driver cleanup by searching for `devcon.exe` in more locations.
  * Prevented panics during vSphere conversion plan cancellations.
  * Enabled VLAN-aware network mapping for Hyper-V migrations.
  * Preserved pre-existing PVCs during initialization to prevent storage copy offload data loss.

* **Documentation**
  * Updated 2.12.1 release notes (including resolved issues and corrected must-gather version references) and refined {project-short} UI wording.
  * Added known issues for virt-v2v VM shutdown behavior and duplicate persistent routes after migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->