### PR TITLE
MTV-6456 Add virt-v2v SELinux relabel-at-boot enhancement to 2.12.6 r…

### DIFF
--- a/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
@@ -13,7 +13,14 @@
 == {project-short} 2.12.6 new features and enhancements
 
 Deferred SELinux relabeling is available for virt-v2v conversions::
-With this update, you can defer SELinux relabeling to the first boot of a migrated virtual machine (VM) instead of relabeling during conversion. To enable deferred relabeling, set the `virt_v2v_extra_args` field to `--selinux-relabel-at-boot` in the `ForkliftController` custom resource (CR). This setting applies to all migrations managed by the controller. As a result, Linux VMs with large filesystems complete conversion without memory-related pod failures.
+With this update, you can defer SELinux relabeling to the first boot of a migrated virtual machine (VM) instead of relabeling during conversion. To enable deferred relabeling, set the `virt_v2v_extra_args` field to `--selinux-relabel-at-boot` in the `ForkliftController` custom resource (CR) by running the following command:
++
+[source,terminal]
+----
+$ {oc} patch ForkliftController -n {namespace} forklift-controller --type=merge -p '{"spec": {"virt_v2v_extra_args":"--selinux-relabel-at-boot"}}'
+----
++
+This setting applies to all migrations managed by the controller. As a result, Linux VMs with large filesystems complete conversion without memory-related pod failures.
 +
 link:https://redhat.atlassian.net/browse/MTV-6456[MTV-6456]
 

--- a/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
@@ -13,7 +13,7 @@
 == {project-short} 2.12.6 new features and enhancements
 
 Deferred SELinux relabeling is available for virt-v2v conversions::
-With this update, {project-short} includes updated `virt-v2v` and `libguestfs` versions that support a `--selinux-relabel-at-boot` argument. This argument defers SELinux relabeling to the first boot of the migrated virtual machine (VM) instead of relabeling during conversion. To enable this argument, set the `virt_v2v_extra_args` field to `--selinux-relabel-at-boot` in the `ForkliftController` custom resource (CR). This setting applies to all migrations managed by the controller. As a result, Linux VMs with large filesystems complete conversion without memory-related pod failures.
+With this update, you can defer SELinux relabeling to the first boot of a migrated virtual machine (VM) instead of relabeling during conversion. To enable deferred relabeling, set the `virt_v2v_extra_args` field to `--selinux-relabel-at-boot` in the `ForkliftController` custom resource (CR). This setting applies to all migrations managed by the controller. As a result, Linux VMs with large filesystems complete conversion without memory-related pod failures.
 +
 link:https://redhat.atlassian.net/browse/MTV-6456[MTV-6456]
 

--- a/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
@@ -9,6 +9,14 @@
 [role="_abstract"]
 {project-first} 2.12 introduces the following features and enhancements.
 
+[id="new-features-and-enhancements-2-12-6_{context}"]
+== {project-short} 2.12.6 new features and enhancements
+
+The `--selinux-relabel-at-boot` argument is available for virt-v2v conversions::
+With this update, {project-short} includes updated `virt-v2v` and `libguestfs` versions that support a `--selinux-relabel-at-boot` argument. This argument defers SELinux relabeling to the first boot of the migrated virtual machine (VM) instead of relabeling during conversion. You enable this argument by setting the `virt_v2v_extra_args` field to `--selinux-relabel-at-boot` in the `ForkliftController` custom resource (CR). This setting applies to all migrations managed by the controller. As a result, Linux VMs with large filesystems complete conversion without memory-related pod failures.
++
+link:https://redhat.atlassian.net/browse/MTV-6456[MTV-6456]
+
 [id="new-features-and-enhancements-2-12-5_{context}"]
 == {project-short} 2.12.5 new features and enhancements
 

--- a/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
@@ -15,7 +15,7 @@
 Deferred SELinux relabeling is available for virt-v2v conversions::
 With this update, you can defer SELinux relabeling to the first boot of a migrated virtual machine (VM) instead of relabeling during conversion. To enable deferred relabeling, set the `virt_v2v_extra_args` field to `--selinux-relabel-at-boot` in the `ForkliftController` custom resource (CR) by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 $ {oc} patch ForkliftController -n {namespace} forklift-controller --type=merge -p '{"spec": {"virt_v2v_extra_args":"--selinux-relabel-at-boot"}}'
 ----

--- a/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
@@ -12,8 +12,8 @@
 [id="new-features-and-enhancements-2-12-6_{context}"]
 == {project-short} 2.12.6 new features and enhancements
 
-The `--selinux-relabel-at-boot` argument is available for virt-v2v conversions::
-With this update, {project-short} includes updated `virt-v2v` and `libguestfs` versions that support a `--selinux-relabel-at-boot` argument. This argument defers SELinux relabeling to the first boot of the migrated virtual machine (VM) instead of relabeling during conversion. You enable this argument by setting the `virt_v2v_extra_args` field to `--selinux-relabel-at-boot` in the `ForkliftController` custom resource (CR). This setting applies to all migrations managed by the controller. As a result, Linux VMs with large filesystems complete conversion without memory-related pod failures.
+Deferred SELinux relabeling is available for virt-v2v conversions::
+With this update, {project-short} includes updated `virt-v2v` and `libguestfs` versions that support a `--selinux-relabel-at-boot` argument. This argument defers SELinux relabeling to the first boot of the migrated virtual machine (VM) instead of relabeling during conversion. To enable this argument, set the `virt_v2v_extra_args` field to `--selinux-relabel-at-boot` in the `ForkliftController` custom resource (CR). This setting applies to all migrations managed by the controller. As a result, Linux VMs with large filesystems complete conversion without memory-related pod failures.
 +
 link:https://redhat.atlassian.net/browse/MTV-6456[MTV-6456]
 


### PR DESCRIPTION
Late enhancement release note for 2.12.6: MTV-6456

Preview: https://forklift-documentation-git-fork-je-002671-yaacov-8047s-projects.vercel.app/downstream/documentation/doc-Release_notes/master.html#new-features-and-enhancements-2-12-6_release-notes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for support of the `--selinux-relabel-at-boot` option during `virt-v2v` conversions.
  * Documented configuration through `virt_v2v_extra_args`.
  * Clarified that SELinux relabeling is deferred until the migrated VM’s first boot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->