### PR TITLE
MTV-6468: Attributes and release notes for MTV 2.12.7

### DIFF
--- a/documentation/doc-Release_notes/master.adoc
+++ b/documentation/doc-Release_notes/master.adoc
@@ -23,6 +23,8 @@ include::modules/ref_new-features-and-enhancements-2-12.adoc[leveloffset=+2]
 include::modules/ref_rn-resolved-issues.adoc[leveloffset=+2]
 
 // Resolved issues by z-stream release. Most recent release goes first in the list.
+include::modules/ref_resolved-issues-2-12-7.adoc[leveloffset=+3]
+
 include::modules/ref_resolved-issues-2-12-6.adoc[leveloffset=+3]
 
 include::modules/ref_resolved-issues-2-12-5.adoc[leveloffset=+3]

--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -26,7 +26,7 @@
 :project-version: 2.12
 :mtv-plan: https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/{project-version}/html/planning_your_migration_to_red_hat_openshift_virtualization/
 :mtv-mig: https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/{project-version}/html/migrating_your_virtual_machines_to_red_hat_openshift_virtualization/
-:project-z-version: 2.12.6
+:project-z-version: 2.12.7
 :rhel-first: Red Hat Enterprise Linux (RHEL)
 :virt: OpenShift Virtualization
 :must-gather-image: registry.redhat.io/migration-toolkit-virtualization/mtv-must-gather-rhel8:{project-z-version}

--- a/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
+++ b/documentation/modules/ref_new-features-and-enhancements-2-12.adoc
@@ -9,6 +9,14 @@
 [role="_abstract"]
 {project-first} 2.12 introduces the following features and enhancements.
 
+[id="new-features-and-enhancements-2-12-7_{context}"]
+== {project-short} 2.12.7 new features and enhancements
+
+IPv6 static addresses are preserved during Windows VM migrations::
+Previously, {project-short} preserved only IPv4 static addresses during Windows virtual machine (VM) migrations. As a consequence, the firstboot network configuration scripts silently dropped IPv6 addresses. With this update, {project-short} preserves both IPv4 and IPv6 static addresses, including dual-stack and IPv6-only configurations. As a result, migrated Windows VMs correctly retain all static network settings in the target environment.
++
+link:https://issues.redhat.com/browse/MTV-6467[MTV-6467]
+
 [id="new-features-and-enhancements-2-12-6_{context}"]
 == {project-short} 2.12.6 new features and enhancements
 

--- a/documentation/modules/ref_resolved-issues-2-12-7.adoc
+++ b/documentation/modules/ref_resolved-issues-2-12-7.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Release_notes/master.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ref_resolved-issues-2-12-7_{context}"]
+= {project-short} fixed issues 2.12.7
+
+[role="_abstract"]
+Review the fixed issues in this release of {project-short}.
+
+Multi-VM migrations do not delete OvirtVolumePopulator resources prematurely::
+Previously, during multi-VM migrations, the `forklift-controller` incorrectly deleted `OvirtVolumePopulator` resources. This occurred when a single virtual machine (VM) in a migration plan completed its migration. As a consequence, other active VM transfers in the same plan failed. With this update, the `forklift-controller` retains the `OvirtVolumePopulator` resources until all VMs in the plan finish migrating. As a result, all VM transfers in a multi-VM migration plan complete successfully.
++
+link:https://issues.redhat.com/browse/MTV-6447[MTV-6447]


### PR DESCRIPTION
MTV 2.12.7

Resolves https://redhat.atlassian.net/browse/MTV-6468 by updating attributes and adding release notes for MTV 2.12.7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Static IPv4 and IPv6 addresses are preserved during Windows VM migrations, including dual-stack and IPv6-only configurations.

* **Bug Fixes**
  * Improved multi-VM migrations to prevent active transfers from failing when one virtual machine completes.

* **Documentation**
  * Added release notes and updated documentation for version 2.12.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->