### PR TITLE
Fixing link formatting

### DIFF
--- a/documentation/modules/con_about-self-service-tsr.adoc
+++ b/documentation/modules/con_about-self-service-tsr.adoc
@@ -45,5 +45,4 @@ The self-service TSR provides a solid baseline for cluster health. If you need a
 
 * link:https://access.redhat.com/support/cases/#/analyze[Technical Supportability Review with AI tool]
 * link:https://access.redhat.com/solutions/7141255[Red{nbsp}Hat Technical Supportability Review with AI: Proactive AI-Driven Cluster Assessments for {ocp}]
-* link:{ocp-doc}/support/gathering-cluster-data[Gathering data about your cluster] 
-
+* {ocp-doc}/support/gathering-cluster-data[Gathering data about your cluster]


### PR DESCRIPTION
Attribute already contains `link:` so generating formatting error
```
* link::ocp-doc: link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html-single
```