### PR TITLE
DOCPLAN-400: Convert ifeval to ifdef for DITA compatibility

### DIFF
--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -45,6 +45,7 @@
 // doc metadata
 :icons: font
 :build: downstream
+:downstream:
 :toc: macro
 :experimental:
 :keywords: migration, VMware, OpenShift Virtualization, KubeVirt, migrating, virtual machines, OpenShift, Red Hat Virtualization, RHV

--- a/documentation/modules/proc_installing-mtv-operator.adoc
+++ b/documentation/modules/proc_installing-mtv-operator.adoc
@@ -28,7 +28,7 @@ endif::[]
 ifdef::web[]
 . In the {ocp} web console, click *Operators* -> *OperatorHub*.
 . Use the *Filter by keyword* field to search for *{operator}*.
-ifeval::["{build}" == "upstream"]
+ifdef::upstream[]
 +
 [NOTE]
 ====
@@ -76,7 +76,7 @@ EOF
 ----
 
 . Create a `Subscription` CR for the Operator:
-ifeval::["{build}" == "upstream"]
+ifdef::upstream[]
 +
 [source,terminal,subs="attributes+"]
 ----
@@ -96,7 +96,7 @@ spec:
 EOF
 ----
 endif::[]
-ifeval::["{build}" == "downstream"]
+ifdef::downstream[]
 +
 [source,terminal,subs="attributes+"]
 ----

--- a/documentation/modules/proc_upgrading-mtv-ui.adoc
+++ b/documentation/modules/proc_upgrading-mtv-ui.adoc
@@ -14,10 +14,10 @@ You can upgrade the {operator-name} by using the {ocp} web console to install th
 
 . Change the update channel to the correct release.
 +
-ifeval::["{build}" == "upstream"]
+ifdef::upstream[]
 See link:https://docs.okd.io/latest/operators/admin/olm-upgrading-operators.html#olm-changing-update-channel_olm-upgrading-operators[Changing update channel] in the {ocp} documentation.
 endif::[]
-ifeval::["{build}" == "downstream"]
+ifdef::downstream[]
 See {ocp-doc}/operators/administrator-tasks#olm-changing-update-channel_olm-upgrading-operators[Changing the update channel for an Operator] in the {ocp} documentation.
 endif::[]
 
@@ -44,10 +44,10 @@ If you set *Update approval* on the *Subscriptions* tab to *Automatic*, the upgr
 +
 . If you set *Update approval* on the *Subscriptions* tab to *Manual*, approve the upgrade.
 +
-ifeval::["{build}" == "upstream"]
+ifdef::upstream[]
 See link:https://docs.okd.io/latest/operators/admin/olm-upgrading-operators.html#olm-approving-pending-upgrade_olm-upgrading-operators[Manually approving a pending upgrade] in the {ocp} documentation.
 endif::[]
-ifeval::["{build}" == "downstream"]
+ifdef::downstream[]
 See {ocp-doc}/operators/administrator-tasks#olm-approving-pending-upgrade_olm-upgrading-operators[Manually approving a pending Operator upgrade] in the {ocp} documentation.
 endif::[]
 

--- a/documentation/upstream-attributes.adoc
+++ b/documentation/upstream-attributes.adoc
@@ -47,6 +47,7 @@
 
 // Build type
 :build: upstream
+:upstream:
 
 // TOC configuration — produces a fixed left sidebar TOC
 :toc: left


### PR DESCRIPTION
**Version(s):**
NA

**Issue:**
https://issues.redhat.com/browse/DOCPLAN-400

**Link to docs preview:**
- https://danielclowers.github.io/forklift-documentation-preview/docplan-400/planning-guide.html
- https://danielclowers.github.io/forklift-documentation-preview/docplan-400/migration-guide.html
- https://forklift-documentation-git-fork-da-0c7956-yaacov-8047s-projects.vercel.app/downstream/documentation/doc-Planning_your_migration/master.html
- https://forklift-documentation-git-fork-da-0c7956-yaacov-8047s-projects.vercel.app/downstream/documentation/doc-Migrating_your_virtual_machines/master.html

**QE review:**
- [ ] QE has approved this change.

**Additional information:**
Converts `ifeval::["{build}" == "value"]` to `ifdef::value[]` for DITA compatibility. Adds `:upstream:` and `:downstream:` standalone attributes following existing conditional patterns (`ifdef::web[]`, `ifdef::vmware[]`, etc.). Addresses 7 ConditionalCode warnings flagged by Vale AsciiDocDITA rules as part of CQA 2.0 pre-migration review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added build-specific documentation flags for upstream and downstream content.
  * Documentation now shows the appropriate installation and upgrade guidance based on the selected build path.

* **Bug Fixes**
  * Improved conditional content handling so operator install details and upgrade links display the correct environment-specific information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->