### PR TITLE
MTV 2.12.6 Attributes and release notes

### DIFF
--- a/documentation/doc-Release_notes/master.adoc
+++ b/documentation/doc-Release_notes/master.adoc
@@ -23,6 +23,8 @@ include::modules/ref_new-features-and-enhancements-2-12.adoc[leveloffset=+2]
 include::modules/ref_rn-resolved-issues.adoc[leveloffset=+2]
 
 // Resolved issues by z-stream release. Most recent release goes first in the list.
+include::modules/ref_resolved-issues-2-12-6.adoc[leveloffset=+3]
+
 include::modules/ref_resolved-issues-2-12-5.adoc[leveloffset=+3]
 
 include::modules/ref_resolved-issues-2-12-4.adoc[leveloffset=+3]

--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -26,7 +26,7 @@
 :project-version: 2.12
 :mtv-plan: https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/{project-version}/html/planning_your_migration_to_red_hat_openshift_virtualization/
 :mtv-mig: https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/{project-version}/html/migrating_your_virtual_machines_to_red_hat_openshift_virtualization/
-:project-z-version: 2.12.5
+:project-z-version: 2.12.6
 :rhel-first: Red Hat Enterprise Linux (RHEL)
 :virt: OpenShift Virtualization
 :must-gather-image: registry.redhat.io/migration-toolkit-virtualization/mtv-must-gather-rhel8:{project-z-version}

--- a/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
@@ -29,7 +29,7 @@ link:https://redhat.atlassian.net/browse/MTV-6365[MTV-6365]
 == {project-short} 2.12.4 new features and enhancements
 
 CSI volume import is available for copy-offload migrations (Developer Preview)::
-With this update, {project-short} introduces a new copy-offload method that uses Container Storage Interface (CSI) driver volume import capabilities. This method migrates {vmw} vSphere Virtual Volumes (vVols) and Raw Device Mapping (RDM) disks within the same array, without running a dedicated populator pod per disk. This capability is a Developer Preview feature.
+With this update, {project-short} introduces a new copy-offload method that uses Container Storage Interface (CSI) driver volume import capabilities. This method migrates {vmw} vSphere Virtual Volumes (vVols) and Raw Device Mapping (RDM) disks within the same array, without running a dedicated populator pod per disk. The {project-short} UI does not display a progress bar for this method and indicates only whether the migration is complete. This capability is a Developer Preview feature.
 +
 link:https://issues.redhat.com/browse/MTV-5483[MTV-5483]
 

--- a/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
@@ -25,6 +25,14 @@ With this update, {project-short} propagates the `xcopyUsed` indicator from the 
 +
 link:https://redhat.atlassian.net/browse/MTV-6365[MTV-6365]
 
+[id="new-features-and-enhancements-2-12-4_{context}"]
+== {project-short} 2.12.4 new features and enhancements
+
+CSI volume import is available for copy-offload migrations (Developer Preview)::
+With this update, {project-short} introduces a new copy-offload method that uses Container Storage Interface (CSI) driver volume import capabilities. This method migrates {vmw} vSphere Virtual Volumes (vVols) and Raw Device Mapping (RDM) disks within the same array, without running a dedicated populator pod per disk. This capability is a Developer Preview feature.
++
+link:https://issues.redhat.com/browse/MTV-5483[MTV-5483]
+
 [id="new-features-and-enhancements-2-12-3_{context}"]
 == {project-short} 2.12.3 new features and enhancements
 

--- a/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
@@ -25,14 +25,6 @@ With this update, {project-short} propagates the `xcopyUsed` indicator from the 
 +
 link:https://redhat.atlassian.net/browse/MTV-6365[MTV-6365]
 
-[id="new-features-and-enhancements-2-12-4_{context}"]
-== {project-short} 2.12.4 new features and enhancements
-
-CSI volume import is available for copy-offload migrations (Developer Preview)::
-With this update, {project-short} introduces a new copy-offload method that uses Container Storage Interface (CSI) driver volume import capabilities. This method migrates {vmw} vSphere Virtual Volumes (vVols) and Raw Device Mapping (RDM) disks within the same array, without running a dedicated populator pod per disk. The {project-short} UI does not display a progress bar for this method and indicates only whether the migration is complete. This capability is a Developer Preview feature.
-+
-link:https://issues.redhat.com/browse/MTV-5483[MTV-5483]
-
 [id="new-features-and-enhancements-2-12-3_{context}"]
 == {project-short} 2.12.3 new features and enhancements
 
@@ -53,6 +45,11 @@ For more information, see link:https://access.redhat.com/support/cases/#/analyze
 
 [id="new-features-and-enhancements-2-12-2_{context}"]
 == {project-short} 2.12.2 new features and enhancements
+
+CSI volume import is available for copy-offload migrations (Developer Preview)::
+With this update, {project-short} introduces a new copy-offload method that uses Container Storage Interface (CSI) driver volume import capabilities. This method migrates {vmw} vSphere Virtual Volumes (vVols) and Raw Device Mapping (RDM) disks within the same array, without running a dedicated populator pod per disk. The {project-short} UI does not display a progress bar for this method and indicates only whether the migration is complete. This capability is a Developer Preview feature.
++
+link:https://issues.redhat.com/browse/MTV-5483[MTV-5483]
 
 Configurable SCSI reservations for shared RDM disks::
 The `scsiReservation` variable is available to enable or disable reservations on demand for shared Raw Device Mapping (RDM) disks. This variable is disabled by default. You can configure this setting per migration plan for all virtual machines (VMs), and a per-VM override is also available. This enhancement prevents issues that occur when a reservation is not desired or supported for a given workload. As a result, you have explicit control over whether SCSI reservations are enabled for shared RDM disks, which prevents unintended reservation behavior and allows fine-grained configuration per workload.

--- a/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
@@ -9,14 +9,6 @@
 [role="_abstract"]
 {project-first} 2.12 introduces the following features and enhancements.
 
-[id="new-features-and-enhancements-2-12-6_{context}"]
-== {project-short} 2.12.6 new features and enhancements
-
-{project-short} automatically removes {vmw} drivers and tools during migration::
-With this update, {project-short} automatically removes {vmw}-specific drivers and tools from virtual machines (VMs) during migration. As a result, migrated VMs do not require manual cleanup of {vmw}-specific components after migration.
-+
-link:https://redhat.atlassian.net/browse/MTV-6395[MTV-6395]
-
 [id="new-features-and-enhancements-2-12-5_{context}"]
 == {project-short} 2.12.5 new features and enhancements
 

--- a/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
@@ -9,6 +9,14 @@
 [role="_abstract"]
 {project-first} 2.12 introduces the following features and enhancements.
 
+[id="new-features-and-enhancements-2-12-6_{context}"]
+== {project-short} 2.12.6 new features and enhancements
+
+{project-short} automatically removes {vmw} drivers and tools during migration::
+With this update, {project-short} automatically removes {vmw}-specific drivers and tools from virtual machines (VMs) during migration. As a result, migrated VMs do not require manual cleanup of {vmw}-specific components after migration.
++
+link:https://redhat.atlassian.net/browse/MTV-6395[MTV-6395]
+
 [id="new-features-and-enhancements-2-12-5_{context}"]
 == {project-short} 2.12.5 new features and enhancements
 

--- a/documentation/modules/ref_resolved-issues-2-12-6.adoc
+++ b/documentation/modules/ref_resolved-issues-2-12-6.adoc
@@ -10,7 +10,7 @@
 Review the fixed issues in this release of {project-short}.
 
 Migration plans allow multiple VM NICs mapped to the same linux-bridge NAD::
-Previously, {project-short} blocked plans when multiple VM NICs were mapped to the same Multus NetworkAttachmentDefinition (NAD). OVN-Kubernetes does not support multiple interfaces on the same NAD. {project-short} applied this check to all NAD types. As a consequence, plans using a linux-bridge NAD with multiple NICs failed with a `Multiple VM NICs use the same Multus NAD name` error. Linux-bridge NADs do support this setup. With this update, {project-short} applies the check only to OVN-Kubernetes NADs. As a result, plans that use linux-bridge NADs with multiple NICs on the same NAD succeed.
+Previously, {project-short} blocked plans when multiple VM NICs were mapped to the same Multus NetworkAttachmentDefinition (NAD). Although OVN-Kubernetes does not support multiple interfaces on the same NAD, linux-bridge NADs do. Because {project-short} applied this check universally, plans using a linux-bridge NAD with multiple NICs failed with a `Multiple VM NICs use the same Multus NAD name` error. With this update, {project-short} applies the check only to OVN-Kubernetes NADs. As a result, plans that use linux-bridge NADs with multiple NICs on the same NAD succeed.
 +
 link:https://redhat.atlassian.net/browse/MTV-6394[MTV-6394]
 
@@ -20,11 +20,11 @@ Previously, {project-short} identified VMs in {vmw} vSphere by BIOS UUID. When m
 link:https://redhat.atlassian.net/browse/MTV-6396[MTV-6396]
 
 Storage copy offload populator metrics are exposed::
-Previously, the vSphere XCOPY volume populator did not expose three Prometheus metrics: `vsphere_xcopy_volume_populator_xcopy_used`, `vsphere_xcopy_volume_populator_progress`, and `vsphere_xcopy_volume_populator_vib_version`. As a consequence, you could not track transfer progress or confirm whether XCOPY hardware offload was used. With this update, the populator pod exposes all three metrics. As a result, you can query them in the {ocp-name} console under *Observe → Metrics*.
+Previously, the vSphere XCOPY volume populator did not expose the following Prometheus metrics: `vsphere_xcopy_volume_populator_xcopy_used`, `vsphere_xcopy_volume_populator_progress`, and `vsphere_xcopy_volume_populator_vib_version`. As a consequence, you could not track transfer progress or confirm whether XCOPY hardware offload was used. With this update, the populator pod exposes all three metrics. As a result, you can query them in the {ocp-name} console under *Observe → Metrics*.
 +
 link:https://redhat.atlassian.net/browse/MTV-6397[MTV-6397]
 
 IBM FlashSystem storage copy offload migrations no longer fail with rate limit errors::
-Previously, IBM FlashSystem limits authentication requests to 3 per second. Multi-VM storage copy offload (XCOPY) migrations exceeded this limit when `controller_max_populator_inflight` was set above 2. As a consequence, migrations failed mid-run with a `FlashSystem authentication failed. Status: 429 Too Many Requests` error. With this update, {project-short} adds retry and backoff logic for 429 responses. As a result, multi-VM XCOPY migrations to IBM FlashSystem succeed at higher concurrency.
+Previously, IBM FlashSystem limited authentication requests to 3 per second. Multi-VM storage copy offload (XCOPY) migrations exceeded this limit when `controller_max_populator_inflight` was set above 2. As a consequence, migrations failed mid-run with a `FlashSystem authentication failed. Status: 429 Too Many Requests` error. With this update, {project-short} adds retry and backoff logic for 429 responses. As a result, multi-VM XCOPY migrations to IBM FlashSystem succeed at higher concurrency.
 +
 link:https://redhat.atlassian.net/browse/MTV-6398[MTV-6398]

--- a/documentation/modules/ref_resolved-issues-2-12-6.adoc
+++ b/documentation/modules/ref_resolved-issues-2-12-6.adoc
@@ -9,8 +9,8 @@
 [role="_abstract"]
 Review the fixed issues in this release of {project-short}.
 
-Migration plans allow multiple VM NICs mapped to the same linux-bridge NAD::
-Previously, {project-short} blocked plans when multiple VM NICs were mapped to the same Multus NetworkAttachmentDefinition (NAD). Although OVN-Kubernetes does not support multiple interfaces on the same NAD, linux-bridge NADs do. Because {project-short} applied this check universally, plans using a linux-bridge NAD with multiple NICs failed with a `Multiple VM NICs use the same Multus NAD name` error. With this update, {project-short} applies the check only to OVN-Kubernetes NADs. As a result, plans that use linux-bridge NADs with multiple NICs on the same NAD succeed.
+Migration plans allow multiple VM NICs mapped to the same NAD::
+Previously, {project-short} blocked plans when multiple VM NICs were mapped to the same Multus NetworkAttachmentDefinition (NAD), regardless of NAD type. As a consequence, plans failed with a `Multiple VM NICs use the same Multus NAD name` error. With this update, {project-short} removes this restriction. As a result, plans that map multiple VM NICs to the same NAD succeed for both linux-bridge and OVN-Kubernetes NAD types.
 +
 link:https://redhat.atlassian.net/browse/MTV-6394[MTV-6394]
 

--- a/documentation/modules/ref_resolved-issues-2-12-6.adoc
+++ b/documentation/modules/ref_resolved-issues-2-12-6.adoc
@@ -23,8 +23,3 @@ Storage copy offload populator metrics are exposed::
 Previously, the vSphere XCOPY volume populator did not expose the following Prometheus metrics: `vsphere_xcopy_volume_populator_xcopy_used`, `vsphere_xcopy_volume_populator_progress`, and `vsphere_xcopy_volume_populator_vib_version`. As a consequence, you could not track transfer progress or confirm whether XCOPY hardware offload was used. With this update, the populator pod exposes all three metrics. As a result, you can query them in the {ocp-name} console under *Observe → Metrics*.
 +
 link:https://redhat.atlassian.net/browse/MTV-6397[MTV-6397]
-
-IBM FlashSystem storage copy offload migrations no longer fail with rate limit errors::
-Previously, IBM FlashSystem limited authentication requests to 3 per second. Multi-VM storage copy offload (XCOPY) migrations exceeded this limit when `controller_max_populator_inflight` was set above 2. As a consequence, migrations failed mid-run with a `FlashSystem authentication failed. Status: 429 Too Many Requests` error. With this update, {project-short} adds retry and backoff logic for 429 responses. As a result, multi-VM XCOPY migrations to IBM FlashSystem succeed at higher concurrency.
-+
-link:https://redhat.atlassian.net/browse/MTV-6398[MTV-6398]

--- a/documentation/modules/ref_resolved-issues-2-12-6.adoc
+++ b/documentation/modules/ref_resolved-issues-2-12-6.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Release_notes/master.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ref_resolved-issues-2-12-6_{context}"]
+= {project-short} fixed issues 2.12.6
+
+[role="_abstract"]
+Review the fixed issues in this release of {project-short}.
+
+Migration plans allow multiple VM NICs mapped to the same linux-bridge NAD::
+Previously, {project-short} blocked plans when multiple VM NICs were mapped to the same Multus NetworkAttachmentDefinition (NAD). OVN-Kubernetes does not support multiple interfaces on the same NAD. {project-short} applied this check to all NAD types. As a consequence, plans using a linux-bridge NAD with multiple NICs failed with a `Multiple VM NICs use the same Multus NAD name` error. Linux-bridge NADs do support this setup. With this update, {project-short} applies the check only to OVN-Kubernetes NADs. As a result, plans that use linux-bridge NADs with multiple NICs on the same NAD succeed.
++
+link:https://redhat.atlassian.net/browse/MTV-6394[MTV-6394]
+
+Warm migrations succeed when {vmw} VMs share the same BIOS UUID::
+Previously, {project-short} identified VMs in {vmw} vSphere by BIOS UUID. When multiple VMs shared the same BIOS UUID, the controller resolved it to the wrong VM and passed the wrong managed object reference (moRef) to VDDK. As a consequence, warm migrations failed with a disk not found error. With this update, {project-short} uses the `instanceUuid` field to identify VMs. As a result, warm migrations succeed even when VMs share the same BIOS UUID.
++
+link:https://redhat.atlassian.net/browse/MTV-6396[MTV-6396]
+
+Storage copy offload populator metrics are exposed::
+Previously, the vSphere XCOPY volume populator did not expose three Prometheus metrics: `vsphere_xcopy_volume_populator_xcopy_used`, `vsphere_xcopy_volume_populator_progress`, and `vsphere_xcopy_volume_populator_vib_version`. As a consequence, you could not track transfer progress or confirm whether XCOPY hardware offload was used. With this update, the populator pod exposes all three metrics. As a result, you can query them in the {ocp-name} console under *Observe → Metrics*.
++
+link:https://redhat.atlassian.net/browse/MTV-6397[MTV-6397]
+
+IBM FlashSystem storage copy offload migrations no longer fail with rate limit errors::
+Previously, IBM FlashSystem limits authentication requests to 3 per second. Multi-VM storage copy offload (XCOPY) migrations exceeded this limit when `controller_max_populator_inflight` was set above 2. As a consequence, migrations failed mid-run with a `FlashSystem authentication failed. Status: 429 Too Many Requests` error. With this update, {project-short} adds retry and backoff logic for 429 responses. As a result, multi-VM XCOPY migrations to IBM FlashSystem succeed at higher concurrency.
++
+link:https://redhat.atlassian.net/browse/MTV-6398[MTV-6398]


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MTV-6390 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documented CSI volume import for copy-offload migrations as a Developer Preview, supporting vVol and RDM disks within the same array.
* **Bug Fixes**
  * Documented fixes for shared-NAD migration plans, vSphere warm migrations with duplicate BIOS UUIDs, and XCOPY Prometheus metrics.
* **Documentation**
  * Added release notes for version 2.12.6.
  * Updated the documentation patch version to 2.12.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->