### PR TITLE
HOLD FOR 5.0: MTV-3208: Document nodeSelector support for warm migration importer pods

### DIFF
--- a/documentation/modules/con_about-scheduling-importer-pods.adoc
+++ b/documentation/modules/con_about-scheduling-importer-pods.adoc
@@ -17,5 +17,5 @@ By default, {virt} assigns the nodes to which these importer pods transfer data.
 For cold migrations from VMware VMs, you can configure `nodeSelector`, `tolerations`, labels, and affinity rules for importer pods. For warm migrations from VMware VMs, you can configure only `nodeSelector` for importer pods. Scheduling importer pods is not supported for migrations from other vendors.
 ====
 
-In {project-short} 2.11, scheduling importer pods is available only for migrations from the command-line interface. You schedule the importer pods in the `Plan` CR, as described in step 8 of {mtv-mig}assembly_migrating-from-vmware_mtv#proc_migrating-vms-cli-vmware_vmware[Running a {vmw} vSphere migration from the command-line].
+Scheduling importer pods is available only for migrations from the command-line interface. You schedule the importer pods in the `Plan` CR, as described in step 8 of {mtv-mig}assembly_migrating-from-vmware_mtv#proc_migrating-vms-cli-vmware_vmware[Running a {vmw} vSphere migration from the command-line].
 

--- a/documentation/modules/con_about-scheduling-importer-pods.adoc
+++ b/documentation/modules/con_about-scheduling-importer-pods.adoc
@@ -10,11 +10,11 @@
 [role="_abstract"]
 {project-full} uses `virt-v2v` convertor pods, or _importer pods_, to transfer data from VMware source virtual machines (VMs) to target VMs. 
 
-By default, {virt} assigns the nodes to which these importer pods transfer data. However, for cold migrations from VMware VMs, you can schedule the destination nodes for the importer pods.
+By default, {virt} assigns the nodes to which these importer pods transfer data. However, for migrations from VMware VMs, you can schedule the destination nodes for the importer pods by using node selector configuration.
 
 [IMPORTANT]
 ====
-Scheduling importer pods is supported _only_ for cold migrations from VMware VMs. It is not supported for warm migrations from VMware or for migrations from other vendors.
+For cold migrations from VMware VMs, you can configure `nodeSelector`, `tolerations`, labels, and affinity rules for importer pods. For warm migrations from VMware VMs, you can configure only `nodeSelector` for importer pods. Scheduling importer pods is not supported for migrations from other vendors.
 ====
 
 In {project-short} 2.11, scheduling importer pods is available only for migrations from the command-line interface. You schedule the importer pods in the `Plan` CR, as described in step 8 of {mtv-mig}assembly_migrating-from-vmware_mtv#proc_migrating-vms-cli-vmware_vmware[Running a {vmw} vSphere migration from the command-line].

--- a/documentation/modules/proc_migrating-vms-cli-vmware.adoc
+++ b/documentation/modules/proc_migrating-vms-cli-vmware.adoc
@@ -472,12 +472,12 @@ To ensure proper system functionality, system-managed labels override any user-d
 +
 For more details on labels and selectors in Kubernetes, see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#labels[Labels and Selectors].
 +
-`convertorLabels`, `convertorNodeSelector`, and `convertorAffinity` are fields that support scheduling the `virt-v2v` conversion pod (importer pod) for cold migrations from {vmw} providers. With this feature, you can set the `convertorLabels`, `convertorNodeSelector`, and `convertorAffinity` that control the labels, `nodeSelector`, and `Affinity` of the convertor pod.
+`convertorLabels`, `convertorNodeSelector`, and `convertorAffinity` are fields that support scheduling the `virt-v2v` conversion pod (importer pod) from {vmw} providers. For cold migrations, you can configure `convertorLabels`, `convertorNodeSelector`, and `convertorAffinity`. For warm migrations, you can configure only `convertorNodeSelector`.
 +
 For more information on importer files, see {mtv-plan}assembly_planning-migration-vmware#con_about-configuring-importer-pods_vmware[About scheduling importer pods].
 
 `convertorNodeSelector`::
-Cold migrations only: Specifies the key-value pairs that must be matched for data to be transferred by the `virt-v2v` convertor pods (importer pods) to the specified target nodes. This is an optional field. With this feature, you can dedicate specific nodes for disk conversion workloads that require high I/O performance or network access to source {vmw} infrastructure.
+Specifies the key-value pairs that must be matched for data to be transferred by the `virt-v2v` convertor pods (importer pods) to the specified target nodes. This is an optional field. With this feature, you can dedicate specific nodes for disk conversion workloads that require high I/O performance or network access to source {vmw} infrastructure. Supported for both cold and warm migrations.
 +
 For more details on node selectors in Kubernetes, see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector[nodeSelector].
 


### PR DESCRIPTION
Update documentation to reflect that warm migrations now support configuring nodeSelector for importer pods, while cold migrations continue to support nodeSelector, tolerations, labels, and affinity rules.