### PR TITLE
Attributes and release notes for MTV 2.12.8

### DIFF
--- a/documentation/doc-Release_notes/master.adoc
+++ b/documentation/doc-Release_notes/master.adoc
@@ -23,6 +23,8 @@ include::modules/ref_new-features-and-enhancements-2-12.adoc[leveloffset=+2]
 include::modules/ref_rn-resolved-issues.adoc[leveloffset=+2]
 
 // Resolved issues by z-stream release. Most recent release goes first in the list.
+include::modules/ref_resolved-issues-2-12-8.adoc[leveloffset=+3]
+
 include::modules/ref_resolved-issues-2-12-7.adoc[leveloffset=+3]
 
 include::modules/ref_resolved-issues-2-12-6.adoc[leveloffset=+3]

--- a/documentation/modules/common-attributes.adoc
+++ b/documentation/modules/common-attributes.adoc
@@ -26,7 +26,7 @@
 :project-version: 2.12
 :mtv-plan: https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/{project-version}/html/planning_your_migration_to_red_hat_openshift_virtualization/
 :mtv-mig: https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/{project-version}/html/migrating_your_virtual_machines_to_red_hat_openshift_virtualization/
-:project-z-version: 2.12.7
+:project-z-version: 2.12.8
 :rhel-first: Red Hat Enterprise Linux (RHEL)
 :virt: OpenShift Virtualization
 :must-gather-image: registry.redhat.io/migration-toolkit-virtualization/mtv-must-gather-rhel8:{project-z-version}

--- a/documentation/modules/ref_resolved-issues-2-12-8.adoc
+++ b/documentation/modules/ref_resolved-issues-2-12-8.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * documentation/doc-Release_notes/master.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ref_resolved-issues-2-12-8_{context}"]
+= {project-short} fixed issues 2.12.8
+
+[role="_abstract"]
+Review the fixed issues in this release of {project-short}.
+
+Network interface cards are preserved during Hyper-V cluster migrations::
+Previously, the Hyper-V provider only queried the connected host for network switches. It also resolved network universally unique identifiers (UUIDs) by name alone. As a consequence, {project-short} silently dropped the network interface cards (NICs) of virtual machines (VMs) on remote cluster nodes. This occurred when their network switches were missing from the inventory. Additionally, identically named switches on different nodes could be assigned the wrong UUID. With this update, {project-short} collects network switches from all cluster nodes and resolves UUIDs by both node and switch name. As a result, {project-short} correctly maps and preserves all NICs during migration.
++
+link:https://issues.redhat.com/browse/MTV-6444[MTV-6444]
+
+Target VM name resolution is standardized across all adapters::
+Previously, the plan builder and validator resolved target virtual machine (VM) names using different field-priority orders. As a consequence, they computed different persistent volume claim (PVC) names, causing migration plan validation to fail. With this update, {project-short} standardizes the target VM name resolution order across all adapters. As a result, all adapters resolve names consistently, which prevents mismatched PVC names during migration plan validation.
++
+link:https://issues.redhat.com/browse/MTV-6446[MTV-6446]
+
+Hyper-V provider automatically recovers from the ConnectionFailed status::
+Previously, the reconciler failed to re-queue the provider after Windows Remote Management (WinRM) basic authentication was re-enabled. As a consequence, the provider remained stuck in the `ConnectionFailed` status until you manually re-created it. With this update, the reconciler re-queues the provider for a connection retest. As a result, the Hyper-V provider automatically recovers from the `ConnectionFailed` status.
++
+link:https://issues.redhat.com/browse/MTV-6450[MTV-6450]
+
+CSI affinity labels are copied to prime PVCs to enable co-location::
+Previously, during PowerStore, PowerFlex, or NetApp ONTAP migrations, {project-short} omitted CSI affinity labels on intermediate `prime` PersistentVolumeClaims (PVCs). As a consequence, the Container Storage Interface (CSI) driver could not co-locate source and destination volumes. With this update, {project-short} copies CSI affinity labels to `prime` PVCs during creation. As a result, the CSI driver successfully co-locates the volumes.
++
+link:https://issues.redhat.com/browse/MTV-6454[MTV-6454]
+
+Offline migrations in ROKS no longer fail due to certificate errors::
+Previously, offline virtual machine (VM) migrations failed in Red Hat OpenShift on IBM Cloud (ROKS) environments. This occurred because {project-short} configured invalid certificates on intermediate `DataVolume` resources. As a consequence, users encountered certificate errors that blocked the migrations. With this update, {project-short} probes the export proxy Transport Layer Security (TLS) endpoint before setting the certificate configuration map. It omits the certificate if the `VMExport` certificate authority (CA) does not verify but system trust does. As a result, offline migrations in ROKS environments complete successfully despite the unverified certificates.
++
+link:https://issues.redhat.com/browse/MTV-6458[MTV-6458]
+
+Inventory database bloat and memory usage are reduced during vSphere migrations::
+Previously, migrating virtual machines (VMs) with many custom value definitions from {vmw} vSphere caused high memory consumption and migration plan failures. With this update, {project-short} reduces memory consumption.
++
+link:https://issues.redhat.com/browse/MTV-6558[MTV-6558]


### PR DESCRIPTION
MTV 2.12.8

Resolves https://redhat.atlassian.net/browse/MTV-6609 by modifying attributes and adding release notes for MTV 2.12.8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved network interface cards during Hyper-V cluster migrations.
  - Standardized target VM name resolution across adapters to prevent mismatched PVC names during migration validation.
  - Improved Hyper-V provider recovery after connection failures.
  - Preserved CSI affinity labels during supported storage migrations to enable volume co-location.
  - Prevented certificate-related failures during offline ROKS migrations.
  - Reduced inventory database growth and memory usage during vSphere migrations.

- **Documentation**
  - Added resolved issues for the 2.12.8 release.
  - Updated the documented project version to 2.12.8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->