### PR TITLE
MTV 2.12.2 Release Notes and Attributes for MTV 2.12.2

### DIFF
--- a/documentation/doc-Release_notes/master.adoc
+++ b/documentation/doc-Release_notes/master.adoc
@@ -23,6 +23,8 @@ include::modules/ref_new-features-and-enhancements-2-12.adoc[leveloffset=+2]
 include::modules/ref_rn-resolved-issues.adoc[leveloffset=+2]
 
 // Resolved issues by z-stream release. Most recent release goes first in the list.
+include::modules/ref_resolved-issues-2-12-2.adoc[leveloffset=+3]
+
 include::modules/ref_resolved-issues-2-12-1.adoc[leveloffset=+3]
 
 include::modules/ref_resolved-issues-2-12-0.adoc[leveloffset=+3]

--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -26,7 +26,7 @@
 :project-version: 2.12
 :mtv-plan: https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/{project-version}/html/planning_your_migration_to_red_hat_openshift_virtualization/
 :mtv-mig: https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/{project-version}/html/migrating_your_virtual_machines_to_red_hat_openshift_virtualization/
-:project-z-version: 2.12.1
+:project-z-version: 2.12.2
 :rhel-first: Red Hat Enterprise Linux (RHEL)
 :virt: OpenShift Virtualization
 :must-gather: registry.redhat.io/migration-toolkit-virtualization/mtv-must-gather-rhel8:{project-z-version}

--- a/documentation/modules/ref_known-issues-2-12.adoc
+++ b/documentation/modules/ref_known-issues-2-12.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="ref_known-issues-2-12_{context}"]
-= Known issues
+= {project-short} known issues
 
 [role="_abstract"]
 {project-first} {project-version} has the following known issues.
@@ -30,23 +30,6 @@ Migrating from VMware to OpenShift Virtualization or deploying User Defined Netw
 To work around this problem, limit simultaneous UDN creation to 72 or fewer. For larger deployments, create the UDNs upfront. Wait for Open Virtual Network Kubernetes (OVNK) utilization to settle before you deploy attached resources. As a result, you maintain stable pod ready latency and prevent node failures.
 +
 link:https://redhat.atlassian.net/browse/MTV-5695[MTV-5695]
-
-Warm migrations of NBDE VMs fail during preflight inspection::
-A warm migration of a Network-Bound Disk Encryption (NBDE) virtual machine (VM) uses a DI pod. This pod cannot connect to the Tang server. As a consequence, the preflight inspection fails, and the migration plan fails.
-+
-To work around this problem, disable the preflight inspection step by adding `runPreflightInspection: false` to the migration plan `spec`:
-+
-[source,yaml]
-----
-spec:
-  ...
-  runPreflightInspection: false
-  ...
-----
-+
-As a result, the migration proceeds without the preflight inspection. Potential issues in the plan might not be caught before execution.
-+
-link:https://redhat.atlassian.net/browse/MTV-5750[MTV-5750]
 
 Duplicate default persistent routes retained after VM migrations::
 A script execution issue during a virtual machine (VM) migration causes duplicate default persistent routes to be retained. As a consequence, the duplicated routes cause network issues after the migration.

--- a/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
@@ -4,13 +4,77 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="ref_new-features-and-enhancements-2-12_{context}"]
-= New features and enhancements
+= {project-short} new features and enhancements
 
 [role="_abstract"]
 {project-first} 2.12 introduces the following features and enhancements.
 
+[id="new-features-and-enhancements-2-12-2_{context}"]
+== {project-short} 2.12.2 new features and enhancements
+
+The `targetVMName` variable is available for PVC name templates::
+The `targetVMName` variable is available for the `PVCNameTemplate` configuration. You can configure this template to generate persistent volume claim (PVC) names for virtual machine (VM) disks. As a result, you can include the target VM name in the generated PVC names. For example, you can use `spec.pvcNameTemplate: '{{.TargetVmName}}-disk-{{.DiskIndex}}'`.
++
+link:https://issues.redhat.com/browse/MTV-3445[MTV-3445]
+ 
+CSI volume import is available for copy-offload migrations (Developer Preview)::
+{project-short} introduces a new copy-offload method that uses Container Storage Interface (CSI) driver volume import capabilities. This capability is a Developer Preview feature. This method migrates VMware vSphere Virtual Volumes (vVols) and Raw Device Mapping (RDM) disks only within the same array. Instead of running a dedicated populator pod per disk, {project-short} creates a persistent volume claim (PVC) with vendor-specific import annotations. The CSI driver handles volume provisioning from the existing source volume and manages the volume lifecycle. This enhancement makes migrations safer, reduces configuration requirements, and improves reliability. The user interface does not display a progress bar. It indicates only whether the migration is finished.
++
+This feature requires the following prerequisites:
++
+* The `StorageMap` configuration must include both `vsphereXcopyConfig` and `csiVolumeImport`. In {project-short} 2.12, RDM disks require an XCOPY plugin entry for vendor resolution. You must configure both parameters on the same mapping entry:
++
+[source,yaml,subs="+quotes"]
+----
+spec:
+  map:
+  - destination:
+      storageClass: primera3par
+    offloadPlugin:
+      csiVolumeImport:
+        secretRef: hpe-3par-secret
+        storageVendorProduct: primera3par
+      vsphereXcopyConfig:
+        secretRef: hpe-3par-secret
+        storageVendorProduct: primera3par
+    source:
+      id: __<datastore_id>__
+----
++
+* You must patch the vSphere provider secret to skip SSL verification. The CSI import code currently reads the SSL skip flag from the vSphere provider secret instead of the storage secret. To find your provider secret name, run the following command:
++
+[subs="+quotes"]
+----
+$ oc get provider __<provider_name>__ -o jsonpath='{.spec.secret.name}'
+----
++
+To patch the vSphere provider secret, run the following command:
++
+[subs="+quotes"]
+----
+$ oc patch secret __<vsphere_provider_secret>__ \
+  -p '{"data":{"insecureSkipVerify":"'"$(echo -n true | base64)"'"}}'
+----
++
+link:https://issues.redhat.com/browse/MTV-5483[MTV-5483]
+
+SCSI persistent reservation support is available for shared RDM disk migrations::
+SCSI persistent reservation support is available for shared Raw Device Mapping (RDM) disk migrations. When you enable the `rdmAsLun` parameter, {project-short} automatically configures the `lun.reservation` and `errorPolicy` properties for target virtual machine (VM) disks. As a result, you avoid manual post-migration edits for clustering solutions. This feature also prevents shared disks from being placed on the same node.
++
+link:https://issues.redhat.com/browse/MTV-6049[MTV-6049]
+
+The `xcopyUsed` indicator is available in the plan status::
+The `xcopyUsed` indicator is available in the migration plan status. You can use this indicator to track whether the storage array used XCOPY (hardware-accelerated copy) for each virtual machine (VM) disk. It appears as a task annotation and in the `VSphereXcopyVolumePopulator` custom resource (CR) status. For example, a `task.Annotations["xcopyUsed"]` value of `"1"` indicates that XCOPY was used. As a result, you can debug performance differences and validate the storage array configuration.
++
+link:https://issues.redhat.com/browse/MTV-5871[MTV-5871]
+
+The `--diagnostics` flag is available for the `kubectl-mtv describe plan` command::
+The `--diagnostics` (`-D`) flag is available for the `kubectl-mtv describe plan` command. This flag gathers logs, events, and configuration details into a single diagnostics report. As a result, you avoid manually piecing together information to troubleshoot failed or stuck virtual machine (VM) migrations.
++
+link:https://issues.redhat.com/browse/MTV-6019[MTV-6019], link:https://issues.redhat.com/browse/MTV-6032[MTV-6032]
+
 [id="new-features-and-enhancements-2-12-1_{context}"]
-== {project-short} 2.12.1
+== {project-short} 2.12.1 new features and enhancements
 
 Automatic retry mechanism added for QEMU guest agent installations on Windows systems::
 With this update, {project-short} includes an automatic retry mechanism for QEMU guest agent installations on Windows systems. This mechanism addresses internal Windows issues that cause installation failures. As a result, the guest agent installs more reliably, which ensures a smoother migration experience.
@@ -18,7 +82,7 @@ With this update, {project-short} includes an automatic retry mechanism for QEMU
 link:https://issues.redhat.com/browse/MTV-5782[MTV-5782]
 
 [id="new-features-and-enhancements-2-12-0_{context}"]
-== {project-short} 2.12.0
+== {project-short} 2.12.0 new features and enhancements
 
 {project-short} UI integrates Red Hat OpenShift Lightspeed::
 With this release, the {project-short} UI integrates Red Hat OpenShift Lightspeed. As a virtual infrastructure administrator, you can use free-text queries to generate AI-powered results. You can use this AI integration to quickly find specific answers during complex migrations. This feature also aligns Red Hat OpenShift Lightspeed across the OpenShift console and the UI. As a result, you can troubleshoot migration issues more efficiently.
@@ -151,7 +215,7 @@ Handling of shared disks with the multi-writer attribute set to false::
 +
 link:https://redhat.atlassian.net/browse/MTV-4683[MTV-4683]
 
-Integration with {ocp-name} Lightspeed using an MCP::
+{project-short} integrates with {ocp-name} Lightspeed by using an MCP::
 {project-short} provides a Model Context Protocol (MCP) to integrate with {ocp} Lightspeed. This enhancement is implemented to connect {project-short} capabilities with the {ocp-name} Lightspeed interface. As a result, you can interact with {project-short} directly through {ocp-name} Lightspeed.
 +
 link:https://redhat.atlassian.net/browse/MTV-4455[MTV-4455]

--- a/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
@@ -17,46 +17,6 @@ The `targetVMName` variable is available for the `PVCNameTemplate` configuration
 +
 link:https://issues.redhat.com/browse/MTV-3445[MTV-3445]
  
-CSI volume import is available for copy-offload migrations (Developer Preview)::
-{project-short} introduces a new copy-offload method that uses Container Storage Interface (CSI) driver volume import capabilities. This capability is a Developer Preview feature. This method migrates VMware vSphere Virtual Volumes (vVols) and Raw Device Mapping (RDM) disks only within the same array. Instead of running a dedicated populator pod per disk, {project-short} creates a persistent volume claim (PVC) with vendor-specific import annotations. The CSI driver handles volume provisioning from the existing source volume and manages the volume lifecycle. This enhancement makes migrations safer, reduces configuration requirements, and improves reliability. The user interface does not display a progress bar. It indicates only whether the migration is finished.
-+
-This feature requires the following prerequisites:
-+
-* The `StorageMap` configuration must include both `vsphereXcopyConfig` and `csiVolumeImport`. In {project-short} 2.12, RDM disks require an XCOPY plugin entry for vendor resolution. You must configure both parameters on the same mapping entry:
-+
-[source,yaml,subs="+quotes"]
-----
-spec:
-  map:
-  - destination:
-      storageClass: primera3par
-    offloadPlugin:
-      csiVolumeImport:
-        secretRef: hpe-3par-secret
-        storageVendorProduct: primera3par
-      vsphereXcopyConfig:
-        secretRef: hpe-3par-secret
-        storageVendorProduct: primera3par
-    source:
-      id: __<datastore_id>__
-----
-+
-* You must patch the vSphere provider secret to skip SSL verification. The CSI import code currently reads the SSL skip flag from the vSphere provider secret instead of the storage secret. To find your provider secret name, run the following command:
-+
-[subs="+quotes"]
-----
-$ oc get provider __<provider_name>__ -o jsonpath='{.spec.secret.name}'
-----
-+
-To patch the vSphere provider secret, run the following command:
-+
-[subs="+quotes"]
-----
-$ oc patch secret __<vsphere_provider_secret>__ \
-  -p '{"data":{"insecureSkipVerify":"'"$(echo -n true | base64)"'"}}'
-----
-+
-link:https://issues.redhat.com/browse/MTV-5483[MTV-5483]
 
 SCSI persistent reservation support is available for shared RDM disk migrations::
 SCSI persistent reservation support is available for shared Raw Device Mapping (RDM) disk migrations. When you enable the `rdmAsLun` parameter, {project-short} automatically configures the `lun.reservation` and `errorPolicy` properties for target virtual machine (VM) disks. As a result, you avoid manual post-migration edits for clustering solutions. This feature also prevents shared disks from being placed on the same node.

--- a/documentation/modules/ref_resolved-issues-2-12-0.adoc
+++ b/documentation/modules/ref_resolved-issues-2-12-0.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="ref_resolved-issues-2-12-0_{context}"]
-= Resolved issues 2.12.0
+= {project-short} fixed issues 2.12.0
 
 [role="_abstract"]
-Review the resolved issues in this release of {project-short}.
+Review the fixed issues in this release of {project-short}.
 
 Deleted migration plans no longer leave orphaned PVCs::
 Before this update, the cleanup process removed only populator pods. It left the original and prime persistent volume claims (PVCs) in the cluster. As a consequence, these orphaned PVCs remained after you archived and deleted a migration plan. With this release, the cleanup process is updated to handle all associated storage resources. As a result, archiving and deleting a migration plan automatically removes the original and prime PVCs. They no longer remain in the cluster.

--- a/documentation/modules/ref_resolved-issues-2-12-1.adoc
+++ b/documentation/modules/ref_resolved-issues-2-12-1.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="ref_resolved-issues-2-12-1_{context}"]
-= Resolved issues 2.12.1
+= {project-short} fixed issues 2.12.1
 
 [role="_abstract"]
-Review the resolved issues in this release of {project-short}.
+Review the fixed issues in this release of {project-short}.
 
 Correct handling of shared disks in {project-short} when multi-writer is set to false::
 Before this update, MTV incorrectly handled shared disks with `multi-writer` set to `false` as individual disks. As a consequence, the system incorrectly treated user data on multiple shared disks, and potentially caused data inconsistency. With this update, shared disks with `multi-writer` set to `false` behave as if the setting is `true`. As a result, the system handles shared disks correctly and maintains data consistency.

--- a/documentation/modules/ref_resolved-issues-2-12-2.adoc
+++ b/documentation/modules/ref_resolved-issues-2-12-2.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Release_notes/master.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ref_resolved-issues-2-12-2_{context}"]
+= {project-short} fixed issues 2.12.2
+
+[role="_abstract"]
+Review the fixed issues in this release of {project-short}.
+
+Server certificates validated against user-provided CA certificates::
+Before this update, the vSphere provider did not validate the server certificate against the user-provided certificate authority (CA) certificate. As a consequence, the provider accepted any valid Privacy-Enhanced Mail (PEM) content and bypassed actual certificate verification. With this update, the vSphere provider properly validates the vCenter server certificate against the user-provided CA certificate. As a result, the provider fails with a `ConnectionTestFailed` condition if the trust chain is broken.
++
+link:https://issues.redhat.com/browse/MTV-5636[MTV-5636]
+
+You can run preflight inspections on NBDE VMs::
+Before this update, the Deep Inspection (DI) pod for a Network-Bound Disk Encryption (NBDE) virtual machine could not reach the Tang server. As a consequence, the preflight inspection failed, and the migration plan failed. With this update, the DI pod successfully connects to the Tang server. As a result, you can run the default preflight inspection on virtual machines that have NBDE enabled.
++
+link:https://redhat.atlassian.net/browse/MTV-5750[MTV-5750]
+
+Shared disks successfully accessed after virtual machine migrations::
+Before this update, a virtual machine (VM) with `migrateSharedDisks` set to `false` attached to a shared persistent volume claim (PVC) prematurely. As a consequence, the shared disk appeared connected but was inaccessible to that VM. With this update, the VM waits in the scheduler queue until the other VM completes its migration. As a result, all data is fully written, and both VMs can access the shared PVC successfully.
++
+link:https://issues.redhat.com/browse/MTV-5883[MTV-5883]
+
+Continuous authentication retry attempts prevented on Hyper-V hosts::
+Before this update, the Hyper-V provider repeatedly retried failed connections when WinRM Basic authentication was disabled. As a consequence, the continuous connection attempts overloaded the Hyper-V host. With this update, the provider detects the authentication failure, sets the `ConnectionAuthFailed` condition, and stops reconciliation. As a result, the provider properly surfaces the failure and does not overload the host.
++
+link:https://issues.redhat.com/browse/MTV-5829[MTV-5829]
+
+You can set storage copy offload parameters after storage map creation::
+Before this update, you could not set storage copy offload parameters after you created and saved a storage map. As a consequence, you could not use an existing map for storage copy offload migrations. With this update, you can specify these parameters on a *Storage map* page after you save the map. As a result, you can successfully update existing storage maps for these migrations.
++
+link:https://issues.redhat.com/browse/MTV-5900[MTV-5900]
+
+Storage copy offload migrations on IBM FlashSystem no longer fail when vdisk protection is disabled at the pool level::
+Before this update, the copy-offload populator validated only the system-level vdisk protection settings for IBM FlashSystem storage. As a consequence, storage copy offload migrations failed if vdisk protection was enabled at the system level, even if it was disabled for the specific child pools in use. With this update, the validation process checks the vdisk protection settings at the pool level. As a result, storage copy offload migrations succeed when vdisk protection is disabled for the specific child pools, regardless of the system-level configuration.
++
+link:https://redhat.atlassian.net/browse/MTV-6038[MTV-6038]
+
+Plan reconciliation time no longer increases during concurrent migrations::
+Before this update, the scheduler queried the inventory service individually for every running virtual machine (VM). As a consequence, high latency in inventory GET calls caused mutex contention and delayed concurrent migrations. With this update, the inventory application programming interface (API) is optimized to reduce database loads. As a result, the scheduler processes concurrent migrations without significant delays in plan reconciliation time.
++
+link:https://issues.redhat.com/browse/MTV-6052[MTV-6052]

--- a/documentation/modules/ref_rn-2-12.adoc
+++ b/documentation/modules/ref_rn-2-12.adoc
@@ -7,4 +7,4 @@
 = {project-full} 2.12
 
 [role="_abstract"]
-The release notes describe technical changes, new features and enhancements, known issues, and resolved issues.
+The release notes describe technical changes, new features and enhancements, known issues, and fixed issues.

--- a/documentation/modules/ref_rn-resolved-issues.adoc
+++ b/documentation/modules/ref_rn-resolved-issues.adoc
@@ -4,8 +4,8 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="ref_rn-resolved-issues_{context}"]
-= Resolved issues
+= {project-short} fixed issues
 
 [role="_abstract"]
-{project-first} {project-version} has the following resolved issues.
+{project-first} {project-version} has the following fixed issues.
 


### PR DESCRIPTION
MTV 2.12.2

Resolves https://redhat.atlassian.net/browse/MTV-5921 by adding release notes and attributes for MTV 2.12.2.

Previews:

- https://forklift-documentation-git-fork-ri-9c6056-yaacov-8047s-projects.vercel.app/downstream/documentation/doc-Release_notes/master.html#new-features-and-enhancements-2-12-2_release-notes
- https://forklift-documentation-git-fork-ri-9c6056-yaacov-8047s-projects.vercel.app/downstream/documentation/doc-Release_notes/master.html#ref_resolved-issues-2-12-2_release-notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documented CSI volume import for copy-offload migrations (Developer Preview).
  * Added `--diagnostics`/`-D` option for `kubectl-mtv describe plan`.
  * Documented `targetVMName` support in `PVCNameTemplate`.
  * Documented SCSI persistent reservation support for shared RDM migrations.
  * Documented `xcopyUsed` in migration plan status/task annotations.
  * Documented configuring copy-offload parameters via the Storage map UI.

* **Bug Fixes**
  * vSphere now validates server certs against user-supplied CA certificates.
  * NBDE preflight can reach the Tang server.
  * Correct shared-disk access after migrations when `migrateSharedDisks` is `false`.
  * Hyper-V stops continuous reconciliation retries when WinRM basic authentication fails.

* **Documentation**
  * Updated release-notes wording (“Resolved” → “Fixed”) and added the 2.12.2 resolved-issues include.
  * Updated known-issues section header and removed an outdated entry/workaround.
  * Updated `{project-z-version}` to 2.12.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->