### PR TITLE
Fix namespace variable rendering in provider procedures

### DIFF
--- a/documentation/modules/proc_adding-source-provider-aws.adoc
+++ b/documentation/modules/proc_adding-source-provider-aws.adoc
@@ -34,7 +34,7 @@ For more information about the support scope of Red{nbsp}Hat Technology Preview 
 If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page.
 ====
 +
-The default project depends on the active {project-short} project (if *All projects* is active, the default is `+{namespace}+`). Administrators can view all projects; authorized non-administrators see only their assigned projects.
+The default project depends on the active {project-short} project. If *All projects* is active, the default is +{namespace}+. Administrators can view all projects; authorized non-administrators see only their assigned projects.
 
 . Enter the provider details:
 +

--- a/documentation/modules/proc_adding-source-provider-cnv.adoc
+++ b/documentation/modules/proc_adding-source-provider-cnv.adoc
@@ -27,7 +27,7 @@ The {ocp} cluster version of the source provider must be 4.16 or later.
 If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page.
 ====
 +
-The default project depends on the active {project-short} project (if *All projects* is active, the default is `+{namespace}+`). Administrators can view all projects; authorized non-administrators see only their assigned projects.
+The default project depends on the active {project-short} project. If *All projects* is active, the default is +{namespace}+. Administrators can view all projects; authorized non-administrators see only their assigned projects.
 . Enter the provider details:
 +
 * *Provider resource name*: Name of the source provider

--- a/documentation/modules/proc_adding-source-provider-hyperv.adoc
+++ b/documentation/modules/proc_adding-source-provider-hyperv.adoc
@@ -27,7 +27,7 @@ You can add a Microsoft Hyper-V source provider by using the {ocp} web console. 
 If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page.
 ====
 +
-The default project depends on the active {project-short} project (if *All projects* is active, the default is `+{namespace}+`). Administrators can view all projects; authorized non-administrators see only their assigned projects.
+The default project depends on the active {project-short} project. If *All projects* is active, the default is +{namespace}+. Administrators can view all projects; authorized non-administrators see only their assigned projects.
 
 . Enter the provider details:
 +

--- a/documentation/modules/proc_adding-source-provider-ostack.adoc
+++ b/documentation/modules/proc_adding-source-provider-ostack.adoc
@@ -27,7 +27,7 @@ When you migrate an image-based VM from an {osp} provider, {project-short} creat
 If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page.
 ====
 +
-The default project depends on the active {project-short} project (if *All projects* is active, the default is `+{namespace}+`). Administrators can view all projects; authorized non-administrators see only their assigned projects.
+The default project depends on the active {project-short} project. If *All projects* is active, the default is +{namespace}+. Administrators can view all projects; authorized non-administrators see only their assigned projects.
 
 . Enter the provider details:
 +

--- a/documentation/modules/proc_adding-source-provider-ova.adoc
+++ b/documentation/modules/proc_adding-source-provider-ova.adoc
@@ -22,7 +22,7 @@ You can add Open Virtual Appliance (OVA) files that were created by {vmw} vSpher
 If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page.
 ====
 +
-The default project depends on the active {project-short} project (if *All projects* is active, the default is `+{namespace}+`). Administrators can view all projects; authorized non-administrators see only their assigned projects.
+The default project depends on the active {project-short} project. If *All projects* is active, the default is +{namespace}+. Administrators can view all projects; authorized non-administrators see only their assigned projects.
 
 . Enter the provider details:
 +

--- a/documentation/modules/proc_adding-source-provider-rhv.adoc
+++ b/documentation/modules/proc_adding-source-provider-rhv.adoc
@@ -26,7 +26,7 @@ You can add {a-rhv} source provider by using the {ocp} web console.
 If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page.
 ====
 +
-The default project depends on the active {project-short} project (if *All projects* is active, the default is `+{namespace}+`). Administrators can view all projects; authorized non-administrators see only their assigned projects.
+The default project depends on the active {project-short} project. If *All projects* is active, the default is +{namespace}+. Administrators can view all projects; authorized non-administrators see only their assigned projects.
 
 . Enter the provider details:
 +

--- a/documentation/modules/proc_adding-source-provider-vmware.adoc
+++ b/documentation/modules/proc_adding-source-provider-vmware.adoc
@@ -38,7 +38,7 @@ You can configure the provider without VDDK if you are only performing cold migr
 If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page.
 ====
 +
-The default project depends on the active {project-short} project (if *All projects* is active, the default is `+{namespace}+`). Administrators can view all projects; authorized non-administrators see only their assigned projects.
+The default project depends on the active {project-short} project. If *All projects* is active, the default is +{namespace}+. Administrators can view all projects; authorized non-administrators see only their assigned projects.
 
 . Enter the provider details:
 +

--- a/documentation/modules/proc_adding-virt-destination-provider.adoc
+++ b/documentation/modules/proc_adding-virt-destination-provider.adoc
@@ -32,7 +32,7 @@ You can use a Red Hat {virt} provider as both source and destination provider. Y
 If the *Welcome* pane is not visible, click *Show the welcome card* in the upper-right corner of the page.
 ====
 +
-The default project depends on the active {project-short} project (if *All projects* is active, the default is `+{namespace}+`). Administrators can view all projects; authorized non-administrators see only their assigned projects.
+The default project depends on the active {project-short} project. If *All projects* is active, the default is +{namespace}+. Administrators can view all projects; authorized non-administrators see only their assigned projects.
 
 . Enter the provider details:
 +


### PR DESCRIPTION
The {namespace} variable wasn't rendering correctly in provider procedures because backticks around +{namespace}+ prevented attribute substitution. Removed the backticks and improved readability by splitting the complex parenthetical sentence into two clear sentences.

This fixes rendering in 8 provider procedures across the Planning guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified default project guidance across source and destination provider procedures.
  * Reformatted the `{namespace}` value for consistent AsciiDoc presentation.
  * Preserved the existing project-selection behavior and procedural content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->