### PR TITLE
MTV-5745 & MTV-5744: Typos and grammar errors

### DIFF
--- a/documentation/modules/con_about-network-maps.adoc
+++ b/documentation/modules/con_about-network-maps.adoc
@@ -15,7 +15,7 @@ Plan-specific maps are owned by that plan. You can create this kind of map in th
 
 Ownerless maps::
 
-Maps created for use by any migration plan are to said to be _ownerless_. You can create this kind of map in the *Network maps* page of the *Migration for Virtualization* section of the {virt} web console.
+Maps created for use by any migration plan are said to be _ownerless_. You can create this kind of map in the *Network maps* page of the *Migration for Virtualization* section of the {virt} web console.
 +
 You, or anyone working in the same project, can use ownerless maps when creating a migration plan in the *Plan creation wizard*. When you choose one of these unowned maps for a migration plan, {project-short} creates a copy of the map and defines your migration plan as the _owner of that copy_. Any changes you make to the copy do not affect the original map, nor do they apply to any other plan that uses a copy of the map.
 

--- a/documentation/modules/con_about-storage-maps.adoc
+++ b/documentation/modules/con_about-storage-maps.adoc
@@ -15,7 +15,7 @@ Plan-specific maps are owned by that plan. You can create these kinds of maps in
 
 Ownerless maps::
 
-Maps created for use by any migration plan are to said to be _ownerless_. You can create this kind of map in the *Storage maps* page of the *Migration for Virtualization* section of the {virt} web console.
+Maps created for use by any migration plan are said to be _ownerless_. You can create this kind of map in the *Storage maps* page of the *Migration for Virtualization* section of the {virt} web console.
 +
 You, or anyone working in the same project, can use ownerless maps when creating a migration plan in the *Plan creation wizard*. When you choose one of these unowned maps for a migration plan, {project-short} creates a copy of the map and defines your migration plan as the _owner of that copy_. Any changes you make to the copy do not affect the original map, nor do they apply to any other plan that uses a copy of the map.
 

--- a/documentation/modules/con_cold-migration.adoc
+++ b/documentation/modules/con_cold-migration.adoc
@@ -13,7 +13,7 @@ Cold migration converts each VM to be compatible with {ocp-short} before transfe
 
 [NOTE]
 ====
-VMware only: In cold migrations, In cold migrations, in situations in which a package manager cannot be used during the migration, {project-short} does not install the `qemu-guest-agent` daemon on the migrated VMs. This has some impact on the functionality of the migrated VMs, butS basic VM operations remain supported.
+VMware only: In cold migrations, in situations in which a package manager cannot be used during the migration, {project-short} does not install the `qemu-guest-agent` daemon on the migrated VMs. This has some impact on the functionality of the migrated VMs, but basic VM operations remain supported.
 
 To enable {project-short} to automatically install `qemu-guest-agent` on the migrated VMs, ensure that your package manager can install the daemon during the first boot of the VM after migration.
 

--- a/documentation/modules/con_non-admin-permissions.adoc
+++ b/documentation/modules/con_non-admin-permissions.adoc
@@ -41,7 +41,7 @@ As a more comprehensive example, you can grant non-administrators the following 
 * Not be able to create providers or to change system settings
 
 [cols="3", options="header"]
-.Example permissions required for non-adminstrators to work with migration plan components but not create providers
+.Example permissions required for non-administrators to work with migration plan components but not create providers
 |===
 |Actions |API group |Resource
 

--- a/documentation/modules/con_target-vm-scheduling-options.adoc
+++ b/documentation/modules/con_target-vm-scheduling-options.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 You can use the following options to schedule when your target VMs are powered on:
 
-* *Node Selector* rule: This is both the simplest rule. You define a set of mandatory exact match key-value label pairs that the target node must possess. If no node on the cluster has all the labels specified, the VM is not scheduled and it remains in a `Pending` state until there is space on a node that fits the key-value label pairs.
+* *Node Selector* rule: This is the simplest rule. You define a set of mandatory exact match key-value label pairs that the target node must possess. If no node on the cluster has all the labels specified, the VM is not scheduled and it remains in a `Pending` state until there is space on a node that fits the key-value label pairs.
 
 * *Affinity and Anti-Affinity* rules: _Node Affinity_ rules let you schedule VMs to run on selected nodes or workloads (pods). _Node Anti-affinity_ rules let you prevent VMs from being scheduled to run on selected workloads (pods).
 +

--- a/documentation/modules/con_warm-migration-stages-precopy.adoc
+++ b/documentation/modules/con_warm-migration-stages-precopy.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 The VMs are not shut down during the precopy stage.
 
-The VM disks are copied incrementally by using changed block tracking (CBT) snapshots. The snapshots are created at one-hour intervals by default. You can change the snapshot interval by updating the `forklift-controller` deployment.For more information about CBT snapshots, see the "Additional resources" section.
+The VM disks are copied incrementally by using changed block tracking (CBT) snapshots. The snapshots are created at one-hour intervals by default. You can change the snapshot interval by updating the `forklift-controller` deployment. For more information about CBT snapshots, see the "Additional resources" section.
 
 A VM can support up to 28 CBT snapshots. If the source VM has too many CBT snapshots and the `Migration Controller` service is not able to create a new snapshot, warm migration might fail. The `Migration Controller` service deletes each snapshot when the snapshot is no longer required.
 

--- a/documentation/modules/proc_migrating-vms-cli-vmware.adoc
+++ b/documentation/modules/proc_migrating-vms-cli-vmware.adoc
@@ -30,7 +30,7 @@ kind: Secret
 metadata:
   name: <secret>
   namespace: <namespace>
-  ownerReferences: 
+  ownerReferences:
     - apiVersion: forklift.konveyor.io/v1beta1
       kind: Provider
       name: <provider_name>
@@ -41,7 +41,7 @@ metadata:
 type: Opaque
 stringData:
   user: <user>
-  password: <password> 
+  password: <password>
   insecureSkipVerify: <"true"/"false">
   cacert: |
     <ca_certificate>
@@ -159,7 +159,7 @@ spec:
     - destination:
         name: <network_name>
         type: pod
-      source: 
+      source:
         id: <source_network_id>
         name: <source_network_name>
     - destination:
@@ -214,7 +214,7 @@ spec:
     - destination:
         storageClass: <storage_class>
         accessMode: <access_mode>
-      offloadPlugin: 
+      offloadPlugin:
         vsphereXcopyConfig:
           secretRef: <Secret_for_the_storage_vendor_product>
           storageVendorProduct: <storage_vendor_product>
@@ -357,22 +357,22 @@ spec:
     destination:
       name: <destination_provider>
       namespace: <namespace>
-  map: 
-    network: 
+  map:
+    network:
       name: <network_map>
       namespace: <namespace>
-    storage: 
+    storage:
       name: <storage_map>
       namespace: <namespace>
-  preserveStaticIPs: 
+  preserveStaticIPs:
   networkNameTemplate: <network_interface_template>
   pvcNameTemplate: <pvc_name_template>
   pvcNameTemplateUseGenerateName: true
   skipGuestConversion: false
-  targetAffinity: <target_affinity_rule> 
-  targetLabels: 
-    label: <label> 
-  targetNodeSelector: 
+  targetAffinity: <target_affinity_rule>
+  targetLabels:
+    label: <label>
+  targetNodeSelector:
     <key>:<value>
   targetNamespace: <target_namespace>
   convertorLabels: <importer_converter_labels>
@@ -380,14 +380,14 @@ spec:
   convertorAffinity<importer_affinity_rule>
   useCompatibilityMode: true
   volumeNameTemplate: <volume_name_template>
-  vms: 
+  vms:
     - id: <source_vm1>
     - name: <source_vm2>
       networkNameTemplate: <network_interface_template_for_this_vm>
       pvcNameTemplate: <pvc_name_template_for_this_vm>
       volumeNameTemplate: <volume_name_template_for_this_vm>
       targetName: <target_name>
-      hooks: 
+      hooks:
         - hook:
             namespace: <namespace>
             name: <hook>
@@ -423,7 +423,7 @@ Specifies a storage mapping even if the VMs to be migrated are not assigned with
 Specifies the name of the `StorageMap` CR.
 
 `preserveStaticIPs`::
-Specifies wheteher to prerserve static IP addresses. By default, virtual network interface controllers (vNICs) change during the migration process. As a result, vNICs that are configured with a static IP address linked to the interface name in the guest VM lose their IP address.
+Specifies whether to preserve static IP addresses. By default, virtual network interface controllers (vNICs) change during the migration process. As a result, vNICs that are configured with a static IP address linked to the interface name in the guest VM lose their IP address.
 To avoid this, set `preserveStaticIPs` to `true`. {project-short} issues a warning message about any VMs for which vNIC properties are missing. To retrieve any missing vNIC properties, run those VMs in vSphere in order for the vNIC properties to be reported to {project-short}.
 
 `networkNameTemplate`::
@@ -472,7 +472,7 @@ To ensure proper system functionality, system-managed labels override any user-d
 +
 For more details on labels and selectors in Kubernetes, see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#labels[Labels and Selectors].
 +
-`convertorLabels`, `convertorNodeSelector`, and `convertorAffinity` are fields that support scheduling the `virt-v2v` conversion pod (importer pod) for cold migrations from {vmw} providers. With this feature, you can set the `convertorLabels`, `convertorNodeSelector`, and `convertorAffinity` that control the labels, `noteSelector`, and `Affinity` of the convertor pod.
+`convertorLabels`, `convertorNodeSelector`, and `convertorAffinity` are fields that support scheduling the `virt-v2v` conversion pod (importer pod) for cold migrations from {vmw} providers. With this feature, you can set the `convertorLabels`, `convertorNodeSelector`, and `convertorAffinity` that control the labels, `nodeSelector`, and `Affinity` of the convertor pod.
 +
 For more information on importer files, see {mtv-plan}assembly_planning-migration-vmware#con_about-configuring-importer-pods_vmware[About scheduling importer pods].
 
@@ -482,7 +482,7 @@ Cold migrations only: Specifies the key-value pairs that must be matched for dat
 For more details on node selectors in Kubernetes, see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector[nodeSelector].
 
 `convertorAffinity`::
-Cold migrations only: Specifies a hard-affinity or a soft-affinity rule for `virt-v2v` convertor pods (importer pods). This is an optional field. Affinity rules can be used to optimize placement for disk conversion performance, such as co-locating with storage or ensuring network proximity to {vmw} infrastructure for cold migration data transfers.  
+Cold migrations only: Specifies a hard-affinity or a soft-affinity rule for `virt-v2v` convertor pods (importer pods). This is an optional field. Affinity rules can be used to optimize placement for disk conversion performance, such as co-locating with storage or ensuring network proximity to {vmw} infrastructure for cold migration data transfers.
 +
 For more information on affinity rules in Kubernetes, see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity[Affinity and anti-affinity].
 
@@ -555,7 +555,7 @@ If you specify a cutover time, use the ISO 8601 format with the UTC time offset,
 +
 [IMPORTANT]
 ====
-When you specify the user permissions only on the VM, the `forklift-controller` consistently fails to reconcile a migration plan, and subsequently returns an HTTP 500 error. 
+When you specify the user permissions only on the VM, the `forklift-controller` consistently fails to reconcile a migration plan, and subsequently returns an HTTP 500 error.
 
 In {project-short}, you must add permissions at the data center level, which includes storage, networks, switches, and so on, which are used by the VM. You must then propagate the permissions to the child elements.
 

--- a/documentation/modules/ref_vddk-validator-containers.adoc
+++ b/documentation/modules/ref_vddk-validator-containers.adoc
@@ -13,7 +13,7 @@ You can see the defaults, which you can override in the `ForkliftController` cus
 
 These settings are highly dependent on your environment. If there are many migrations happening at once and the quotas are not set enough for the migrations, then the migrations can fail. This can also be correlated to the `MAX_VM_INFLIGHT` setting that determines how many VMs/disks are migrated at once.
 
-The following defaults can be overriden in the `ForkliftController` CR:
+The following defaults can be overridden in the `ForkliftController` CR:
 
 * Defaults that affect both cold and warm migrations:
 +


### PR DESCRIPTION
## JIRA

* https://redhat.atlassian.net/browse/MTV-5744
* https://redhat.atlassian.net/browse/MTV-5745

## Description

* Fixing typos and grammar errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected several wording, spelling, and grammar issues across migration and networking documentation.
  * Improved clarity in descriptions of ownerless maps, cold migration notes, scheduling rules, and permissions guidance.
  * Cleaned up CLI procedure examples and YAML snippet formatting for better readability.
  * Fixed a few minor typos and spacing issues in reference and stage documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->