### PR TITLE
MTV-6062: replacing the problematic olm_level with controller_log_level

### DIFF
--- a/documentation/modules/proc_installing-mtv-operator.adoc
+++ b/documentation/modules/proc_installing-mtv-operator.adoc
@@ -7,13 +7,13 @@
 ifdef::web[]
 = Installing the {operator-name} by using the {ocp} web console
 
-[role="_abstract"] 
+[role="_abstract"]
 You can install the {operator-name} by using the {ocp} web console.
 endif::[]
 ifdef::cli[]
 = Installing the {operator-name} by using the command-line interface
 
-[role="_abstract"] 
+[role="_abstract"]
 You can install the {operator-name} by using the command-line interface (CLI).
 endif::[]
 
@@ -122,13 +122,12 @@ endif::[]
 [source,terminal,subs="attributes+"]
 ----
 $ cat << EOF | {oc} apply -f -
-apiVersion: forklift.konveyor.io/v1beta1
 kind: ForkliftController
 metadata:
   name: forklift-controller
-  namespace: {namespace}
+  namespace: openshift-mtv
 spec:
-  olm_managed: true
+  controller_log_level: 3
 EOF
 ----
 

--- a/documentation/modules/proc_installing-mtv-operator.adoc
+++ b/documentation/modules/proc_installing-mtv-operator.adoc
@@ -122,12 +122,15 @@ endif::[]
 [source,terminal,subs="attributes+"]
 ----
 $ cat << EOF | {oc} apply -f -
+apiVersion: forklift.konveyor.io/v1beta1
 kind: ForkliftController
 metadata:
   name: forklift-controller
   namespace: openshift-mtv
-spec:
-  controller_log_level: 3
+spec":
+  feature_ui_plugin: true
+  feature_validation: true
+  feature_volume_populator: true
 EOF
 ----
 

--- a/documentation/modules/proc_installing-mtv-operator.adoc
+++ b/documentation/modules/proc_installing-mtv-operator.adoc
@@ -127,7 +127,7 @@ kind: ForkliftController
 metadata:
   name: forklift-controller
   namespace: openshift-mtv
-spec":
+spec:
   feature_ui_plugin: true
   feature_validation: true
   feature_volume_populator: true


### PR DESCRIPTION
## JIRA

* [MTV-6062](https://redhat.atlassian.net/browse/MTV-6062)

---

## Description

we have an old documentation bug (5y) in:
[ https://github.com/kubev2v/forklift-documentation/blob/main/documentation/modules/proc_installing-mtv-operator.adoc?plain=1#L124 ](https://github.com/kubev2v/forklift-documentation/blob/main/documentation/modules/proc_installing-mtv-operator.adoc?plain=1#L124)

where we give a wrong example yaml:
```
apiVersion: [forklift.konveyor.io/v1beta1](http://forklift.konveyor.io/v1beta1)
kind: ForkliftController
metadata:
  name: forklift-controller
  namespace: {namespace}
spec:
  olm_managed: true
```

A better example to use can be found in our code docs:
[ https://github.com/kubev2v/forklift/blob/main/docs/compatibility/forkliftcontroller-settings.md?plain=1#L16 ](https://github.com/kubev2v/forklift/blob/main/docs/compatibility/forkliftcontroller-settings.md?plain=1#L16)
for this specific fix, I suggest a simple example:

```
kind: ForkliftController
metadata:
  name: forklift-controller
  namespace: openshift-mtv
spec:
  controller_log_level: 3
```

replacing the problematic olm_level with controller_log_level that can do little harm, and it's default value is 3, so we don't change any settings by this example.

---

## PREVIEW

* [Installing and configuring the MTV Operator
](https://forklift-documentation-git-fork-an-e624f5-yaacov-8047s-projects.vercel.app/downstream/documentation/doc-Planning_your_migration/master.html#assembly_installing-mtv-operator_mtv)


[MTV-6062]: https://redhat.atlassian.net/browse/MTV-6062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ