### PR TITLE
HOLD FOR 5.0: MTV-2834 Add existing secret option for LUKS disk decryption

### DIFF
--- a/documentation/modules/con_migration-of-luks-encrypted-disks.adoc
+++ b/documentation/modules/con_migration-of-luks-encrypted-disks.adoc
@@ -8,18 +8,23 @@
 = Migration of LUKS-encrypted disks
 
 [role="_abstract"]
-If you have virtual machines (VMs) with LUKS-encrypted disks in your source VMware VSphere environment, you can migrate them to Red Hat {virt} by enabling Network-Bound Disk Encryption (NBDE) with Clevis. Alternatively, you can manually add passwords for LUKS-encrypted devices in your migration plan. 
 
-If you enable NBDE, passwords are retrieved from the Clevis server. When you manually add LUKS passwords to your migration plan, you provide the list of passwords, and you cannot use NBDE to retrieve them. The two methods for migrating LUKS-encrypted disks are incompatible. You must use either NBDE or manual LUKS passwords to migrate LUKS-encrypted disks.
+You can migrate virtual machines (VMs) with LUKS-encrypted disks from VMware vSphere to Red Hat OpenShift Virtualization. Use one of these methods:
 
-MTV transfers the data of VMs with LUKS-encrypted disks from the source environment to the target {virt} cluster. MTV reads only the blocks that are required for guest conversion, decrypting the required blocks and re-encrypting them locally with the same key.
+* Enable Network-Bound Disk Encryption (NBDE) with Clevis to retrieve passphrases from a Tang server.
+* Select an existing `Secret` manifest of the `Opaque` type that contains the decryption passphrase.
+* Enter passphrases manually for the LUKS-encrypted devices in your migration plan.
 
-Clevis is a client-side framework that automates the decryption of LUKS volumes by binding a LUKS key slot to a policy. During the migration of VMs with LUKS-encrypted disks, MTV authenticates with the configured network service by requesting the key to unlock the LUKS-encrypted disk from the Tang server. The automatic retrieval of the key allows the VM to boot without a manual passphrase entry from an administrator.
+In the user interface (UI), you can select only one decryption method per migration plan. If you use YAML configurations, you can combine different methods for virtual machines in the same plan.
+
+{project-short} transfers the data of VMs with LUKS-encrypted disks from the source environment to the target {virt} cluster. {project-short} reads only the blocks required for guest conversion. {project-short} decrypts these blocks and re-encrypts them locally with the same key.
+
+Clevis is a client-side framework that automates the decryption of LUKS volumes by binding a LUKS key slot to a policy. During the migration, {project-short} authenticates with the configured network service. It requests the key to unlock the LUKS-encrypted disk from the Tang server. With automatic key retrieval, the VM boots without manual passphrase entry.
 
 Benefits of NBDE::
 
 * *Automation:* Eliminates the need to enter keys manually during migration.
-* *Enhanced security:* Maintains the security of VMs throughout their migration lifecycle by preserving LUKS encryption from the source to the destination.
-* *Seamless operation:* Ensures that VMs with encrypted disks can be brought online in the new OpenShift Virtualization environment with minimal interruption.
+* *Enhanced security:* Maintains VM security during migration by preserving LUKS encryption from the source to the destination.
+* *Seamless operation:* Ensures that VMs with encrypted disks boot in the target environment with minimal interruption.
 
 

--- a/documentation/modules/proc_creating-plan-wizard-vmware.adoc
+++ b/documentation/modules/proc_creating-plan-wizard-vmware.adoc
@@ -22,11 +22,44 @@ Limitations::
 {project-first} cannot migrate {vmw} vSphere 6 and {vmw} vSphere 7 VMs to a FIPS-compliant {virt} cluster.
 ====
 
-.Prerequisites
 
-* Have a {vmw} source provider and {a-virt} destination provider. For more information, see xref:proc_adding-source-provider_{context}[Adding a VMware vSphere source provider] or xref:proc_adding-virt-destination-provider_dest_{context}[Adding {a-virt} destination provider].
-* If you plan to create a *Network map* or a *Storage map* that will be used by more than one migration plan, create it in the *Network maps* or *Storage maps* page of the UI before you create a migration plan that uses that map.
-* If you are using a user-defined network (UDN), note the name of its namespace as defined in {virt}.
+* You configured a {vmw} source provider and an {a-virt} destination provider. For details, see xref:proc_adding-source-provider_{context}[Adding a VMware vSphere source provider] or xref:proc_adding-virt-destination-provider_dest_{context}[Adding {a-virt} destination provider].
+* You created shared network maps or storage maps on the *Network maps* or *Storage maps* page of the user interface (UI).
+* If you use a user-defined network (UDN), you know the namespace name as defined in {virt}.
+* If you use the *Use an existing secret* option for LUKS-encrypted disks, you created a `Secret` manifest that meets these requirements:
+** It has the `Opaque` type.
+** It resides in the namespace of the migration plan.
+** It contains one passphrase per data entry.
+** It uses any key name in the `data` or `stringData` fields.
++
+--
+For example, you can use the following YAML configuration to define the secret:
+
+[source,yaml,subs="+quotes"]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: __<luks_secret_name>__
+  namespace: __<migration_plan_namespace>__
+type: Opaque
+stringData:
+  __<disk_key>__: "__<passphrase>__"
+----
+where:
+
+`<luks_secret_name>`::
+Specifies the name of your decryption secret.
+
+`<migration_plan_namespace>`::
+Specifies the namespace where you create your migration plan.
+
+`<disk_key>`::
+Specifies any key name that represents the encrypted disk.
+
+`<passphrase>`::
+Specifies the decryption passphrase for your LUKS-encrypted device.
+--
 
 .Procedure
 
@@ -121,13 +154,14 @@ If needed, click *Add mapping* to add another mapping.
 . Click *Next*.
 +
 // Other settings page
-. On the *Other settings (optional)* page, specify any of the following settings that are appropriate for your plan. All are optional.
 
-* *Disk decryption passphrases*: For disks encrypted using Linux Unified Key Setup (LUKS).
+. On the *Other settings (optional)* page, specify the optional settings for your migration plan.
 
-** Enter a decryption passphrase for a LUKS-encrypted device.
-** To add another passphrase, click *Add passphrase* and add a passphrase.
-** Repeat as needed.
+* *Disk decryption passphrases*: For disks encrypted with Linux Unified Key Setup (LUKS), select one of these options:
+
+** *Use network-bound disk encryption (NBDE/Clevis)*: Select this option to use NBDE with Clevis to decrypt the disks during migration.
+** *Use an existing secret*: Select a secret from the list. The secret must be an `Opaque` `Secret` manifest that contains the decryption passphrase.
+** *Enter passphrases*: Enter a decryption passphrase for a LUKS-encrypted device. Repeat as needed. This option creates a plan-owned `Secret` to store the passphrases.
 +
 You do not need to enter the passphrases in a specific order. For each LUKS-encrypted device, {project-short} tries each passphrase until one unlocks the device.
 

--- a/documentation/modules/proc_enabling-nbde-with-clevis.adoc
+++ b/documentation/modules/proc_enabling-nbde-with-clevis.adoc
@@ -4,42 +4,59 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc_enabling-nbde-with-clevis_{context}"]
-= Enabling Network-Bound Disk Encryption with Clevis 
+= Enabling network-bound disk encryption with Clevis 
 
 [role="_abstract"]
-When you enable Network-Bound Disk Encryption (NBDE) with Clevis, the Tang server manages the keys for Linux Unified Key Setup (LUKS)-encrypted disks during a migration. If you do not use NBDE to migrate LUKS-encrypted disks from your source environment, you can manually add passwords for LUKS-encrypted devices instead. You must use either NBDE or manual LUKS passwords to migrate LUKS-encrypted disks.
+When you enable network-bound disk encryption (NBDE) with Clevis, the Tang server manages the decryption keys during migration. If you do not use NBDE, you can decrypt Linux Unified Key Setup (LUKS) disks manually. Alternatively, you can use an existing secret.
 
-You can enable NBDE with Clevis either in the MTV UI or in the YAML file for your migration plan:
+You can configure LUKS decryption in the {project-short} user interface (UI) or in the migration plan YAML file.
 
-* In the MTV UI, you must select either NBDE with Clevis or LUKS passphrases. You can have only one encryption type, and you apply the setting to all VMs in your migration plan.
-* In the YAML file for your migration plan, you can combine encryption types and apply the setting to selected VMs in the YAML file.
+* In the UI, you can select only one decryption method per plan. This method applies to all virtual machines (VMs) in that plan.
+* In the YAML file, you can combine different decryption methods for different VMs in the same plan.
 
 .Prerequisites
+
+For NBDE with Clevis:
+
 * The Tang server is accessible from your OpenShift cluster and from the migration network.
-* You have a LUKS key slot bound to the Tang server policy.
+* You bound a LUKS key slot to the Tang server policy.
 +
-NOTE: For MTV to access the keys from the Tang server, the keys must be on a different subnet range than a user-defined network (UDN).
+[NOTE]
+====
+To access the Tang server keys, they must reside on a different subnet than a user-defined network (UDN).
+====
+
+For a `Secret` manifest or manual passphrase:
+
+* You have the LUKS decryption passphrase.
+* Optional: If you create a `Secret` manifest, it must have the `Opaque` type and reside in the plan namespace.
+* The secret must contain one passphrase per data entry. For details, see xref:proc_creating-plan-wizard-vmware_{context}[Creating a VMware vSphere migration plan by using the MTV wizard].
 
 .Procedure
-. Enable NBDE with Clevis in the MTV UI.
-.. In the Create migration plan wizard, navigate to *Other settings* under *Additional setup* in the left navigation pane.
-.. Select *Use NBDE/Clevis*. 
-+
-If you are not using NBDE with Clevis, you add passphrases for LUKS-encrypted devices so that the Tang servers can decrypt the disks during a migration.
-.. Click *Next*, and verify that *Use NBDE/Clevis* shows as *Enabled* under *Other settings (optional)*.
-.. When you create your migration plan, click *Migration plans* in the left navigation menu, and open the *Plan details* page for your migration plan.
-.. Click the *Edit* icon for *Disk decryption* under *Plan settings*.
-.. Verify that *Use network-bound disk encryption (NBDE/Clevis)* is selected. 
-+
-If you are not using NBDE with Clevis, verify that the passphrases for LUKS-encrypted devices are added. 
 
-. Enable NBDE with Clevis in the YAML file.
+. Configure disk decryption in the {project-short} UI.
+.. In the *Create migration plan* wizard, navigate to *Other settings* under *Additional setup* in the left navigation pane.
+.. Select the decryption method for LUKS-encrypted disks:
++
+* For NBDE with Clevis: Select *Use NBDE/Clevis*.
+* For a `Secret` manifest or manual passphrase: Add passphrases for the LUKS devices or select a `Secret` manifest.
+.. Click *Next*, and verify your selection under *Other settings (optional)*:
++
+* For NBDE with Clevis: Verify that *Use NBDE/Clevis* is *Enabled*.
+* For a `Secret` manifest or manual passphrase: Verify that the `Secret` manifest or passphrases are listed.
+.. After you create the migration plan, click *Migration plans* in the left navigation menu. Open the *Plan details* page.
+.. Click the *Edit* icon for *Disk decryption* under *Plan settings*.
+.. Verify your decryption method:
++
+* For NBDE with Clevis: Verify that *Use network-bound disk encryption (NBDE/Clevis)* is selected.
+* For a `Secret` manifest or manual passphrase: Verify that you configured the `Secret` manifest or added the passphrases. 
+
+. Configure disk decryption in the YAML file.
 .. Click *Migration plans* in the left navigation menu and open the *Plan details* page for your migration plan.
 .. Click the *YAML* tab to open the `Plan` custom resource (CR) for your migration plan.
-.. For each VM under `vms` in the YAML file, enter the encryption type. In this example, you set `nbdeClevis` as the encryption type for `vm-1`, LUKS passphrase as the encryption type for `vm-2`, and no encryption type for `vm-3`:
+.. For each VM under the `vms` field, enter the decryption method. In this example, you set `nbdeClevis` for `vm-1`, a passphrase secret for `vm-2`, and omit decryption for `vm-3`:
 +
-Example:
-+
+[source,yaml]
 ----
 vms:
   - id: vm-1
@@ -52,6 +69,12 @@ vms:
   - id: vm-3
     name: vm-3-esx8.0-rhel8.10-raid1
 ----
++
+[NOTE]
+====
+If you configure both `nbdeClevis` and `luks` for the same VM, {project-short} uses `nbdeClevis` and ignores the `luks` setting.
+====
 
 .Troubleshooting
-* For information about LUKS or Clevis configuration on the source VM, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-by-using-policy-based-decryption[Configuring automated unlocking of encrypted volumes by using policy-based decryption] in the RHEL _Security hardening_ guide.
+
+* For information about configuring LUKS or Clevis on the source VM, see the RHEL _Security hardening_ guide. See link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-by-using-policy-based-decryption[Configuring automated unlocking of encrypted volumes by using policy-based decryption].


### PR DESCRIPTION
MTV 5.0.0

Resolves https://redhat.atlassian.net/browse/MTV-2834 by adding instructions for the "Use existing secret" option for LUKS disk decryption in the UI. This PR  also includes the option for using NBDE/Clevis encryption which was missing from the UI documentation.

Previews:

- https://forklift-documentation-git-fork-ri-7b5cc0-yaacov-8047s-projects.vercel.app/downstream/documentation/doc-Planning_your_migration/master.html#con_migration-of-luks-encrypted-disks_vmware 
- https://forklift-documentation-git-fork-ri-7b5cc0-yaacov-8047s-projects.vercel.app/downstream/documentation/doc-Planning_your_migration/master.html#proc_enabling-nbde-with-clevis_vmware
- https://forklift-documentation-git-fork-ri-7b5cc0-yaacov-8047s-projects.vercel.app/downstream/documentation/doc-Planning_your_migration/master.html#proc_creating-plan-wizard-vmware_vmware [Prerequisites AND step 13]


AI-generated comments:

Claude:

## Summary
- **proc_creating-plan-wizard-vmware.adoc**: Added optional prerequisite for creating an `Opaque` `Secret` manifest with LUKS decryption passphrase. Updated the *Disk decryption passphrases* section to present three options: NBDE/Clevis, use an existing secret, or enter passphrases manually.
- **con_migration-of-luks-encrypted-disks.adoc**: Updated the concept overview to list three mutually exclusive methods for migrating LUKS-encrypted disks (NBDE, existing secret, manual passphrases), replacing the previous two-method description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

coderabbit:

* **Documentation**
  * Updated LUKS disk migration guidance to cover NBDE with Clevis, existing opaque secrets, and manually entered passphrases.
  * Clarified decryption-method limits for UI plans and per-VM flexibility in YAML plans.
  * Added VMware prerequisites and an example YAML configuration for an optional decryption secret.
  * Expanded Tang prerequisites, method-specific setup instructions, secret requirements, and verification guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->