### PR TITLE
MTV-6367 | restore live migration Technology Preview note for CNV 4.20

### DIFF
--- a/documentation/doc-Planning_your_migration/assemblies/assembly_live-migration.adoc
+++ b/documentation/doc-Planning_your_migration/assemblies/assembly_live-migration.adoc
@@ -12,6 +12,13 @@ Live migration is supported by {project-first} version 2.10.0 and later. It requ
 
 [IMPORTANT]
 ====
+Live migration between {virt} clusters is a Technology Preview feature when you use {virt} 4.20. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. For more information about the support scope of Red Hat Technology Preview features, see https://access.redhat.com/support/offerings/techpreview/.
+
+To use live migration with full support, both the source and target clusters must run {virt} 4.21.1 or later.
+====
+
+[IMPORTANT]
+====
 Migration between namespaces on the same {virt} cluster fails because of MAC address collisions. For more information about this known issue, see the "Additional resources" section.
 ====
 

--- a/documentation/modules/con_about-live-migration.adoc
+++ b/documentation/modules/con_about-live-migration.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 You can use _live migration_ to migrate virtual machines (VMs) between {virt} clusters, or between namespaces on the same {virt} cluster, with extremely limited downtime.
 
-Live migration is supported by {project-first} version 2.10.0 and later. It requires {virt} 4.20 or later on both your source and target clusters. 
+Live migration is supported by {project-first} version 2.10.0 and later. It requires {virt} 4.20 or later on both your source and target clusters. Live migration with {virt} 4.20 is a Technology Preview feature. For full support, both clusters must run {virt} 4.21.1 or later. 
 
 Live migration makes it easier for you to perform Day 2 tasks, such as seamless maintenance and workload balancing after you have migrated your VMs to {virt}.
 

--- a/documentation/modules/con_planning-intro.adoc
+++ b/documentation/modules/con_planning-intro.adoc
@@ -31,7 +31,14 @@ OVA migration is validated for migrating supported guest operating systems expor
 
 * Warm migration is available only for {vmw} vSphere and {rhv-full}. This type of migration migrates VMs that are powered _on_ and requires shared storage.
 
-* Live migration is available *_only_* for migrations between {virt} clusters or between namespaces on the same {virt} cluster. It requires {project-short} version 2.10 or later and {virt} version 4.20 or later. 
+* Live migration is available *_only_* for migrations between {virt} clusters or between namespaces on the same {virt} cluster. It requires {project-short} version 2.10 or later and {virt} version 4.20 or later.
+
+[IMPORTANT]
+====
+Live migration between {virt} clusters is a Technology Preview feature when you use {virt} 4.20. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. For more information about the support scope of Red Hat Technology Preview features, see https://access.redhat.com/support/offerings/techpreview/.
+
+To use live migration with full support, both the source and target clusters must run {virt} 4.21.1 or later.
+====
 
 [role="_additional-resources"]
 .Additional resources

--- a/documentation/modules/proc_creating-plan-wizard-cnv-live.adoc
+++ b/documentation/modules/proc_creating-plan-wizard-cnv-live.adoc
@@ -9,6 +9,13 @@
 [role="_abstract"]
 You create a migration plan for a live migration of virtual machines (VMs) almost exactly as you create a migration plan for a cold migration. The only difference is that you specify it is a *Live migration* in the *Migration type* page.
 
+[IMPORTANT]
+====
+Live migration between {virt} clusters is a Technology Preview feature when you use {virt} 4.20. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. For more information about the support scope of Red Hat Technology Preview features, see https://access.redhat.com/support/offerings/techpreview/.
+
+To use live migration with full support, both the source and target clusters must run {virt} 4.21.1 or later.
+====
+
 .Prerequisites
 
 As described in xref:ref_cnv-cnv-live-prerequisites_mtv[{virt} live migration prerequisites].

--- a/documentation/modules/proc_migrating-live-cnv-cnv-vms-cli.adoc
+++ b/documentation/modules/proc_migrating-live-cnv-cnv-vms-cli.adoc
@@ -9,6 +9,13 @@
 [role="_abstract"]
 You can perform a live migration by using the command-line interface (CLI). The procedure for live migration is identical to the procedure for other migrations between {virt} clusters except for the addition of the `type` label in the `Plan` CR. For a live migration, the `type` label must be set to `live`.
 
+[IMPORTANT]
+====
+Live migration between {virt} clusters is a Technology Preview feature when you use {virt} 4.20. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. For more information about the support scope of Red Hat Technology Preview features, see https://access.redhat.com/support/offerings/techpreview/.
+
+To use live migration with full support, both the source and target clusters must run {virt} 4.21.1 or later.
+====
+
 .Prerequisites
 Ensure you meet the {virt} live migration prerequisites. For more information, see link:https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.10/html/planning_your_migration_to_red_hat_openshift_virtualization/assembly_provider-specific-requirements-for-migration_mtv#ref_cnv-cnv-live-prerequisites_mtv[{virt} live migration prerequisites].
 

--- a/documentation/modules/ref_cnv-cnv-live-prerequisites.adoc
+++ b/documentation/modules/ref_cnv-cnv-live-prerequisites.adoc
@@ -10,7 +10,7 @@
 In addition to the regular xref:ref_cnv-prerequisites_mtv[{virt} prerequisites], live migration has the following additional prerequisites:
 
 * {project-first} 2.10.0 or later installed. {project-short} treats all {virt} migrations run on {project-short} 2.9 or earlier as cold migrations, even if they are configured as live migrations.
-* {virt} 4.20.0 or later installed on both source and target clusters.
+* {virt} 4.20.0 or later installed on both source and target clusters. Live migration with {virt} 4.20 is a Technology Preview feature. For full support, both clusters must run {virt} 4.21.1 or later.
 * In the `KubeVirt` resource of both clusters in the `featureGates` of the YAML,`DecentralizedLiveMigration` is listed. You must have `cluster-admin` privileges to set this field.
 * Connectivity between the clusters must be established, including connectivity for state transfer. Technologies such as Submariner can be used for this purpose.
 * The target cluster has `VirtualMachineInstanceTypes` and `VirtualMachinePreferences` that match those used by the VMs on the source cluster.


### PR DESCRIPTION
## Summary
- Restores a Technology Preview warning for cross-cluster live migration when using OpenShift Virtualization 4.20.
- States that full support requires OpenShift Virtualization 4.21.1 or later on source and target clusters.
- Resolves https://issues.redhat.com/browse/MTV-6367 for the MTV 2.12 (`main`) documentation.

## Test plan
- [ ] Preview the Planning guide live-migration chapter and confirm the TP note appears after the 4.20 requirement sentence.
- [ ] Confirm the note also appears in the planning intro, live-migration prerequisites, UI procedure, and CLI procedure.
- [ ] Confirm the existing MAC-address known-issue note is still present.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that cross-cluster live migration in {virt} 4.20 is a Technology Preview.
  * Noted that it is not recommended for production and is not covered by production SLAs.
  * Documented that full support requires both clusters to run {virt} 4.21.1 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->